### PR TITLE
Temporarily disable ts-integration tests (revisit after modernization)

### DIFF
--- a/packages/streamr-libstreamrproxyclient/CMakeLists.txt
+++ b/packages/streamr-libstreamrproxyclient/CMakeLists.txt
@@ -119,17 +119,22 @@ if (NOT IOS)
         include(GoogleTest)
         gtest_discover_tests(streamr-streamrproxyclient-test-integration)
         gtest_discover_tests(streamrproxyclient-cpp-wrapper-test)
-        add_test(
-            NAME ts-end-to-end-test
-            COMMAND "${CMAKE_CURRENT_LIST_DIR}/run-ts-end-to-end-tests.sh"
-            WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
-            )
+        # TEMPORARILY DISABLED: these tests build the whole streamr-dev/network
+        # TS monorepo at a 2024 commit (ts-integration/install.sh), which no
+        # longer works on current CI runners, and compiling the whole
+        # repository is not necessary anymore. Re-enable against a current,
+        # slimmer TS setup after the toolchain/modules modernization.
+        # add_test(
+        #     NAME ts-end-to-end-test
+        #     COMMAND "${CMAKE_CURRENT_LIST_DIR}/run-ts-end-to-end-tests.sh"
+        #     WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+        #     )
 
-        add_test(
-            NAME ts-multiple-messages-test
-            COMMAND "${CMAKE_CURRENT_LIST_DIR}/run-ts-multiple-messages-test.sh"
-            WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
-            )
+        # add_test(
+        #     NAME ts-multiple-messages-test
+        #     COMMAND "${CMAKE_CURRENT_LIST_DIR}/run-ts-multiple-messages-test.sh"
+        #     WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+        #     )
     endif()
     # Install header to dist/target-triplet
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/streamrproxyclient.h

--- a/packages/streamr-trackerless-network/CMakeLists.txt
+++ b/packages/streamr-trackerless-network/CMakeLists.txt
@@ -145,11 +145,16 @@ if(NOT IOS)
          # gtest_discover_tests(streamr-trackerless-network-test-unit)
          #gtest_discover_tests(streamr-trackerless-network-test-integration)
      
-         add_test(
-            NAME ts-integration-test
-            COMMAND "${CMAKE_CURRENT_LIST_DIR}/run-ts-integration-tests.sh"
-            WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
-            )
+         # TEMPORARILY DISABLED: this test builds the whole streamr-dev/network
+         # TS monorepo at a 2024 commit (ts-integration/install.sh), which no
+         # longer works on current CI runners, and compiling the whole
+         # repository is not necessary anymore. Re-enable against a current,
+         # slimmer TS setup after the toolchain/modules modernization.
+         # add_test(
+         #    NAME ts-integration-test
+         #    COMMAND "${CMAKE_CURRENT_LIST_DIR}/run-ts-integration-tests.sh"
+         #    WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+         #    )
 
     endif()
 endif()


### PR DESCRIPTION
Disables the three failing TS-interop tests (`ts-integration-test`, `ts-end-to-end-test`, `ts-multiple-messages-test`) with an explanatory note in both CMakeLists, per discussion.

**Why:** their install step (`ts-integration/install.sh`) clones and builds the **entire streamr-dev/network TS monorepo at a 2024 commit**, which no longer works on current CI runners — and compiling the whole repository is not necessary anymore given how much the network monorepo has changed. They'll be revisited against a current, slimmer TS setup **after the modernization completes**.

**Ruled out during diagnosis:** these tests don't depend on any external server at runtime — all three run against a locally spawned TS subscriber with `--local` (`127.0.0.1:44211` on both the TS and C++ sides). The hardcoded global entry point (`95.216.15.80:44211`) in `subscriber.ts` is only used without `--local`. The clone target repo and its pinned commit also still exist.

**Expected CI effect:** these were the *only* failing tests on the Linux legs, so `validate.yml`'s ubuntu-24.04 and linux-arm64 legs should now go fully green — giving Phase 1.2 a clean gate. (macOS legs stay red until Phase 1.2's compiler upgrade, unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)