### PR TITLE
Modernization Phase 1.6: CI/docs closeout — macos-26 runners, scheduled iOS build [iosbuild]

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,11 @@ jobs:
       # must not cancel the others.
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, linux-arm64-runner]
+        # macos-26: current GA arm64 image, ships Xcode 26 (required for the
+        # iOS deployment target 26 SDK; macos-latest still maps to macOS 15).
+        # ubuntu-latest = 24.04: ubuntu-26.04 is still a preview image —
+        # revisit when GA.
+        os: [macos-26, ubuntu-latest, linux-arm64-runner]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validateandroid.yml
+++ b/.github/workflows/validateandroid.yml
@@ -11,11 +11,12 @@ on:
   pull_request:
     branches:
       - '*'
+  workflow_dispatch:
 
 jobs:
   install-lint:
-    if: contains(github.event.head_commit.message, 'androidbuild') || contains(github.event.pull_request.title, 'androidbuild')
-    runs-on: macos-latest
+    if: contains(github.event.head_commit.message, 'androidbuild') || contains(github.event.pull_request.title, 'androidbuild') || github.event_name == 'workflow_dispatch'
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/validateios.yml
+++ b/.github/workflows/validateios.yml
@@ -11,11 +11,17 @@ on:
   pull_request:
     branches:
       - '*'
+  # Weekly scheduled build so the iOS toolchain path cannot silently rot
+  # between keyword-triggered runs (runner image, SDK and Homebrew LLVM all
+  # move underneath us).
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
 
 jobs:
   install-lint:
-    if: contains(github.event.head_commit.message, 'iosbuild') || contains(github.event.pull_request.title, 'iosbuild')
-    runs-on: macos-latest
+    if: contains(github.event.head_commit.message, 'iosbuild') || contains(github.event.pull_request.title, 'iosbuild') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,3 +31,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: install
         uses: ./.github/workflows/reusable/cached-install
+      - name: upload xcframework
+        uses: actions/upload-artifact@v4
+        with:
+          name: streamr-xcframework
+          path: dist/ios/streamr.xcframework
+          retention-days: 30

--- a/.github/workflows/validateios.yml
+++ b/.github/workflows/validateios.yml
@@ -11,16 +11,11 @@ on:
   pull_request:
     branches:
       - '*'
-  # Weekly scheduled build so the iOS toolchain path cannot silently rot
-  # between keyword-triggered runs (runner image, SDK and Homebrew LLVM all
-  # move underneath us).
-  schedule:
-    - cron: '0 5 * * 1'
   workflow_dispatch:
 
 jobs:
   install-lint:
-    if: contains(github.event.head_commit.message, 'iosbuild') || contains(github.event.pull_request.title, 'iosbuild') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: contains(github.event.head_commit.message, 'iosbuild') || contains(github.event.pull_request.title, 'iosbuild') || github.event_name == 'workflow_dispatch'
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4

--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -305,11 +305,11 @@ document/replace in 1.4.
   which the iOS deployment target requires (`macos-latest` still maps to
   macOS 15). `ubuntu-26.04` is still a preview image → Linux stays on
   `ubuntu-latest` (24.04); revisit when GA.
-- **Scheduled iOS build**: validateios.yml gains a weekly cron (Mon 05:00
-  UTC) + `workflow_dispatch`, so the iOS toolchain path cannot silently rot
-  between keyword-triggered runs (runner image, SDK and Homebrew LLVM all
-  move underneath us). The XCFramework is uploaded as a build artifact
-  (30-day retention). validateandroid.yml gains `workflow_dispatch`.
+- **iOS/Android manual triggers**: validateios.yml and validateandroid.yml
+  gain `workflow_dispatch` (manual run without commit-message keywords).
+  No scheduled/timed runs (owner decision, 2026-07: no cron jobs in this
+  repo). The iOS XCFramework is uploaded as a build artifact (30-day
+  retention) on every iOS workflow run.
 - **README**: Xcode 26 requirement stated in prerequisites; new
   per-platform C++26 feature-availability section (Homebrew/apt libc++ 22
   on macOS/Linux vs iOS SDK libc++ availability-gated by the deployment

--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -269,7 +269,7 @@ document/replace in 1.4.
   (deployment-target-26 / SDK-libc++ build, Personal Team signing);
   Android sanity via CI keyword.
 
-## Phase 1.5 — Lint stack remainder (PR pending)
+## Phase 1.5 — Lint stack remainder ✅ (PR #26, merged)
 - clangd/clang-format 22 already landed in Phase 1.2 (forced by libc++ 22).
 - **clangd-tidy: submodule → PyPI**. The submodule pinned tag 0.2.1 (a
   single-script era); upstream 1.x is a Python package with dependencies
@@ -299,13 +299,24 @@ document/replace in 1.4.
 - **Gate**: `./lint.sh` green both platforms; full test suite green
   (several fixes touch runtime code paths); format at fixed point.
 
-## Phase 1.6 — CI/docs closeout
-- Revisit preview runner images (macos-26 / ubuntu-26.04) once GA; consider a
-  scheduled iOS build job (build-only, no signing; upload XCFramework
-  artifact).
-- README: per-platform C++26 feature-availability note (Homebrew libc++ vs
-  iOS SDK libc++ at the deployment target vs NDK libc++), baseline-bump
-  procedure.
+## Phase 1.6 — CI/docs closeout (PR pending)
+- **Runner images** (checked 2026-07): `macos-26` arm64 is GA → all macOS
+  legs (validate matrix, iOS, Android) moved to it — it ships Xcode 26,
+  which the iOS deployment target requires (`macos-latest` still maps to
+  macOS 15). `ubuntu-26.04` is still a preview image → Linux stays on
+  `ubuntu-latest` (24.04); revisit when GA.
+- **Scheduled iOS build**: validateios.yml gains a weekly cron (Mon 05:00
+  UTC) + `workflow_dispatch`, so the iOS toolchain path cannot silently rot
+  between keyword-triggered runs (runner image, SDK and Homebrew LLVM all
+  move underneath us). The XCFramework is uploaded as a build artifact
+  (30-day retention). validateandroid.yml gains `workflow_dispatch`.
+- **README**: Xcode 26 requirement stated in prerequisites; new
+  per-platform C++26 feature-availability section (Homebrew/apt libc++ 22
+  on macOS/Linux vs iOS SDK libc++ availability-gated by the deployment
+  target vs NDK libc++; practical header-only-vs-runtime rule). The
+  baseline-bump procedure was already documented in 1.3.
+- **Gate**: CI green on the new images; iOS workflow runs via the PR
+  keyword (validates the edited workflow file end to end).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,19 @@ The compiler toolchain is the latest LLVM/Clang on every platform:
 
 * **macOS**: Homebrew `llvm` (keg-only — the build locates it through the `LLVM_PREFIX` environment variable exported by `install-prerequisities.sh`/`setenvs.sh`).
 * **Linux**: `clang-22` + `libc++` from [apt.llvm.org](https://apt.llvm.org/). libc++ (instead of libstdc++) keeps the standard library uniform across macOS, iOS, Android and Linux.
-* **iOS/Android**: cross-compiled with the same LLVM (iOS) or the Android NDK's clang.
+* **iOS/Android**: cross-compiled with the same LLVM (iOS) or the Android NDK's clang. **iOS builds require Xcode 26 or newer** (the deployment target is iOS 26, so the iOS 26 SDK is needed; `install-prerequisities.sh` warns if an older Xcode is selected).
 
 All builds use the [Ninja](https://ninja-build.org/) CMake generator (exported as `CMAKE_GENERATOR=Ninja` by `install-prerequisities.sh`/`setenvs.sh`). Ninja is faster than Makefiles and is required by CMake's C++ modules support. **If you have build directories configured with the previous Makefile generator, run `./clean.sh` once after updating.**
+
+#### C++26 feature availability per platform
+
+The codebase is built as C++26 (`CMAKE_CXX_STANDARD 26`, required) everywhere, but the *standard library* differs per platform, so library-feature availability is bounded by the oldest libc++ in play:
+
+* **macOS / Linux**: Homebrew / apt.llvm.org libc++ 22 — the full feature set of the current LLVM release, including everything behind runtime-library support.
+* **iOS**: compiled against the **iPhoneOS SDK's libc++ headers** and linked against the **device's system libc++** (the runtime that ships with iOS and cannot be updated separately). The SDK headers carry availability annotations tied to the deployment target (currently iOS 26), so using a library feature whose runtime support is newer than the deployment target is a compile error rather than a crash on device — this is the intended guardrail. Language features are unaffected (they depend only on the compiler).
+* **Android**: the NDK's libc++ (follows the NDK's LLVM version, currently close to but typically one release behind Homebrew's).
+
+Practical rule: header-only features (ranges, `contains`, concepts, formatting of standard types, etc.) work everywhere; features needing runtime-library symbols (e.g. new locale facets, some `std::print`/filesystem edges) are gated by the iOS deployment target — the iOS build will tell you.
 
 ### Install all the dependencies and build the SDK for MacOS and Linux
 


### PR DESCRIPTION
Final Part 1 phase — small closeout, no code changes.

## CI

- **All macOS legs → `macos-26`** (checked 2026-07: it's the GA arm64 image and ships Xcode 26, which our iOS deployment target requires; `macos-latest` still maps to macOS 15). **Linux stays `ubuntu-latest`** — `ubuntu-26.04` is still a preview image; noted for revisit when GA.
- **validateios.yml / validateandroid.yml gain `workflow_dispatch`** (manual trigger without commit-message keywords). No scheduled/timed runs — owner decision: no cron jobs in this repo.
- The iOS workflow uploads the XCFramework as a build artifact (30-day retention) on every run, so any green iOS run doubles as a downloadable binary.

## Docs (README)

- Xcode 26 requirement stated in prerequisites.
- New **per-platform C++26 feature-availability** section: uniform libc++ 22 on macOS/Linux; iOS compiled against the SDK's libc++ headers and availability-gated by the deployment target (compile error instead of on-device crash — the intended guardrail from Phase 1.4); NDK libc++ on Android; practical header-only vs runtime-symbol rule.

This PR's `[iosbuild]` title exercises the edited iOS workflow end to end on the new runner image, including the new artifact-upload step.

## Part 1 complete after this

| Phase | PR |
|---|---|
| 1.0 Baseline | #20 |
| 1.1 Build-system hygiene | #21 |
| — ts-integration interim | #22 |
| 1.2 Compilers LLVM 17→22 + CI images | #23 |
| 1.3 vcpkg baseline + dependency wave | #24 |
| 1.4 iOS refresh (SDK libc++, DT 26, device-tested) | #25 |
| 1.5 Lint remainder (zero suppressions) | #26 |
| 1.6 CI/docs closeout | this |

Next: **Part 2 — the C++ modules migration** (phases 2.0–2.6 in MODERNIZATION.md), starting with scaffolding + compile-time baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)