### PR TITLE
Modernization Phase 2.2: modules — streamr-logger + streamr-utils (folly GMF, coro canary) [iosbuild]

### DIFF
--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -456,7 +456,7 @@ header parsing, and the top of the expensive list is exactly the
   primary metric). Capture the Linux numbers on the self-hosted arm64 box
   and an iOS build-only timing before the Phase 2.4 checkpoint.
 
-## Phase 2.1 — Canary: streamr-eventemitter + streamr-json (PR pending)
+## Phase 2.1 — Canary: streamr-eventemitter + streamr-json ✅ (PR #29, merged)
 First real modules. Both packages carry the designed façade shape: one
 `.cppm` partition per public header (header `#include`d in the global
 module fragment, public names re-exported with `export using`), a primary
@@ -490,6 +490,54 @@ interface unit `export import`ing the partitions, INTERFACE→STATIC via
   lint.sh extended); headers remain the fully-linted source of truth.
 - iOS gate via the PR's `iosbuild` keyword (module lib builds; tests are
   host-only). Android modules validation lands with its phase-2.5 gate.
+
+## Phase 2.2 — streamr-logger + streamr-utils (PR pending)
+folly enters the global module fragment; utils is the folly::coro canary.
+- **streamr-logger**: 4 partitions (Logger, LoggerImpl, SLogger,
+  StreamrLogLevel) + primary unit. folly logging machinery in the GMF
+  compiled without incident. `detail/` headers get no partitions (internal
+  API); LoggerEnvTest, which tests detail machinery, keeps its detail
+  `#include` alongside `import streamr.logger` — mixing is the designed
+  property of the façade.
+- **streamr-utils**: 21 partitions + primary. **The folly::coro coroutine
+  canary passed with zero compiler workarounds** — waitForEvent,
+  waitForCondition, collect, toCoroTask (coro Tasks in GMF, coroutine
+  code re-exported) all build and run under Clang 22. The per-header
+  opt-out budget went unused.
+- **New mechanism discovered (now in `streamr_add_module_library()`)**:
+  exported module targets need `target_compile_features(… PUBLIC
+  cxx_std_26)`. When another build tree imports the target from its
+  export file, CMake synthesizes a consumer-side BMI-compiling target and
+  hard-errors if the standard level is not part of the exported usage
+  requirements. (First surfaced when streamr-logger consumed
+  streamr-json's export.)
+- **Language rule fallout**: namespace-scope `constexpr` variables have
+  internal linkage and cannot be re-exported — 7 header constants across
+  both packages became `inline constexpr` (the correct C++17+ idiom for
+  header constants regardless of modules).
+- 20 test files + both examples flipped to `import`; the
+  include-what-you-use pass stayed small (`<thread>`, `<chrono>`,
+  `<string>`).
+- **clangd-modules root cause identified**: the 2.1 quirks (constrained
+  `string(string_view)` ctor, and now generic-lambda `std::visit`
+  exhaustiveness + plain `std::string` overload failures) share one
+  mechanism — clangd fails to unify std types between its own preamble
+  and the types reached through module BMIs. It only bites where std
+  types cross the module boundary in an import-using file. One test file
+  (`toEthereumAddressOrENSNameTest.cpp` — its whole API is std types in
+  Branded wrappers) needed the planned lint-exclusion fallback: first and
+  only use so far; the compiler still typechecks it on every build.
+  `bugprone-exception-escape` also surfaces on `main()` in import-using
+  files (clangd sees deeper through BMIs) — legitimate findings, fixed
+  with function-try-blocks.
+- Verified: logger 63/63, utils 49/49 through import; downstream
+  proto-rpc/dht standalone builds unchanged; root tree 307/307; full lint
+  (one documented exclusion).
+- **Honest bench note**: no incremental-rebuild improvement is expected
+  yet — the heavy consumers of SLogger/utils headers (dht,
+  trackerless-network) still `#include` them; the measured win arrives
+  when those packages flip (2.4/2.5) and their test TUs load BMIs instead
+  of re-parsing the header stack.
 
 ## Lint/IDE survival
 - During the façade stage, headers remain the fully-linted source of truth

--- a/cmake/StreamrModules.cmake
+++ b/cmake/StreamrModules.cmake
@@ -71,6 +71,11 @@ function(streamr_add_module_library TARGET)
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    # PUBLIC compile feature (not just CMAKE_CXX_STANDARD): when another
+    # build tree imports this target from its export, CMake synthesizes a
+    # BMI-compiling target on the consumer side and requires the standard
+    # level to be part of the exported usage requirements.
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-dht/StreamrModules.cmake
+++ b/packages/streamr-dht/StreamrModules.cmake
@@ -71,6 +71,11 @@ function(streamr_add_module_library TARGET)
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    # PUBLIC compile feature (not just CMAKE_CXX_STANDARD): when another
+    # build tree imports this target from its export, CMake synthesizes a
+    # BMI-compiling target on the consumer side and requires the standard
+    # level to be part of the exported usage requirements.
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-eventemitter/StreamrModules.cmake
+++ b/packages/streamr-eventemitter/StreamrModules.cmake
@@ -71,6 +71,11 @@ function(streamr_add_module_library TARGET)
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    # PUBLIC compile feature (not just CMAKE_CXX_STANDARD): when another
+    # build tree imports this target from its export, CMake synthesizes a
+    # BMI-compiling target on the consumer side and requires the standard
+    # level to be part of the exported usage requirements.
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-json/StreamrModules.cmake
+++ b/packages/streamr-json/StreamrModules.cmake
@@ -71,6 +71,11 @@ function(streamr_add_module_library TARGET)
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    # PUBLIC compile feature (not just CMAKE_CXX_STANDARD): when another
+    # build tree imports this target from its export, CMake synthesizes a
+    # BMI-compiling target on the consumer side and requires the standard
+    # level to be part of the exported usage requirements.
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-libstreamrproxyclient/StreamrModules.cmake
+++ b/packages/streamr-libstreamrproxyclient/StreamrModules.cmake
@@ -71,6 +71,11 @@ function(streamr_add_module_library TARGET)
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    # PUBLIC compile feature (not just CMAKE_CXX_STANDARD): when another
+    # build tree imports this target from its export, CMake synthesizes a
+    # BMI-compiling target on the consumer side and requires the standard
+    # level to be part of the exported usage requirements.
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-logger/CMakeLists.txt
+++ b/packages/streamr-logger/CMakeLists.txt
@@ -25,13 +25,29 @@ find_package(folly CONFIG REQUIRED)
 find_package(streamr-json CONFIG REQUIRED)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-add_library(streamr-logger INTERFACE)
+
+# C++ modules support (guards, policies, helpers) — must come after
+# project() because it inspects the compiler id.
+include(${CMAKE_CURRENT_SOURCE_DIR}/StreamrModules.cmake)
+
+# Module façade (MODERNIZATION.md Part 2): the package is now a STATIC
+# library whose module interface units re-export the public headers.
+# #include consumers are unaffected; import consumers get the BMIs.
+# detail/ headers stay internal (no partitions).
+streamr_add_module_library(streamr-logger
+  FILES
+    modules/streamr.logger.cppm
+    modules/streamr.logger-Logger.cppm
+    modules/streamr.logger-LoggerImpl.cppm
+    modules/streamr.logger-SLogger.cppm
+    modules/streamr.logger-StreamrLogLevel.cppm)
 set_property(TARGET streamr-logger PROPERTY CXX_STANDARD 26)
 
 add_library(streamr::streamr-logger ALIAS streamr-logger)
 
 if(NOT IOS)
   add_executable(env_category_tests test/unit/LoggerEnvTest.cpp)
+  streamr_enable_imports(env_category_tests)
   target_link_libraries(env_category_tests PRIVATE streamr-logger)
   enable_testing()
   add_test(
@@ -60,18 +76,21 @@ if(NOT IOS)
 endif()
 
 target_include_directories(
-  streamr-logger INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  streamr-logger PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(streamr-logger INTERFACE Folly::folly INTERFACE streamr::streamr-json)
+# PUBLIC (was INTERFACE): the module interface units compile against folly
+# and streamr-json in their global module fragments.
+target_link_libraries(streamr-logger PUBLIC Folly::folly PUBLIC streamr::streamr-json)
 # TODO: Is there a better way to do this?
 # - Apparently not: https://gitlab.kitware.com/cmake/cmake/-/issues/20511
 # - At least parse the deps from the vcpkg.json file and use them to find_package() in this file and to add the
 # find_package() calls to the wrapper
 
-export(TARGETS streamr-logger 
+export(TARGETS streamr-logger
   NAMESPACE streamr::
-  FILE streamr-logger-config-in.cmake)
+  FILE streamr-logger-config-in.cmake
+  CXX_MODULES_DIRECTORY streamr-logger-modules)
 
   file(WRITE "${CMAKE_BINARY_DIR}/streamr-logger-config.cmake" 
   "list(APPEND CMAKE_FIND_ROOT_PATH \"${CMAKE_FIND_ROOT_PATH}\")\n"
@@ -84,8 +103,11 @@ if(NOT IOS)
   find_package(GTest CONFIG REQUIRED)
 
   add_executable(streamr-logger-test-unit test/unit/LoggerTest.cpp test/unit/StreamrLogFormatterTest.cpp)
+  # LoggerTest imports streamr.logger (StreamrLogFormatterTest keeps
+  # #include — it tests a detail/ header that has no partition).
+  streamr_enable_imports(streamr-logger-test-unit)
 
-  target_link_libraries(streamr-logger-test-unit 
+  target_link_libraries(streamr-logger-test-unit
     PRIVATE streamr-logger
     PRIVATE GTest::gtest 
     PRIVATE GTest::gtest_main 
@@ -98,5 +120,6 @@ if(NOT IOS)
   endif()
 
   add_executable(streamr-logger-example src/examples/LoggerExample.cpp)
+  streamr_enable_imports(streamr-logger-example)
   target_link_libraries(streamr-logger-example PRIVATE streamr-logger)
 endif()

--- a/packages/streamr-logger/StreamrModules.cmake
+++ b/packages/streamr-logger/StreamrModules.cmake
@@ -71,6 +71,11 @@ function(streamr_add_module_library TARGET)
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    # PUBLIC compile feature (not just CMAKE_CXX_STANDARD): when another
+    # build tree imports this target from its export, CMake synthesizes a
+    # BMI-compiling target on the consumer side and requires the standard
+    # level to be part of the exported usage requirements.
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-logger/include/streamr-logger/Logger.hpp
+++ b/packages/streamr-logger/include/streamr-logger/Logger.hpp
@@ -16,7 +16,7 @@ using streamr::json::toJson;
 
 // const char* (not string_view): passed to getenv(), which needs a
 // null-terminated string.
-constexpr const char* envLogLevelName = "LOG_LEVEL";
+inline constexpr const char* envLogLevelName = "LOG_LEVEL";
 class Logger {
 private:
     std::shared_ptr<LoggerImpl> mLoggerImpl;

--- a/packages/streamr-logger/include/streamr-logger/StreamrLogLevel.hpp
+++ b/packages/streamr-logger/include/streamr-logger/StreamrLogLevel.hpp
@@ -57,7 +57,8 @@ using StreamrLogLevel = std::variant<
     streamrloglevel::Error,
     streamrloglevel::Fatal>;
 
-constexpr StreamrLogLevel systemDefaultLogLevel = streamrloglevel::Info{};
+inline constexpr StreamrLogLevel systemDefaultLogLevel =
+    streamrloglevel::Info{};
 template <typename T>
 concept StreamrLogLevelConcept = std::is_same_v<T, StreamrLogLevel>;
 

--- a/packages/streamr-logger/lint.sh
+++ b/packages/streamr-logger/lint.sh
@@ -9,3 +9,12 @@ clangd-tidy -p ./build $FILES
 
 echo "Running clang-format --dry-run on $FILES"
 ../../run-clang-format.py $FILES
+
+# Module interface units: format check only. clangd-tidy is not run on
+# .cppm files (headers remain the fully linted source of truth during the
+# façade migration; clangd modules support is still experimental).
+MODULE_FILES=$(find ./modules -type f -name "*.cppm" 2>/dev/null | xargs echo)
+if [ -n "$MODULE_FILES" ]; then
+    echo "Running clang-format --dry-run on $MODULE_FILES"
+    ../../run-clang-format.py $MODULE_FILES
+fi

--- a/packages/streamr-logger/modules/streamr.logger-Logger.cppm
+++ b/packages/streamr-logger/modules/streamr.logger-Logger.cppm
@@ -1,0 +1,14 @@
+// Façade partition over streamr-logger/Logger.hpp (see the streamr.eventemitter
+// partitions for the pattern rationale).
+module;
+
+#include "streamr-logger/Logger.hpp"
+
+export module streamr.logger:Logger;
+
+export namespace streamr::logger {
+
+using streamr::logger::envLogLevelName;
+using streamr::logger::Logger;
+
+} // namespace streamr::logger

--- a/packages/streamr-logger/modules/streamr.logger-LoggerImpl.cppm
+++ b/packages/streamr-logger/modules/streamr.logger-LoggerImpl.cppm
@@ -1,0 +1,13 @@
+// Façade partition over streamr-logger/LoggerImpl.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-logger/LoggerImpl.hpp"
+
+export module streamr.logger:LoggerImpl;
+
+export namespace streamr::logger {
+
+using streamr::logger::LoggerImpl;
+
+} // namespace streamr::logger

--- a/packages/streamr-logger/modules/streamr.logger-SLogger.cppm
+++ b/packages/streamr-logger/modules/streamr.logger-SLogger.cppm
@@ -1,0 +1,13 @@
+// Façade partition over streamr-logger/SLogger.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-logger/SLogger.hpp"
+
+export module streamr.logger:SLogger;
+
+export namespace streamr::logger {
+
+using streamr::logger::SLogger;
+
+} // namespace streamr::logger

--- a/packages/streamr-logger/modules/streamr.logger-StreamrLogLevel.cppm
+++ b/packages/streamr-logger/modules/streamr.logger-StreamrLogLevel.cppm
@@ -1,0 +1,29 @@
+// Façade partition over streamr-logger/StreamrLogLevel.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-logger/StreamrLogLevel.hpp"
+
+export module streamr.logger:StreamrLogLevel;
+
+export namespace streamr::logger::streamrloglevel {
+
+using streamr::logger::streamrloglevel::Debug;
+using streamr::logger::streamrloglevel::Error;
+using streamr::logger::streamrloglevel::Fatal;
+using streamr::logger::streamrloglevel::Info;
+using streamr::logger::streamrloglevel::Trace;
+using streamr::logger::streamrloglevel::Warn;
+
+} // namespace streamr::logger::streamrloglevel
+
+export namespace streamr::logger {
+
+using streamr::logger::getStreamrLogLevelByName;
+using streamr::logger::getStreamrLogLevelValue;
+using streamr::logger::LevelGetter;
+using streamr::logger::StreamrLogLevel;
+using streamr::logger::StreamrLogLevelConcept;
+using streamr::logger::systemDefaultLogLevel;
+
+} // namespace streamr::logger

--- a/packages/streamr-logger/modules/streamr.logger.cppm
+++ b/packages/streamr-logger/modules/streamr.logger.cppm
@@ -1,0 +1,8 @@
+// Primary module interface unit of streamr.logger. Consumers write
+// `import streamr.logger;` and get every partition re-exported.
+export module streamr.logger;
+
+export import :Logger;
+export import :LoggerImpl;
+export import :SLogger;
+export import :StreamrLogLevel;

--- a/packages/streamr-logger/src/examples/LoggerExample.cpp
+++ b/packages/streamr-logger/src/examples/LoggerExample.cpp
@@ -1,6 +1,8 @@
-#include "streamr-logger/Logger.hpp"
-#include "streamr-logger/SLogger.hpp"
-#include "streamr-logger/StreamrLogLevel.hpp"
+#include <exception>
+#include <iostream>
+#include <string>
+
+import streamr.logger;
 
 using Logger = streamr::logger::Logger;
 using SLogger = streamr::logger::SLogger;
@@ -69,8 +71,11 @@ public:
     }
 };
 
-int main() {
+int main() try {
     LoggerExample loggerExample;
     loggerExample.doSomething();
     return 0;
+} catch (const std::exception& e) {
+    std::cerr << "Example failed: " << e.what() << '\n';
+    return 1;
 }

--- a/packages/streamr-logger/test/unit/LoggerEnvTest.cpp
+++ b/packages/streamr-logger/test/unit/LoggerEnvTest.cpp
@@ -1,5 +1,9 @@
-#include "streamr-logger/Logger.hpp"
-#include "streamr-logger/StreamrLogLevel.hpp"
+// Tests detail-level machinery, so the detail header stays #included (no
+// module partition exists for detail/ headers); mixing with import is safe.
+#include "streamr-logger/detail/FollyLoggerImpl.hpp"
+
+import streamr.logger;
+
 using Logger = streamr::logger::Logger;
 namespace streamrloglevel = streamr::logger::streamrloglevel;
 using FollyLoggerImpl = streamr::logger::detail::FollyLoggerImpl;
@@ -56,7 +60,7 @@ public:
     }
 };
 
-int main(int /* argc */, char* argv[]) {
+int main(int /* argc */, char* argv[]) try {
     LoggerEnvTest loggerEnvTest;
     if (argv[1] == std::string("1")) {
         return static_cast<int>(loggerEnvTest.testInfoLogWritten());
@@ -71,5 +75,7 @@ int main(int /* argc */, char* argv[]) {
         return static_cast<int>(
             loggerEnvTest.testInfoLogWrittenWhenDefaultLogLevelIsWarn());
     }
+    return 1;
+} catch (const std::exception&) {
     return 1;
 }

--- a/packages/streamr-logger/test/unit/LoggerTest.cpp
+++ b/packages/streamr-logger/test/unit/LoggerTest.cpp
@@ -1,9 +1,9 @@
-#include "streamr-logger/Logger.hpp"
 #include <string>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "streamr-logger/StreamrLogLevel.hpp"
 #include "streamr-logger/detail/FollyLoggerImpl.hpp"
+
+import streamr.logger;
 
 using streamr::logger::Logger;
 using streamr::logger::StreamrLogLevel;

--- a/packages/streamr-proto-rpc/StreamrModules.cmake
+++ b/packages/streamr-proto-rpc/StreamrModules.cmake
@@ -71,6 +71,11 @@ function(streamr_add_module_library TARGET)
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    # PUBLIC compile feature (not just CMAKE_CXX_STANDARD): when another
+    # build tree imports this target from its export, CMake synthesizes a
+    # BMI-compiling target on the consumer side and requires the standard
+    # level to be part of the exported usage requirements.
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-trackerless-network/StreamrModules.cmake
+++ b/packages/streamr-trackerless-network/StreamrModules.cmake
@@ -71,6 +71,11 @@ function(streamr_add_module_library TARGET)
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    # PUBLIC compile feature (not just CMAKE_CXX_STANDARD): when another
+    # build tree imports this target from its export, CMake synthesizes a
+    # BMI-compiling target on the consumer side and requires the standard
+    # level to be part of the exported usage requirements.
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-utils/CMakeLists.txt
+++ b/packages/streamr-utils/CMakeLists.txt
@@ -38,11 +38,41 @@ if(NOT TARGET Boost::endian)
 endif()
 
 
-add_library(streamr-utils INTERFACE)
+# C++ modules support (guards, policies, helpers) — must come after
+# project() because it inspects the compiler id.
+include(${CMAKE_CURRENT_SOURCE_DIR}/StreamrModules.cmake)
+
+# Module façade (MODERNIZATION.md Part 2): the package is now a STATIC
+# library whose module interface units re-export the public headers.
+# #include consumers are unaffected; import consumers get the BMIs.
+streamr_add_module_library(streamr-utils
+  FILES
+    modules/streamr.utils.cppm
+    modules/streamr.utils-AbortController.cppm
+    modules/streamr.utils-AbortableTimers.cppm
+    modules/streamr.utils-BinaryUtils.cppm
+    modules/streamr.utils-Branded.cppm
+    modules/streamr.utils-ENSName.cppm
+    modules/streamr.utils-EnableSharedFromThis.cppm
+    modules/streamr.utils-EthereumAddress.cppm
+    modules/streamr.utils-Ipv4Helper.cppm
+    modules/streamr.utils-ReplayEventEmitterWrapper.cppm
+    modules/streamr.utils-RetryUtils.cppm
+    modules/streamr.utils-SigningUtils.cppm
+    modules/streamr.utils-StreamID.cppm
+    modules/streamr.utils-StreamPartID.cppm
+    modules/streamr.utils-Uuid.cppm
+    modules/streamr.utils-collect.cppm
+    modules/streamr.utils-partition.cppm
+    modules/streamr.utils-runAndWaitForEvents.cppm
+    modules/streamr.utils-toCoroTask.cppm
+    modules/streamr.utils-toEthereumAddressOrENSName.cppm
+    modules/streamr.utils-waitForCondition.cppm
+    modules/streamr.utils-waitForEvent.cppm)
 add_library(streamr::streamr-utils ALIAS streamr-utils)
 
 target_include_directories(
-  streamr-utils INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  streamr-utils PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include>)
 
 find_library(SECP256K1_LIBRARY secp256k1)
@@ -54,21 +84,24 @@ if(NOT SECP256K1_LIBRARY_PRECOMPUTED)
 endif()
 
 message(STATUS "SECP256K1_LIBRARY_PRECOMPUTED: ${SECP256K1_LIBRARY_PRECOMPUTED}")
+# PUBLIC (was INTERFACE): the module interface units compile against these
+# in their global module fragments.
 target_link_libraries(streamr-utils
-    INTERFACE Folly::folly
-    INTERFACE streamr::streamr-eventemitter
-    INTERFACE streamr::streamr-logger
-    INTERFACE Boost::uuid
-    INTERFACE Boost::endian
-    INTERFACE Boost::algorithm
-    INTERFACE cryptopp::cryptopp
-    INTERFACE ${SECP256K1_LIBRARY}
-    INTERFACE ${SECP256K1_LIBRARY_PRECOMPUTED}
+    PUBLIC Folly::folly
+    PUBLIC streamr::streamr-eventemitter
+    PUBLIC streamr::streamr-logger
+    PUBLIC Boost::uuid
+    PUBLIC Boost::endian
+    PUBLIC Boost::algorithm
+    PUBLIC cryptopp::cryptopp
+    PUBLIC ${SECP256K1_LIBRARY}
+    PUBLIC ${SECP256K1_LIBRARY_PRECOMPUTED}
 )
 
 export(TARGETS streamr-utils
     NAMESPACE streamr::
-    FILE streamr-utils-config-in.cmake)
+    FILE streamr-utils-config-in.cmake
+    CXX_MODULES_DIRECTORY streamr-utils-modules)
   
 file(WRITE "${CMAKE_BINARY_DIR}/streamr-utils-config.cmake" 
     "list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_FIND_ROOT_PATH})\n"
@@ -123,10 +156,13 @@ if(NOT IOS)
     test/unit/BinaryUtilsTest.cpp
   )
 
-  target_link_libraries(streamr-utils-test-unit 
+  # The tests import streamr.utils, so their sources need module
+  # dependency scanning.
+  streamr_enable_imports(streamr-utils-test-unit)
+  target_link_libraries(streamr-utils-test-unit
     PUBLIC streamr-utils
-    PUBLIC GTest::gtest 
-    PUBLIC streamr-utils-test-main 
+    PUBLIC GTest::gtest
+    PUBLIC streamr-utils-test-main
   )
   
   if (NOT (${VCPKG_TARGET_TRIPLET} MATCHES "android"))

--- a/packages/streamr-utils/StreamrModules.cmake
+++ b/packages/streamr-utils/StreamrModules.cmake
@@ -71,6 +71,11 @@ function(streamr_add_module_library TARGET)
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    # PUBLIC compile feature (not just CMAKE_CXX_STANDARD): when another
+    # build tree imports this target from its export, CMake synthesizes a
+    # BMI-compiling target on the consumer side and requires the standard
+    # level to be part of the exported usage requirements.
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-utils/include/streamr-utils/StreamPartID.hpp
+++ b/packages/streamr-utils/include/streamr-utils/StreamPartID.hpp
@@ -9,7 +9,7 @@
 
 namespace streamr::utils {
 
-constexpr auto DELIMITER = "#"; // NOLINT
+inline constexpr auto DELIMITER = "#"; // NOLINT
 
 using StreamPartID = Branded<std::string, struct StreamPartIDBrand>;
 

--- a/packages/streamr-utils/include/streamr-utils/partition.hpp
+++ b/packages/streamr-utils/include/streamr-utils/partition.hpp
@@ -8,7 +8,7 @@
 
 namespace streamr::utils {
 
-constexpr auto MAX_PARTITION_COUNT = 100; // NOLINT
+inline constexpr auto MAX_PARTITION_COUNT = 100; // NOLINT
 
 inline void ensureValidStreamPartitionIndex(
     std::optional<uint32_t> streamPartition) {

--- a/packages/streamr-utils/include/streamr-utils/runAndWaitForEvents.hpp
+++ b/packages/streamr-utils/include/streamr-utils/runAndWaitForEvents.hpp
@@ -13,7 +13,7 @@ using streamr::eventemitter::EventEmitter;
 using streamr::eventemitter::HandlerToken;
 using streamr::utils::waitForEvent;
 
-constexpr std::chrono::milliseconds runAndWaitForEventsDefaultTimeout =
+inline constexpr std::chrono::milliseconds runAndWaitForEventsDefaultTimeout =
     std::chrono::milliseconds(5000);
 
 template <typename... BoundEventTypes>

--- a/packages/streamr-utils/include/streamr-utils/waitForCondition.hpp
+++ b/packages/streamr-utils/include/streamr-utils/waitForCondition.hpp
@@ -14,7 +14,8 @@ namespace streamr::utils {
 using streamr::eventemitter::Event;
 using streamr::eventemitter::ReplayEventEmitter;
 
-constexpr auto defaultRetryInterval = std::chrono::milliseconds(100); // NOLINT
+inline constexpr auto defaultRetryInterval =
+    std::chrono::milliseconds(100); // NOLINT
 
 struct ConditionMet : public Event<> {};
 

--- a/packages/streamr-utils/include/streamr-utils/waitForEvent.hpp
+++ b/packages/streamr-utils/include/streamr-utils/waitForEvent.hpp
@@ -20,7 +20,7 @@ struct remove_pointer<T*> {
     using type = typename remove_pointer<T>::type;
 };
 
-constexpr auto defaultTimeout = std::chrono::milliseconds(5000);
+inline constexpr auto defaultTimeout = std::chrono::milliseconds(5000);
 
 // Disable default specialization
 template <typename T>

--- a/packages/streamr-utils/lint.sh
+++ b/packages/streamr-utils/lint.sh
@@ -5,7 +5,23 @@ set -e
 FILES=$(find . -type d \( -name src -o -name include -o -name test \) ! -path '*/build/*' ! -path '*/proto/*' -print0 | xargs -0 -I{} find {} -type f \( -name "*.hpp" -o -name "*.cpp" \) -print0 | xargs -0 echo)
 echo "Running clangd-tidy on $FILES"
 
-clangd-tidy -p ./build $FILES
+# toEthereumAddressOrENSNameTest.cpp: clangd's experimental modules
+# support cannot unify std types between its preamble and the module BMIs
+# in this file (std::string crosses the module boundary in both
+# directions) — excluded from clangd-tidy until clangd modules support
+# matures. The compiler still fully typechecks it on every build and
+# clang-format still covers it.
+TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'toEthereumAddressOrENSNameTest.cpp' | tr '\n' ' ')
+clangd-tidy -p ./build $TIDY_FILES
 
 echo "Running clang-format --dry-run on $FILES"
 ../../run-clang-format.py $FILES
+
+# Module interface units: format check only. clangd-tidy is not run on
+# .cppm files (headers remain the fully linted source of truth during the
+# façade migration; clangd modules support is still experimental).
+MODULE_FILES=$(find ./modules -type f -name "*.cppm" 2>/dev/null | xargs echo)
+if [ -n "$MODULE_FILES" ]; then
+    echo "Running clang-format --dry-run on $MODULE_FILES"
+    ../../run-clang-format.py $MODULE_FILES
+fi

--- a/packages/streamr-utils/modules/streamr.utils-AbortController.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-AbortController.cppm
@@ -1,0 +1,22 @@
+// Façade partition over streamr-utils/AbortController.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/AbortController.hpp"
+
+export module streamr.utils:AbortController;
+
+export namespace streamr::utils::abortsignalevents {
+
+using streamr::utils::abortsignalevents::Aborted;
+
+} // namespace streamr::utils::abortsignalevents
+
+export namespace streamr::utils {
+
+using streamr::utils::AbortController;
+using streamr::utils::AbortSignal;
+using streamr::utils::AbortSignalEvents;
+using streamr::utils::abortsignalevents::Aborted;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-AbortableTimers.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-AbortableTimers.cppm
@@ -1,0 +1,13 @@
+// Façade partition over streamr-utils/AbortableTimers.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/AbortableTimers.hpp"
+
+export module streamr.utils:AbortableTimers;
+
+export namespace streamr::utils {
+
+using streamr::utils::AbortableTimers;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-BinaryUtils.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-BinaryUtils.cppm
@@ -1,0 +1,13 @@
+// Façade partition over streamr-utils/BinaryUtils.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/BinaryUtils.hpp"
+
+export module streamr.utils:BinaryUtils;
+
+export namespace streamr::utils {
+
+using streamr::utils::BinaryUtils;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-Branded.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-Branded.cppm
@@ -1,0 +1,17 @@
+// Façade partition over streamr-utils/Branded.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/Branded.hpp"
+
+export module streamr.utils:Branded;
+
+export namespace streamr::utils {
+
+using streamr::utils::Branded;
+using streamr::utils::BrandString;
+using streamr::utils::IntegralType;
+using streamr::utils::NonIntegralType;
+using streamr::utils::operator""_brand;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-ENSName.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-ENSName.cppm
@@ -1,0 +1,15 @@
+// Façade partition over streamr-utils/ENSName.hpp (see the streamr.eventemitter
+// partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/ENSName.hpp"
+
+export module streamr.utils:ENSName;
+
+export namespace streamr::utils {
+
+using streamr::utils::ENSName;
+using streamr::utils::isENSNameFormatIgnoreCase;
+using streamr::utils::toENSName;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-EnableSharedFromThis.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-EnableSharedFromThis.cppm
@@ -1,0 +1,14 @@
+// Façade partition over streamr-utils/EnableSharedFromThis.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/EnableSharedFromThis.hpp"
+
+export module streamr.utils:EnableSharedFromThis;
+
+export namespace streamr::utils {
+
+using streamr::utils::EnableSharedFromThis;
+using streamr::utils::EnableSharedFromThisBase;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-EthereumAddress.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-EthereumAddress.cppm
@@ -1,0 +1,14 @@
+// Façade partition over streamr-utils/EthereumAddress.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/EthereumAddress.hpp"
+
+export module streamr.utils:EthereumAddress;
+
+export namespace streamr::utils {
+
+using streamr::utils::EthereumAddress;
+using streamr::utils::toEthereumAddress;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-Ipv4Helper.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-Ipv4Helper.cppm
@@ -1,0 +1,13 @@
+// Façade partition over streamr-utils/Ipv4Helper.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/Ipv4Helper.hpp"
+
+export module streamr.utils:Ipv4Helper;
+
+export namespace streamr::utils {
+
+using streamr::utils::Ipv4Helper;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-ReplayEventEmitterWrapper.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-ReplayEventEmitterWrapper.cppm
@@ -1,0 +1,15 @@
+// Façade partition over streamr-utils/ReplayEventEmitterWrapper.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/ReplayEventEmitterWrapper.hpp"
+
+export module streamr.utils:ReplayEventEmitterWrapper;
+
+export namespace streamr::utils {
+
+using streamr::utils::createReplayEventEmitterWrapper;
+using streamr::utils::makeReplayEventEmitterWrapper;
+using streamr::utils::ReplayEventEmitterWrapper;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-RetryUtils.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-RetryUtils.cppm
@@ -1,0 +1,13 @@
+// Façade partition over streamr-utils/RetryUtils.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/RetryUtils.hpp"
+
+export module streamr.utils:RetryUtils;
+
+export namespace streamr::utils {
+
+using streamr::utils::RetryUtils;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-SigningUtils.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-SigningUtils.cppm
@@ -1,0 +1,13 @@
+// Façade partition over streamr-utils/SigningUtils.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/SigningUtils.hpp"
+
+export module streamr.utils:SigningUtils;
+
+export namespace streamr::utils {
+
+using streamr::utils::SigningUtils;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-StreamID.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-StreamID.cppm
@@ -1,0 +1,15 @@
+// Façade partition over streamr-utils/StreamID.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/StreamID.hpp"
+
+export module streamr.utils:StreamID;
+
+export namespace streamr::utils {
+
+using streamr::utils::StreamID;
+using streamr::utils::StreamIDUtils;
+using streamr::utils::toStreamID;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-StreamPartID.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-StreamPartID.cppm
@@ -1,0 +1,16 @@
+// Façade partition over streamr-utils/StreamPartID.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/StreamPartID.hpp"
+
+export module streamr.utils:StreamPartID;
+
+export namespace streamr::utils {
+
+using streamr::utils::DELIMITER;
+using streamr::utils::StreamPartID;
+using streamr::utils::StreamPartIDUtils;
+using streamr::utils::toStreamPartID;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-Uuid.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-Uuid.cppm
@@ -1,0 +1,13 @@
+// Façade partition over streamr-utils/Uuid.hpp (see the streamr.eventemitter
+// partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/Uuid.hpp"
+
+export module streamr.utils:Uuid;
+
+export namespace streamr::utils {
+
+using streamr::utils::Uuid;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-collect.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-collect.cppm
@@ -1,0 +1,14 @@
+// Façade partition over streamr-utils/collect.hpp (see the streamr.eventemitter
+// partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/collect.hpp"
+
+export module streamr.utils:collect;
+
+export namespace streamr::utils {
+
+using streamr::utils::collect;
+using streamr::utils::ResultType;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-partition.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-partition.cppm
@@ -1,0 +1,15 @@
+// Façade partition over streamr-utils/partition.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/partition.hpp"
+
+export module streamr.utils:partition;
+
+export namespace streamr::utils {
+
+using streamr::utils::ensureValidStreamPartitionCount;
+using streamr::utils::ensureValidStreamPartitionIndex;
+using streamr::utils::MAX_PARTITION_COUNT;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-runAndWaitForEvents.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-runAndWaitForEvents.cppm
@@ -1,0 +1,14 @@
+// Façade partition over streamr-utils/runAndWaitForEvents.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/runAndWaitForEvents.hpp"
+
+export module streamr.utils:runAndWaitForEvents;
+
+export namespace streamr::utils {
+
+using streamr::utils::runAndWaitForEvents;
+using streamr::utils::runAndWaitForEventsDefaultTimeout;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-toCoroTask.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-toCoroTask.cppm
@@ -1,0 +1,13 @@
+// Façade partition over streamr-utils/toCoroTask.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/toCoroTask.hpp"
+
+export module streamr.utils:toCoroTask;
+
+export namespace streamr::utils {
+
+using streamr::utils::toCoroTask;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-toEthereumAddressOrENSName.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-toEthereumAddressOrENSName.cppm
@@ -1,0 +1,13 @@
+// Façade partition over streamr-utils/toEthereumAddressOrENSName.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/toEthereumAddressOrENSName.hpp"
+
+export module streamr.utils:toEthereumAddressOrENSName;
+
+export namespace streamr::utils {
+
+using streamr::utils::toEthereumAddressOrENSName;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-waitForCondition.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-waitForCondition.cppm
@@ -1,0 +1,17 @@
+// Façade partition over streamr-utils/waitForCondition.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/waitForCondition.hpp"
+
+export module streamr.utils:waitForCondition;
+
+export namespace streamr::utils {
+
+using streamr::utils::ConditionMet;
+using streamr::utils::defaultRetryInterval;
+using streamr::utils::Poller;
+using streamr::utils::PollerEvents;
+using streamr::utils::waitForCondition;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils-waitForEvent.cppm
+++ b/packages/streamr-utils/modules/streamr.utils-waitForEvent.cppm
@@ -1,0 +1,16 @@
+// Façade partition over streamr-utils/waitForEvent.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-utils/waitForEvent.hpp"
+
+export module streamr.utils:waitForEvent;
+
+export namespace streamr::utils {
+
+using streamr::utils::defaultTimeout;
+using streamr::utils::remove_pointer;
+using streamr::utils::Waiter;
+using streamr::utils::waitForEvent;
+
+} // namespace streamr::utils

--- a/packages/streamr-utils/modules/streamr.utils.cppm
+++ b/packages/streamr-utils/modules/streamr.utils.cppm
@@ -1,0 +1,25 @@
+// Primary module interface unit of streamr.utils. Consumers write
+// `import streamr.utils;` and get every partition re-exported.
+export module streamr.utils;
+
+export import :AbortController;
+export import :AbortableTimers;
+export import :BinaryUtils;
+export import :Branded;
+export import :ENSName;
+export import :EnableSharedFromThis;
+export import :EthereumAddress;
+export import :Ipv4Helper;
+export import :ReplayEventEmitterWrapper;
+export import :RetryUtils;
+export import :SigningUtils;
+export import :StreamID;
+export import :StreamPartID;
+export import :Uuid;
+export import :collect;
+export import :partition;
+export import :runAndWaitForEvents;
+export import :toCoroTask;
+export import :toEthereumAddressOrENSName;
+export import :waitForCondition;
+export import :waitForEvent;

--- a/packages/streamr-utils/test/unit/AbortControllerTest.cpp
+++ b/packages/streamr-utils/test/unit/AbortControllerTest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
-#include <streamr-utils/AbortController.hpp>
+
+import streamr.utils;
 
 using streamr::utils::AbortController;
 

--- a/packages/streamr-utils/test/unit/AbortableTimersTest.cpp
+++ b/packages/streamr-utils/test/unit/AbortableTimersTest.cpp
@@ -1,7 +1,9 @@
-#include "streamr-utils/AbortableTimers.hpp"
+#include <chrono>
 #include <future>
+#include <thread>
 #include <gtest/gtest.h>
-#include "streamr-utils/AbortController.hpp"
+
+import streamr.utils;
 
 using streamr::utils::AbortableTimers;
 using streamr::utils::AbortController;

--- a/packages/streamr-utils/test/unit/BinaryUtilsTest.cpp
+++ b/packages/streamr-utils/test/unit/BinaryUtilsTest.cpp
@@ -1,7 +1,8 @@
-#include "streamr-utils/BinaryUtils.hpp"
 #include <iostream>
 #include <string>
 #include "gtest/gtest.h"
+
+import streamr.utils;
 
 using streamr::utils::BinaryUtils;
 

--- a/packages/streamr-utils/test/unit/BrandedTest.cpp
+++ b/packages/streamr-utils/test/unit/BrandedTest.cpp
@@ -1,5 +1,6 @@
-#include "streamr-utils/Branded.hpp"
 #include <gtest/gtest.h>
+
+import streamr.utils;
 
 using streamr::utils::Branded;
 using streamr::utils::operator""_brand; // NOLINT(misc-unused-using-decls)

--- a/packages/streamr-utils/test/unit/ENSNameTest.cpp
+++ b/packages/streamr-utils/test/unit/ENSNameTest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
-#include <streamr-utils/ENSName.hpp>
+
+import streamr.utils;
 
 using streamr::utils::ENSName;
 

--- a/packages/streamr-utils/test/unit/EthereumAddressTest.cpp
+++ b/packages/streamr-utils/test/unit/EthereumAddressTest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "streamr-utils/EthereumAddress.hpp"
+import streamr.utils;
 
 using streamr::utils::EthereumAddress; // NOLINT
 

--- a/packages/streamr-utils/test/unit/ReplayEventEmitterWrapperTest.cpp
+++ b/packages/streamr-utils/test/unit/ReplayEventEmitterWrapperTest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "streamr-utils/ReplayEventEmitterWrapper.hpp"
+import streamr.utils;
 
 using streamr::utils::ReplayEventEmitterWrapper; // NOLINT
 

--- a/packages/streamr-utils/test/unit/RetryUtilsTest.cpp
+++ b/packages/streamr-utils/test/unit/RetryUtilsTest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
-#include <streamr-utils/RetryUtils.hpp>
+
+import streamr.utils;
 
 using streamr::utils::RetryUtils; // NOLINT
 

--- a/packages/streamr-utils/test/unit/SigninUtilsTest.cpp
+++ b/packages/streamr-utils/test/unit/SigninUtilsTest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
-#include <streamr-utils/BinaryUtils.hpp>
-#include <streamr-utils/SigningUtils.hpp>
+
+import streamr.utils;
 
 using streamr::utils::BinaryUtils;
 using streamr::utils::SigningUtils;

--- a/packages/streamr-utils/test/unit/SigningUtilsTest.cpp
+++ b/packages/streamr-utils/test/unit/SigningUtilsTest.cpp
@@ -1,5 +1,6 @@
-#include "streamr-utils/SigningUtils.hpp"
 #include <gtest/gtest.h>
+
+import streamr.utils;
 
 using streamr::utils::BinaryUtils;
 using streamr::utils::SigningUtils;

--- a/packages/streamr-utils/test/unit/StreamIDTest.cpp
+++ b/packages/streamr-utils/test/unit/StreamIDTest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "streamr-utils/StreamID.hpp"
+import streamr.utils;
 
 using streamr::utils::StreamID; // NOLINT
 

--- a/packages/streamr-utils/test/unit/StreamPartIDTest.cpp
+++ b/packages/streamr-utils/test/unit/StreamPartIDTest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
-#include <streamr-utils/StreamPartID.hpp>
+
+import streamr.utils;
 
 using streamr::utils::StreamID;
 using streamr::utils::StreamPartID;

--- a/packages/streamr-utils/test/unit/collectTest.cpp
+++ b/packages/streamr-utils/test/unit/collectTest.cpp
@@ -1,8 +1,9 @@
-#include "streamr-utils/collect.hpp"
 #include <gtest/gtest.h>
 #include <folly/experimental/coro/BlockingWait.h>
 #include <folly/experimental/coro/Promise.h>
 #include <folly/experimental/coro/Task.h>
+
+import streamr.utils;
 
 using streamr::utils::collect;
 using streamr::utils::toCoroTask;

--- a/packages/streamr-utils/test/unit/runAndWaitForEventsTest.cpp
+++ b/packages/streamr-utils/test/unit/runAndWaitForEventsTest.cpp
@@ -1,10 +1,11 @@
-#include "streamr-utils/runAndWaitForEvents.hpp"
 #include <chrono>
 #include <thread>
 #include <tuple>
 #include <gtest/gtest.h>
 #include <folly/experimental/coro/Timeout.h>
 #include "streamr-eventemitter/EventEmitter.hpp"
+
+import streamr.utils;
 
 using streamr::eventemitter::Event;
 using streamr::eventemitter::EventEmitter;

--- a/packages/streamr-utils/test/unit/toCoroTaskTest.cpp
+++ b/packages/streamr-utils/test/unit/toCoroTaskTest.cpp
@@ -1,7 +1,8 @@
-#include "streamr-utils/toCoroTask.hpp"
 #include <gtest/gtest.h>
 #include <folly/experimental/coro/BlockingWait.h>
 #include <folly/experimental/coro/Task.h>
+
+import streamr.utils;
 
 using streamr::utils::toCoroTask;
 

--- a/packages/streamr-utils/test/unit/toEthereumAddressOrENSNameTest.cpp
+++ b/packages/streamr-utils/test/unit/toEthereumAddressOrENSNameTest.cpp
@@ -1,5 +1,8 @@
+#include <string>
+#include <variant>
 #include <gtest/gtest.h>
-#include <streamr-utils/toEthereumAddressOrENSName.hpp>
+
+import streamr.utils;
 
 using streamr::utils::EthereumAddress;
 using streamr::utils::toEthereumAddressOrENSName;
@@ -8,16 +11,12 @@ TEST(toEthereumAddressOrENSNameTest, shouldReturnEthereumAddress) {
     const std::string ethereumAddress =
         "0x1234567890123456789012345678901234567890";
     const auto expected = EthereumAddress{ethereumAddress};
-    std::visit(
-        [&](const auto& result) {
-            if constexpr (
-                std::is_same_v<
-                    std::decay_t<decltype(result)>,
-                    EthereumAddress>) {
-                EXPECT_EQ(result, expected);
-            } else {
-                FAIL() << "Expected EthereumAddress, but got ENSName";
-            }
-        },
-        toEthereumAddressOrENSName(ethereumAddress));
+    // holds_alternative/get instead of std::visit with a generic lambda:
+    // clangd's (still experimental) modules support misjudges generic-lambda
+    // visitors as non-exhaustive in import-using files (the compiler is
+    // fine with either form).
+    const auto result = toEthereumAddressOrENSName(ethereumAddress);
+    ASSERT_TRUE(std::holds_alternative<EthereumAddress>(result))
+        << "Expected EthereumAddress, but got ENSName";
+    EXPECT_EQ(std::get<EthereumAddress>(result), expected);
 }

--- a/packages/streamr-utils/test/unit/waitForConditionTest.cpp
+++ b/packages/streamr-utils/test/unit/waitForConditionTest.cpp
@@ -1,6 +1,7 @@
-#include "streamr-utils/waitForCondition.hpp"
 #include <gtest/gtest.h>
 #include <folly/experimental/coro/BlockingWait.h>
+
+import streamr.utils;
 
 using streamr::utils::AbortController;
 using streamr::utils::waitForCondition;

--- a/packages/streamr-utils/test/unit/waitForEventTest.cpp
+++ b/packages/streamr-utils/test/unit/waitForEventTest.cpp
@@ -1,13 +1,13 @@
 #include <tuple>
 #include <gtest/gtest.h>
 #include <streamr-eventemitter/EventEmitter.hpp>
-#include <streamr-utils/AbortController.hpp>
-#include <streamr-utils/waitForEvent.hpp>
 #include <folly/experimental/coro/BlockingWait.h>
 #include <folly/experimental/coro/Collect.h>
 #include <folly/experimental/coro/Invoke.h>
 #include <folly/experimental/coro/Sleep.h>
 #include <folly/experimental/coro/Timeout.h>
+
+import streamr.utils;
 
 using streamr::eventemitter::Event;
 using streamr::eventemitter::EventEmitter;


### PR DESCRIPTION
The phase the plan budgeted risk for: **folly enters the global module fragment**, and streamr-utils is the **folly::coro coroutine canary**. Both cleared with margin.

## What's migrated

- **streamr-logger** — 4 partitions (`:Logger`, `:LoggerImpl`, `:SLogger`, `:StreamrLogLevel`) + primary unit. folly's logging machinery compiles in the GMF without incident. `detail/` headers get no partitions (internal API); the detail-testing `LoggerEnvTest` keeps its detail `#include` *alongside* `import streamr.logger` — mixing is the designed property of the façade.
- **streamr-utils** — **21 partitions** + primary. The coroutine canary (`waitForEvent`, `waitForCondition`, `collect`, `toCoroTask` — folly::coro Tasks in exported signatures) **passed with zero compiler workarounds** under Clang 22. The per-header opt-out budget went unused.
- 20 test files + both examples now `import`; logger 63/63, utils 49/49 tests green through modules.

## Mechanisms discovered (now part of the scaffolding/docs)

1. **`target_compile_features(… PUBLIC cxx_std_26)` is required on exported module targets** — when another build tree consumes the export, CMake synthesizes a BMI-compiling target on the consumer side and hard-errors unless the standard is an exported usage requirement. Added to `streamr_add_module_library()`; surfaced the moment logger consumed json's export.
2. **Namespace-scope `constexpr` constants have internal linkage** and can't be re-exported — 7 header constants became `inline constexpr` (the correct C++17 idiom regardless of modules).
3. **clangd-modules root cause pinned down**: the quirks from 2.1 and this phase share one mechanism — clangd fails to unify std types between its preamble and types reached through BMIs, biting only where std types cross the module boundary in import-using files. One test file (`toEthereumAddressOrENSNameTest.cpp`, whose whole API is std types in `Branded` wrappers) needed the planned lint-exclusion fallback — first and only use; the compiler still typechecks it on every build. Also: `bugprone-exception-escape` now correctly fires on `main()` in import-using files (clangd sees deeper through BMIs) — real findings, fixed with function-try-blocks.

## Verification

| Gate | Result |
|---|---|
| Package builds (26 BMIs + archives) | ✅ |
| Package tests via `import` | ✅ logger 63/63, utils 49/49 |
| Downstream standalone builds (proto-rpc, dht — `find_package` + `#include`) | ✅ unchanged |
| Root tree | ✅ **307/307** |
| Full lint | ✅ (one documented exclusion) |
| iOS cross-build | this PR (`[iosbuild]`) |

**Honest bench note**: no incremental-rebuild improvement is expected yet — dht/trackerless-network still `#include` SLogger/utils headers. The measured win (the 48-TU/62–70 s SLogger.hpp baseline) arrives when those packages flip in 2.4/2.5 and their test TUs load BMIs instead of re-parsing the header stack.

## Next
Phase 2.3: streamr-proto-rpc — the first `:protos` partition (over `ProtoRpc.pb.h`) and the RpcCommunicator template stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)