### PR TITLE
Modernization Phase 2.3: modules — streamr-proto-rpc (:protos partition, protobuf overlay) [iosbuild]

### DIFF
--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -491,7 +491,7 @@ interface unit `export import`ing the partitions, INTERFACE→STATIC via
 - iOS gate via the PR's `iosbuild` keyword (module lib builds; tests are
   host-only). Android modules validation lands with its phase-2.5 gate.
 
-## Phase 2.2 — streamr-logger + streamr-utils (PR pending)
+## Phase 2.2 — streamr-logger + streamr-utils ✅ (PR #30, merged)
 folly enters the global module fragment; utils is the folly::coro canary.
 - **streamr-logger**: 4 partitions (Logger, LoggerImpl, SLogger,
   StreamrLogLevel) + primary unit. folly logging machinery in the GMF
@@ -538,6 +538,42 @@ folly enters the global module fragment; utils is the folly::coro canary.
   trackerless-network) still `#include` them; the measured win arrives
   when those packages flip (2.4/2.5) and their test TUs load BMIs instead
   of re-parsing the header stack.
+
+## Phase 2.3 — streamr-proto-rpc (PR pending)
+The first `:protos` partition — the pattern rehearsal for 2.4/2.5.
+- 9 units: primary + `:protos` (wraps generated `ProtoRpc.pb.h`, exports
+  `::protorpc::RpcMessage`/`RpcErrorType` + enumerators via `using enum`)
+  + 7 partitions mirroring the public headers. The module surface is
+  added to the EXISTING static library (it also compiles the generated
+  `.pb.cc`) via the new `streamr_target_module_sources()` helper.
+- **protobuf is not GMF-clean — overlay patch required**: any protobuf
+  header in a global module fragment fails on arm64 under Clang 22
+  ("no matching function for call to 'VarintParseSlowArm'"): the helper
+  overloads are `static` (TU-local), and implicit template instantiation
+  in module units happens in purview context where TU-local GMF entities
+  are unusable. Fixed with a one-word overlay patch (`static` →
+  `inline`, ODR-safe) — `overlayports/protobuf/` with JUSTIFICATION.md;
+  first overlay added since the 1.3 cleanup (now 4). Found via minimal
+  repro at the cheapest possible phase — dht's three big pb.h files
+  would have hit the same wall in 2.4.
+- **Imported-target modules are usable only by DIRECT consumers**: a
+  target whose sources `import streamr.logger;` must link
+  `streamr::streamr-logger` itself — BMI usability does not propagate
+  through a native target's transitive linkage. (Good hygiene anyway:
+  direct dependency for direct import.)
+- **Export-alias rule established**: partitions re-export aliases the
+  package declares for types in its API signatures (`RpcMessage`,
+  `RpcErrorType`, `Any`, `Empty`); incidental convenience aliases
+  (`SLogger`, `Task`) are NOT exported — importing TUs import the owning
+  module instead.
+- Library deps flipped INTERFACE/PRIVATE → PUBLIC (consumer-side BMI
+  compilation needs the full usage requirements, including protobuf and
+  magic_enum include dirs). 2 more constants → `inline constexpr`.
+- The plan's "extern C test export" gate: no `extern "C"` exists in this
+  package's sources (stale plan note; verified by grep).
+- Verified: 26/26 tests through import (unit + integration incl. the
+  generated client/server pb stubs), both examples build; downstream
+  dht/tn standalone builds unchanged; root tree 307/307; full lint.
 
 ## Lint/IDE survival
 - During the façade stage, headers remain the fully-linted source of truth

--- a/cmake/StreamrModules.cmake
+++ b/cmake/StreamrModules.cmake
@@ -78,6 +78,26 @@ function(streamr_add_module_library TARGET)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
+# streamr_target_module_sources(<target> FILES <unit.cppm>...)
+#
+# Adds C++ module interface units to an EXISTING library target (used by
+# packages that already compile ordinary sources, e.g. generated protobuf
+# .cc files). Same effect as streamr_add_module_library() minus the
+# add_library().
+function(streamr_target_module_sources TARGET)
+    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    if(NOT ARG_FILES)
+        message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    target_sources(${TARGET}
+        PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        FILES ${ARG_FILES})
+    set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
+endfunction()
+
 # streamr_enable_imports(<target>)
 #
 # Enables module scanning on an existing target whose ordinary .cpp sources

--- a/overlayports/protobuf/JUSTIFICATION.md
+++ b/overlayports/protobuf/JUSTIFICATION.md
@@ -1,0 +1,30 @@
+# Why this overlay exists
+
+Baseline: vcpkg 2026.06.24 port of protobuf v33.4, plus ONE local patch.
+
+## fix-static-varint-parse-for-cxx-modules.patch
+
+`src/google/protobuf/parse_context.h` declares the two
+`VarintParseSlowArm(...)` overloads as `static` (internal linkage). When a
+protobuf header is included in the *global module fragment* of a C++
+module unit (the monorepo's `:protos` façade partitions —
+MODERNIZATION.md Part 2), Clang 22 performs the implicit instantiation of
+`VarintParse<...>` in module-purview context, where TU-local (internal
+linkage) declarations from the GMF are not usable — the build fails with
+"no matching function for call to 'VarintParseSlowArm'" on every arm64
+platform (macOS, iOS, Android, arm64-linux).
+
+Minimal repro (fails without the patch, compiles with it):
+
+```cpp
+module;
+#include <google/protobuf/any.pb.h>
+export module repro;
+```
+
+The patch changes `static` → `inline` on the two overloads: external
+linkage (usable from module purview), ODR-safe because the definitions
+are identical in every TU. No behavior change.
+
+Delete this overlay when upstream protobuf makes its headers module-GMF
+clean (or switches these helpers to `inline`).

--- a/overlayports/protobuf/fix-constinit-with-clang-cl.patch
+++ b/overlayports/protobuf/fix-constinit-with-clang-cl.patch
@@ -1,0 +1,14 @@
+diff --git a/src/google/protobuf/port_def.inc b/src/google/protobuf/port_def.inc
+index a512b4843..31f1f5a12 100644
+--- a/src/google/protobuf/port_def.inc
++++ b/src/google/protobuf/port_def.inc
+@@ -678,6 +678,9 @@ static_assert(PROTOBUF_ABSL_MIN(20230125, 3),
+ #  define PROTOBUF_CONSTINIT
+ #  define PROTOBUF_CONSTEXPR constexpr
+ # endif
++#elif defined(_MSC_VER)  && defined(__clang__)
++#  define PROTOBUF_CONSTINIT
++#  define PROTOBUF_CONSTEXPR constexpr
+ #else
+ # if defined(__cpp_constinit) && !defined(__CYGWIN__)
+ #  define PROTOBUF_CONSTINIT constinit

--- a/overlayports/protobuf/fix-default-proto-file-path.patch
+++ b/overlayports/protobuf/fix-default-proto-file-path.patch
@@ -1,0 +1,21 @@
+diff --git a/src/google/protobuf/compiler/command_line_interface.cc b/src/google/protobuf/compiler/command_line_interface.cc
+index cd95c8b41..d4825180d 100644
+--- a/src/google/protobuf/compiler/command_line_interface.cc
++++ b/src/google/protobuf/compiler/command_line_interface.cc
+@@ -272,12 +272,15 @@ void AddDefaultProtoPaths(
+     paths->emplace_back("", std::move(include_path));
+     return;
+   }
+-  // Check if the upper level directory has an "include" subdirectory.
++  // change "'$/bin' is next to 'include'" assumption to "'$/bin/tools' is next to 'include'"
++  for (int i = 0; i < 2; i++)
++  {
+   pos = path.find_last_of("/\\");
+   if (pos == std::string::npos || pos == 0) {
+     return;
+   }
+   path = path.substr(0, pos);
++  }
+   include_path = absl::StrCat(path, "/include");
+   if (IsInstalledProtoPath(include_path)) {
+     paths->emplace_back("", std::move(include_path));

--- a/overlayports/protobuf/fix-install-dirs.patch
+++ b/overlayports/protobuf/fix-install-dirs.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2b9ca8ed6..1881eb221 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,6 +13,7 @@ endif()
+ 
+ # Project
+ project(protobuf C CXX)
++include(GNUInstallDirs)
+ 
+ if(CMAKE_CXX_STANDARD AND CMAKE_CXX_STANDARD LESS 17)
+   message(FATAL_ERROR "The minimum supported C++ standard is C++ 17")

--- a/overlayports/protobuf/fix-static-build.patch
+++ b/overlayports/protobuf/fix-static-build.patch
@@ -1,0 +1,22 @@
+diff --git a/cmake/install.cmake b/cmake/install.cmake
+index 65765ca29..f5ad69102 100644
+--- a/cmake/install.cmake
++++ b/cmake/install.cmake
+@@ -65,7 +65,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)
+     endforeach ()
+   endif ()
+   foreach (binary IN LISTS _protobuf_binaries)
+-    if (UNIX AND NOT APPLE)
++    if (UNIX AND NOT APPLE AND NOT protobuf_MSVC_STATIC_RUNTIME)
+       set_property(TARGET ${binary}
+         PROPERTY INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+     elseif (APPLE)
+@@ -85,7 +85,5 @@ set(protobuf_HEADERS
+   ${cpp_features_proto_proto_srcs}
+   ${descriptor_proto_proto_srcs}
+   ${plugin_proto_proto_srcs}
+-  ${java_features_proto_proto_srcs}
+-  ${go_features_proto_proto_srcs}
+ )
+ if (protobuf_BUILD_LIBUPB)
+   list(APPEND protobuf_HEADERS ${libupb_hdrs})

--- a/overlayports/protobuf/fix-static-varint-parse-for-cxx-modules.patch
+++ b/overlayports/protobuf/fix-static-varint-parse-for-cxx-modules.patch
@@ -1,0 +1,19 @@
+--- a/src/google/protobuf/parse_context.h
++++ b/src/google/protobuf/parse_context.h
+@@ -966,14 +966,14 @@
+   return {info.p, result};
+ }
+ 
+-static const char* VarintParseSlowArm(const char* p, uint32_t* out,
++inline const char* VarintParseSlowArm(const char* p, uint32_t* out,
+                                       uint64_t first8) {
+   auto tmp = VarintParseSlowArm32(p, first8);
+   *out = tmp.second;
+   return tmp.first;
+ }
+ 
+-static const char* VarintParseSlowArm(const char* p, uint64_t* out,
++inline const char* VarintParseSlowArm(const char* p, uint64_t* out,
+                                       uint64_t first8) {
+   auto tmp = VarintParseSlowArm64(p, first8);
+   *out = tmp.second;

--- a/overlayports/protobuf/fix-upb.patch
+++ b/overlayports/protobuf/fix-upb.patch
@@ -1,0 +1,22 @@
+diff --git a/cmake/install.cmake b/cmake/install.cmake
+index 5e816b311..84211495b 100644
+--- a/cmake/install.cmake
++++ b/cmake/install.cmake
+@@ -60,7 +60,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)
+   install(TARGETS protoc EXPORT protobuf-targets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc
+     BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
+-  if (protobuf_BUILD_LIBUPB)
++  if (0)
+     foreach (generator upb upbdefs upb_minitable)
+       list(APPEND _protobuf_binaries protoc-gen-${generator})
+       install(TARGETS protoc-gen-${generator} EXPORT protobuf-targets
+@@ -93,7 +93,7 @@ set(protobuf_HEADERS
+   ${descriptor_proto_proto_srcs}
+   ${plugin_proto_proto_srcs}
+ )
+-if (protobuf_BUILD_LIBUPB)
++if (0)
+   list(APPEND protobuf_HEADERS ${libupb_hdrs})
+   # Manually install the bootstrap headers
+   install(

--- a/overlayports/protobuf/fix-utf8-range.patch
+++ b/overlayports/protobuf/fix-utf8-range.patch
@@ -1,0 +1,71 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2b9ca8ed6..a9798c35e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -274,6 +274,7 @@ endif (protobuf_BUILD_TESTS)
+ include(${protobuf_SOURCE_DIR}/cmake/abseil-cpp.cmake)
+ 
+ if (protobuf_BUILD_PROTOBUF_BINARIES)
++  find_package(utf8_range CONFIG REQUIRED)
+   include(${protobuf_SOURCE_DIR}/cmake/utf8_range.cmake)
+   include(${protobuf_SOURCE_DIR}/cmake/libprotobuf-lite.cmake)
+   if (NOT DEFINED protobuf_LIB_PROTOBUF_LITE)
+diff --git a/cmake/libprotobuf-lite.cmake b/cmake/libprotobuf-lite.cmake
+index 6a923f6c8..d910c8499 100644
+--- a/cmake/libprotobuf-lite.cmake
++++ b/cmake/libprotobuf-lite.cmake
+@@ -43,4 +43,4 @@ set_target_properties(libprotobuf-lite PROPERTIES
+ )
+ add_library(protobuf::libprotobuf-lite ALIAS libprotobuf-lite)
+ 
+-target_link_libraries(libprotobuf-lite PRIVATE utf8_validity)
++target_link_libraries(libprotobuf-lite PRIVATE utf8_range::utf8_validity)
+diff --git a/cmake/libprotobuf.cmake b/cmake/libprotobuf.cmake
+index 22df1fd14..ea9a1054b 100644
+--- a/cmake/libprotobuf.cmake
++++ b/cmake/libprotobuf.cmake
+@@ -45,4 +45,4 @@ set_target_properties(libprotobuf PROPERTIES
+ )
+ add_library(protobuf::libprotobuf ALIAS libprotobuf)
+ 
+-target_link_libraries(libprotobuf PUBLIC utf8_validity)
++target_link_libraries(libprotobuf PUBLIC utf8_range::utf8_validity)
+diff --git a/cmake/libupb.cmake b/cmake/libupb.cmake
+index 1cbbaa209..4feb0345e 100644
+--- a/cmake/libupb.cmake
++++ b/cmake/libupb.cmake
+@@ -48,4 +48,4 @@ set_target_properties(libupb PROPERTIES
+     VISIBILITY_INLINES_HIDDEN ON
+ )
+ add_library(protobuf::libupb ALIAS libupb)
+-target_link_libraries(libupb PRIVATE utf8_range)
++target_link_libraries(libupb PRIVATE utf8_range::utf8_range)
+diff --git a/cmake/upb_generators.cmake b/cmake/upb_generators.cmake
+index 7a55f851e..de897a079 100644
+--- a/cmake/upb_generators.cmake
++++ b/cmake/upb_generators.cmake
+@@ -24,7 +24,7 @@ foreach(generator upb upbdefs upb_minitable)
+   endif()
+   target_link_libraries(protoc-gen-${generator}
+     libprotobuf
+-    utf8_validity
++    utf8_range::utf8_validity
+     ${protobuf_LIB_UPB}
+     ${protobuf_ABSL_USED_TARGETS}
+   )
+diff --git a/cmake/utf8_range.cmake b/cmake/utf8_range.cmake
+index f411a8c5b..21bf8235b 100644
+--- a/cmake/utf8_range.cmake
++++ b/cmake/utf8_range.cmake
+@@ -1,4 +1,4 @@
+-if (NOT TARGET utf8_range)
++if (0)
+   set(utf8_range_ENABLE_TESTS OFF CACHE BOOL "Disable utf8_range tests")
+ 
+   if (NOT EXISTS "${protobuf_SOURCE_DIR}/third_party/utf8_range/CMakeLists.txt")
+@@ -12,4 +12,4 @@ if (NOT TARGET utf8_range)
+   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/utf8_range)
+ endif ()
+ 
+-set(_protobuf_FIND_UTF8_RANGE "if(NOT TARGET utf8_range)\n  find_package(utf8_range CONFIG)\nendif()")
++set(_protobuf_FIND_UTF8_RANGE "if(NOT TARGET utf8_range::utf8_range)\n  find_package(utf8_range CONFIG)\nendif()")

--- a/overlayports/protobuf/portfile.cmake
+++ b/overlayports/protobuf/portfile.cmake
@@ -1,0 +1,141 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO protocolbuffers/protobuf
+    REF "v33.4"
+    SHA512 540059a93721447cf4723bcca06e91c43a4399cb366c05bf84e9d8e2c439f3107ba17803f9d912549b54c471f2dcc4c9fc834145ec441dff31ca24f9a3543aa9
+    HEAD_REF master
+    PATCHES
+        fix-static-build.patch
+        fix-default-proto-file-path.patch
+        fix-utf8-range.patch
+        fix-install-dirs.patch
+        fix-constinit-with-clang-cl.patch
+        fix-upb.patch
+        fix-static-varint-parse-for-cxx-modules.patch
+)
+
+string(COMPARE EQUAL "${TARGET_TRIPLET}" "${HOST_TRIPLET}" protobuf_BUILD_PROTOC_BINARIES)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" protobuf_BUILD_SHARED_LIBS)
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" protobuf_MSVC_STATIC_RUNTIME)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        libprotoc protobuf_BUILD_TARGET_LIBPROTOC
+        zlib      protobuf_WITH_ZLIB
+)
+
+set(protobuf_BUILD_LIBPROTOC OFF)
+if(NOT VCPKG_TARGET_IS_UWP AND (protobuf_BUILD_PROTOC_BINARIES OR protobuf_BUILD_TARGET_LIBPROTOC))
+    set(protobuf_BUILD_LIBPROTOC ON)
+endif()
+
+if (VCPKG_DOWNLOAD_MODE)
+    # download PKGCONFIG in download mode which is used in `vcpkg_fixup_pkgconfig()` at the end of this script.
+    # download it here because `vcpkg_cmake_configure()` halts execution in download mode when running configure process.
+    vcpkg_find_acquire_program(PKGCONFIG)
+endif()
+
+# Delete language backends we aren't targeting to reduce false positives in automated dependency
+# detectors like Dependabot.
+file(REMOVE_RECURSE
+    "${SOURCE_PATH}/csharp"
+    "${SOURCE_PATH}/java"
+    "${SOURCE_PATH}/lua"
+    "${SOURCE_PATH}/objectivec"
+    "${SOURCE_PATH}/php"
+    "${SOURCE_PATH}/python"
+    "${SOURCE_PATH}/ruby"
+    "${SOURCE_PATH}/rust"
+    "${SOURCE_PATH}/go"
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_CXX_STANDARD=17
+        -Dprotobuf_BUILD_SHARED_LIBS=${protobuf_BUILD_SHARED_LIBS}
+        -Dprotobuf_MSVC_STATIC_RUNTIME=${protobuf_MSVC_STATIC_RUNTIME}
+        -Dprotobuf_BUILD_TESTS=OFF
+        -DCMAKE_INSTALL_CMAKEDIR:STRING=share/protobuf
+        -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES}
+        -Dprotobuf_BUILD_LIBPROTOC=${protobuf_BUILD_LIBPROTOC}
+        -Dprotobuf_LOCAL_DEPENDENCIES_ONLY=ON
+        -Dprotobuf_BUILD_LIBUPB=${protobuf_BUILD_LIBPROTOC}
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+if(protobuf_BUILD_PROTOC_BINARIES)
+    if(VCPKG_TARGET_IS_WINDOWS)
+        vcpkg_copy_tools(TOOL_NAMES protoc AUTO_CLEAN)
+    else()
+        string(REPLACE "." ";" VERSION_LIST ${VERSION})
+        list(GET VERSION_LIST 1 VERSION_MINOR)
+        list(GET VERSION_LIST 2 VERSION_PATCH)
+        vcpkg_copy_tools(TOOL_NAMES protoc protoc-${VERSION_MINOR}.${VERSION_PATCH}.0 AUTO_CLEAN)
+    endif()
+else()
+    file(COPY "${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+endif()
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/protobuf-config.cmake"
+    "if(protobuf_MODULE_COMPATIBLE)"
+    "if(protobuf_MODULE_COMPATIBLE OR CMAKE_FIND_PACKAGE_NAME STREQUAL \"Protobuf\")"
+)
+if(NOT protobuf_BUILD_LIBPROTOC)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/protobuf-module.cmake"
+        "_protobuf_find_libraries(Protobuf_PROTOC protoc)"
+        ""
+    )
+endif()
+
+vcpkg_cmake_config_fixup()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/google/protobuf/port_def.inc"
+        "\#ifdef PROTOBUF_PORT_"
+        "\#ifndef PROTOBUF_USE_DLLS\n\#define PROTOBUF_USE_DLLS\n\#endif // PROTOBUF_USE_DLLS\n\n\#ifdef PROTOBUF_PORT_"
+    )
+endif()
+
+vcpkg_copy_pdbs()
+
+function(replace_package_string package)
+    set(debug_file "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${package}.pc")
+    set(release_file "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${package}.pc")
+
+    if(EXISTS "${release_file}")
+        vcpkg_replace_string("${release_file}" "absl_abseil_dll" "abseil_dll" IGNORE_UNCHANGED)
+        if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+            vcpkg_replace_string("${release_file}" "-l${package}" "-llib${package}" IGNORE_UNCHANGED)
+        endif()
+    endif()
+
+    if(EXISTS "${debug_file}")
+        vcpkg_replace_string("${debug_file}" "absl_abseil_dll" "abseil_dll" IGNORE_UNCHANGED)
+        if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+            vcpkg_replace_string("${debug_file}" "-l${package}" "-llib${package}d" IGNORE_UNCHANGED)
+        else()
+            vcpkg_replace_string("${debug_file}" "-l${package}" "-l${package}d" IGNORE_UNCHANGED)
+        endif()
+    endif()
+endfunction()
+
+set(packages protobuf protobuf-lite)
+foreach(package IN LISTS packages)
+    replace_package_string("${package}")
+endforeach()
+
+
+vcpkg_fixup_pkgconfig()
+
+if(NOT protobuf_BUILD_PROTOC_BINARIES)
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/protobuf-targets-vcpkg-protoc.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/protobuf-targets-vcpkg-protoc.cmake" COPYONLY)
+endif()
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share" "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/overlayports/protobuf/protobuf-targets-vcpkg-protoc.cmake
+++ b/overlayports/protobuf/protobuf-targets-vcpkg-protoc.cmake
@@ -1,0 +1,8 @@
+# Create imported target protobuf::protoc
+add_executable(protobuf::protoc IMPORTED)
+
+# Import target "protobuf::protoc" for configuration "Release"
+set_property(TARGET protobuf::protoc APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+set_target_properties(protobuf::protoc PROPERTIES
+    IMPORTED_LOCATION_RELEASE "${Protobuf_PROTOC_EXECUTABLE}"
+)

--- a/overlayports/protobuf/vcpkg-cmake-wrapper.cmake
+++ b/overlayports/protobuf/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,3 @@
+find_program(Protobuf_PROTOC_EXECUTABLE NAMES protoc PATHS "${CMAKE_CURRENT_LIST_DIR}/../../../@HOST_TRIPLET@/tools/protobuf" NO_DEFAULT_PATH)
+
+_find_package(${ARGS} CONFIG)

--- a/overlayports/protobuf/vcpkg.json
+++ b/overlayports/protobuf/vcpkg.json
@@ -1,0 +1,36 @@
+{
+  "name": "protobuf",
+  "version": "6.33.4",
+  "port-version": 2,
+  "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
+  "homepage": "https://github.com/protocolbuffers/protobuf",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    "abseil",
+    {
+      "name": "protobuf",
+      "host": true
+    },
+    "utf8-range",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "libprotoc": {
+      "description": "Build the libprotoc compiler library for target builds.",
+      "supports": "!uwp"
+    },
+    "zlib": {
+      "description": "ZLib based features like Gzip streams",
+      "dependencies": [
+        "zlib"
+      ]
+    }
+  }
+}

--- a/packages/streamr-dht/StreamrModules.cmake
+++ b/packages/streamr-dht/StreamrModules.cmake
@@ -78,6 +78,26 @@ function(streamr_add_module_library TARGET)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
+# streamr_target_module_sources(<target> FILES <unit.cppm>...)
+#
+# Adds C++ module interface units to an EXISTING library target (used by
+# packages that already compile ordinary sources, e.g. generated protobuf
+# .cc files). Same effect as streamr_add_module_library() minus the
+# add_library().
+function(streamr_target_module_sources TARGET)
+    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    if(NOT ARG_FILES)
+        message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    target_sources(${TARGET}
+        PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        FILES ${ARG_FILES})
+    set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
+endfunction()
+
 # streamr_enable_imports(<target>)
 #
 # Enables module scanning on an existing target whose ordinary .cpp sources

--- a/packages/streamr-eventemitter/StreamrModules.cmake
+++ b/packages/streamr-eventemitter/StreamrModules.cmake
@@ -78,6 +78,26 @@ function(streamr_add_module_library TARGET)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
+# streamr_target_module_sources(<target> FILES <unit.cppm>...)
+#
+# Adds C++ module interface units to an EXISTING library target (used by
+# packages that already compile ordinary sources, e.g. generated protobuf
+# .cc files). Same effect as streamr_add_module_library() minus the
+# add_library().
+function(streamr_target_module_sources TARGET)
+    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    if(NOT ARG_FILES)
+        message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    target_sources(${TARGET}
+        PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        FILES ${ARG_FILES})
+    set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
+endfunction()
+
 # streamr_enable_imports(<target>)
 #
 # Enables module scanning on an existing target whose ordinary .cpp sources

--- a/packages/streamr-json/StreamrModules.cmake
+++ b/packages/streamr-json/StreamrModules.cmake
@@ -78,6 +78,26 @@ function(streamr_add_module_library TARGET)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
+# streamr_target_module_sources(<target> FILES <unit.cppm>...)
+#
+# Adds C++ module interface units to an EXISTING library target (used by
+# packages that already compile ordinary sources, e.g. generated protobuf
+# .cc files). Same effect as streamr_add_module_library() minus the
+# add_library().
+function(streamr_target_module_sources TARGET)
+    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    if(NOT ARG_FILES)
+        message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    target_sources(${TARGET}
+        PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        FILES ${ARG_FILES})
+    set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
+endfunction()
+
 # streamr_enable_imports(<target>)
 #
 # Enables module scanning on an existing target whose ordinary .cpp sources

--- a/packages/streamr-libstreamrproxyclient/StreamrModules.cmake
+++ b/packages/streamr-libstreamrproxyclient/StreamrModules.cmake
@@ -78,6 +78,26 @@ function(streamr_add_module_library TARGET)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
+# streamr_target_module_sources(<target> FILES <unit.cppm>...)
+#
+# Adds C++ module interface units to an EXISTING library target (used by
+# packages that already compile ordinary sources, e.g. generated protobuf
+# .cc files). Same effect as streamr_add_module_library() minus the
+# add_library().
+function(streamr_target_module_sources TARGET)
+    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    if(NOT ARG_FILES)
+        message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    target_sources(${TARGET}
+        PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        FILES ${ARG_FILES})
+    set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
+endfunction()
+
 # streamr_enable_imports(<target>)
 #
 # Enables module scanning on an existing target whose ordinary .cpp sources

--- a/packages/streamr-logger/StreamrModules.cmake
+++ b/packages/streamr-logger/StreamrModules.cmake
@@ -78,6 +78,26 @@ function(streamr_add_module_library TARGET)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
+# streamr_target_module_sources(<target> FILES <unit.cppm>...)
+#
+# Adds C++ module interface units to an EXISTING library target (used by
+# packages that already compile ordinary sources, e.g. generated protobuf
+# .cc files). Same effect as streamr_add_module_library() minus the
+# add_library().
+function(streamr_target_module_sources TARGET)
+    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    if(NOT ARG_FILES)
+        message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    target_sources(${TARGET}
+        PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        FILES ${ARG_FILES})
+    set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
+endfunction()
+
 # streamr_enable_imports(<target>)
 #
 # Enables module scanning on an existing target whose ordinary .cpp sources

--- a/packages/streamr-proto-rpc/CMakeLists.txt
+++ b/packages/streamr-proto-rpc/CMakeLists.txt
@@ -32,9 +32,28 @@ if(NOT TARGET Boost::uuid)
   set_target_properties(Boost::uuid PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
 endif()
 
+# C++ modules support (guards, policies, helpers) — must come after
+# project() because it inspects the compiler id.
+include(${CMAKE_CURRENT_SOURCE_DIR}/StreamrModules.cmake)
+
 add_library(streamr-proto-rpc)
 set_property(TARGET streamr-proto-rpc PROPERTY CXX_STANDARD 26)
 add_library(streamr::streamr-proto-rpc ALIAS streamr-proto-rpc)
+
+# Module façade (MODERNIZATION.md Part 2), added to the existing library
+# (it also compiles the generated ProtoRpc.pb.cc). :protos wraps the
+# generated header; the other partitions mirror the public headers.
+streamr_target_module_sources(streamr-proto-rpc
+  FILES
+    modules/streamr.protorpc.cppm
+    modules/streamr.protorpc-protos.cppm
+    modules/streamr.protorpc-Errors.cppm
+    modules/streamr.protorpc-ProtoCallContext.cppm
+    modules/streamr.protorpc-RpcCommunicator.cppm
+    modules/streamr.protorpc-RpcCommunicatorClientApi.cppm
+    modules/streamr.protorpc-RpcCommunicatorServerApi.cppm
+    modules/streamr.protorpc-ServerRegistry.cppm
+    modules/streamr.protorpc-StreamPrinter.cppm)
 target_include_directories(streamr-proto-rpc 
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     PUBLIC $<INSTALL_INTERFACE:include>
@@ -45,19 +64,24 @@ target_include_directories(streamr-proto-rpc
 target_sources(streamr-proto-rpc 
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/proto/packages/proto-rpc/protos/ProtoRpc.pb.cc)
 
-target_link_libraries(streamr-proto-rpc 
-    INTERFACE streamr::streamr-logger
-    INTERFACE streamr::streamr-eventemitter
-    INTERFACE streamr::streamr-utils
-    PRIVATE protobuf::libprotobuf
-    INTERFACE Boost::uuid
-    PRIVATE magic_enum::magic_enum
+# PUBLIC (was INTERFACE/PRIVATE): the module interface units compile the
+# public headers in their global module fragments, and consumer build
+# trees recompile those units from the export — every dependency the
+# headers reach must be an exported usage requirement.
+target_link_libraries(streamr-proto-rpc
+    PUBLIC streamr::streamr-logger
+    PUBLIC streamr::streamr-eventemitter
+    PUBLIC streamr::streamr-utils
+    PUBLIC protobuf::libprotobuf
+    PUBLIC Boost::uuid
+    PUBLIC magic_enum::magic_enum
     PUBLIC Folly::folly
     )
 
-export(TARGETS streamr-proto-rpc 
+export(TARGETS streamr-proto-rpc
     NAMESPACE streamr::
-    FILE streamr-proto-rpc-config-in.cmake)
+    FILE streamr-proto-rpc-config-in.cmake
+    CXX_MODULES_DIRECTORY streamr-proto-rpc-modules)
   
 file(WRITE "${CMAKE_BINARY_DIR}/streamr-proto-rpc-config.cmake" 
     "list(APPEND CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH})\n"
@@ -104,15 +128,20 @@ if(NOT IOS)
         test/unit/RpcCommunicatorTest.cpp
     )
 
-    target_include_directories(streamr-proto-rpc-test-unit 
+    streamr_enable_imports(streamr-proto-rpc-test-unit)
+    target_include_directories(streamr-proto-rpc-test-unit
         PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test/proto>
     )
 
-    target_link_libraries(streamr-proto-rpc-test-unit 
+    target_link_libraries(streamr-proto-rpc-test-unit
         PUBLIC streamr-proto-rpc
-        PUBLIC GTest::gtest 
+        # Imported modules are usable only by DIRECT consumers: a target
+        # whose sources `import streamr.logger;` must link the imported
+        # target itself (transitive linkage does not propagate BMIs).
+        PUBLIC streamr::streamr-logger
+        PUBLIC GTest::gtest
         PUBLIC streamr-proto-rpc-test-main
-        PUBLIC GTest::gmock 
+        PUBLIC GTest::gmock
         PUBLIC Folly::folly
     )
     if (NOT (${VCPKG_TARGET_TRIPLET} MATCHES "android"))
@@ -128,15 +157,19 @@ if(NOT IOS)
         test/integration/ProtoRpcTest.cpp
     )
 
-    target_include_directories(streamr-proto-rpc-test-integration 
+    streamr_enable_imports(streamr-proto-rpc-test-integration)
+    target_include_directories(streamr-proto-rpc-test-integration
         PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test/proto>
     )
 
-    target_link_libraries(streamr-proto-rpc-test-integration 
+    target_link_libraries(streamr-proto-rpc-test-integration
         PUBLIC streamr-proto-rpc
-        PUBLIC GTest::gtest 
-        PUBLIC streamr-proto-rpc-test-main 
-        PUBLIC GTest::gmock 
+        # Direct links for directly-imported modules (see the unit test).
+        PUBLIC streamr::streamr-logger
+        PUBLIC streamr::streamr-eventemitter
+        PUBLIC GTest::gtest
+        PUBLIC streamr-proto-rpc-test-main
+        PUBLIC GTest::gmock
         PUBLIC Folly::folly
     )
     if (NOT (${VCPKG_TARGET_TRIPLET} MATCHES "android"))
@@ -154,7 +187,8 @@ if(NOT IOS)
         PUBLIC Folly::folly
     )
 
-    target_include_directories(streamr-proto-rpc-example-hello 
+    streamr_enable_imports(streamr-proto-rpc-example-hello)
+    target_include_directories(streamr-proto-rpc-example-hello
         PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/examples/hello/proto>
     )
 
@@ -168,6 +202,7 @@ if(NOT IOS)
         PUBLIC Folly::folly
     )
 
+    streamr_enable_imports(streamr-proto-rpc-example-routed-hello)
     target_include_directories(streamr-proto-rpc-example-routed-hello
         PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/examples/routed-hello/proto>
     )

--- a/packages/streamr-proto-rpc/StreamrModules.cmake
+++ b/packages/streamr-proto-rpc/StreamrModules.cmake
@@ -78,6 +78,26 @@ function(streamr_add_module_library TARGET)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
+# streamr_target_module_sources(<target> FILES <unit.cppm>...)
+#
+# Adds C++ module interface units to an EXISTING library target (used by
+# packages that already compile ordinary sources, e.g. generated protobuf
+# .cc files). Same effect as streamr_add_module_library() minus the
+# add_library().
+function(streamr_target_module_sources TARGET)
+    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    if(NOT ARG_FILES)
+        message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    target_sources(${TARGET}
+        PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        FILES ${ARG_FILES})
+    set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
+endfunction()
+
 # streamr_enable_imports(<target>)
 #
 # Enables module scanning on an existing target whose ordinary .cpp sources

--- a/packages/streamr-proto-rpc/examples/hello/hello.cpp
+++ b/packages/streamr-proto-rpc/examples/hello/hello.cpp
@@ -4,8 +4,8 @@
 #include "HelloRpc.client.pb.h"
 #include "HelloRpc.pb.h"
 #include "HelloRpc.server.pb.h"
-#include "streamr-proto-rpc/ProtoCallContext.hpp"
-#include "streamr-proto-rpc/RpcCommunicator.hpp"
+
+import streamr.protorpc;
 
 using streamr::protorpc::HelloRpcService;
 using streamr::protorpc::HelloRpcServiceClient;

--- a/packages/streamr-proto-rpc/examples/routed-hello/routedhello.cpp
+++ b/packages/streamr-proto-rpc/examples/routed-hello/routedhello.cpp
@@ -5,8 +5,8 @@
 #include "RoutedHelloRpc.client.pb.h"
 #include "RoutedHelloRpc.pb.h"
 #include "RoutedHelloRpc.server.pb.h"
-#include "streamr-proto-rpc/ProtoCallContext.hpp"
-#include "streamr-proto-rpc/RpcCommunicator.hpp"
+
+import streamr.protorpc;
 
 using ::RoutedHelloResponse;
 using streamr::protorpc::ProtoCallContext;

--- a/packages/streamr-proto-rpc/include/streamr-proto-rpc/RpcCommunicator.hpp
+++ b/packages/streamr-proto-rpc/include/streamr-proto-rpc/RpcCommunicator.hpp
@@ -28,7 +28,7 @@ using RpcMessage = ::protorpc::RpcMessage;
 using RpcErrorType = ::protorpc::RpcErrorType;
 using folly::coro::Task;
 
-constexpr std::chrono::milliseconds defaultRpcRequestTimeout = 5000ms;
+inline constexpr std::chrono::milliseconds defaultRpcRequestTimeout = 5000ms;
 
 // NOLINTBEGIN
 enum class StatusCode { OK, STOPPED, DEADLINE_EXCEEDED, SERVER_ERROR };

--- a/packages/streamr-proto-rpc/include/streamr-proto-rpc/RpcCommunicatorClientApi.hpp
+++ b/packages/streamr-proto-rpc/include/streamr-proto-rpc/RpcCommunicatorClientApi.hpp
@@ -23,7 +23,7 @@ using folly::coro::Task;
 using streamr::utils::Branded;
 using streamr::utils::Uuid;
 
-constexpr size_t threadPoolSize = 20;
+inline constexpr size_t threadPoolSize = 20;
 
 template <typename CallContextType, typename OutgoingMessageCallbackType>
 class RpcCommunicatorClientApi {

--- a/packages/streamr-proto-rpc/lint.sh
+++ b/packages/streamr-proto-rpc/lint.sh
@@ -9,3 +9,12 @@ clangd-tidy -p ./build $FILES
 
 echo "Running clang-format --dry-run on $FILES"
 ../../run-clang-format.py $FILES
+
+# Module interface units: format check only. clangd-tidy is not run on
+# .cppm files (headers remain the fully linted source of truth during the
+# façade migration; clangd modules support is still experimental).
+MODULE_FILES=$(find ./modules -type f -name "*.cppm" 2>/dev/null | xargs echo)
+if [ -n "$MODULE_FILES" ]; then
+    echo "Running clang-format --dry-run on $MODULE_FILES"
+    ../../run-clang-format.py $MODULE_FILES
+fi

--- a/packages/streamr-proto-rpc/modules/streamr.protorpc-Errors.cppm
+++ b/packages/streamr-proto-rpc/modules/streamr.protorpc-Errors.cppm
@@ -1,0 +1,22 @@
+// Façade partition over streamr-proto-rpc/Errors.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-proto-rpc/Errors.hpp"
+
+export module streamr.protorpc:Errors;
+
+export namespace streamr::protorpc {
+
+using streamr::protorpc::Err;
+using streamr::protorpc::ErrorCode;
+using streamr::protorpc::FailedToParse;
+using streamr::protorpc::FailedToSerialize;
+using streamr::protorpc::RpcClientError;
+using streamr::protorpc::RpcException;
+using streamr::protorpc::RpcRequestError;
+using streamr::protorpc::RpcServerError;
+using streamr::protorpc::RpcTimeout;
+using streamr::protorpc::UnknownRpcMethod;
+
+} // namespace streamr::protorpc

--- a/packages/streamr-proto-rpc/modules/streamr.protorpc-ProtoCallContext.cppm
+++ b/packages/streamr-proto-rpc/modules/streamr.protorpc-ProtoCallContext.cppm
@@ -1,0 +1,13 @@
+// Façade partition over streamr-proto-rpc/ProtoCallContext.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-proto-rpc/ProtoCallContext.hpp"
+
+export module streamr.protorpc:ProtoCallContext;
+
+export namespace streamr::protorpc {
+
+using streamr::protorpc::ProtoCallContext;
+
+} // namespace streamr::protorpc

--- a/packages/streamr-proto-rpc/modules/streamr.protorpc-RpcCommunicator.cppm
+++ b/packages/streamr-proto-rpc/modules/streamr.protorpc-RpcCommunicator.cppm
@@ -1,0 +1,18 @@
+// Façade partition over streamr-proto-rpc/RpcCommunicator.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-proto-rpc/RpcCommunicator.hpp"
+
+export module streamr.protorpc:RpcCommunicator;
+
+export namespace streamr::protorpc {
+
+using streamr::protorpc::defaultRpcRequestTimeout;
+using streamr::protorpc::RpcCommunicator;
+using streamr::protorpc::RpcCommunicatorOptions;
+using streamr::protorpc::RpcErrorType;
+using streamr::protorpc::RpcMessage;
+using streamr::protorpc::StatusCode;
+
+} // namespace streamr::protorpc

--- a/packages/streamr-proto-rpc/modules/streamr.protorpc-RpcCommunicatorClientApi.cppm
+++ b/packages/streamr-proto-rpc/modules/streamr.protorpc-RpcCommunicatorClientApi.cppm
@@ -1,0 +1,14 @@
+// Façade partition over streamr-proto-rpc/RpcCommunicatorClientApi.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-proto-rpc/RpcCommunicatorClientApi.hpp"
+
+export module streamr.protorpc:RpcCommunicatorClientApi;
+
+export namespace streamr::protorpc {
+
+using streamr::protorpc::RpcCommunicatorClientApi;
+using streamr::protorpc::threadPoolSize;
+
+} // namespace streamr::protorpc

--- a/packages/streamr-proto-rpc/modules/streamr.protorpc-RpcCommunicatorServerApi.cppm
+++ b/packages/streamr-proto-rpc/modules/streamr.protorpc-RpcCommunicatorServerApi.cppm
@@ -1,0 +1,13 @@
+// Façade partition over streamr-proto-rpc/RpcCommunicatorServerApi.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-proto-rpc/RpcCommunicatorServerApi.hpp"
+
+export module streamr.protorpc:RpcCommunicatorServerApi;
+
+export namespace streamr::protorpc {
+
+using streamr::protorpc::RpcCommunicatorServerApi;
+
+} // namespace streamr::protorpc

--- a/packages/streamr-proto-rpc/modules/streamr.protorpc-ServerRegistry.cppm
+++ b/packages/streamr-proto-rpc/modules/streamr.protorpc-ServerRegistry.cppm
@@ -1,0 +1,16 @@
+// Façade partition over streamr-proto-rpc/ServerRegistry.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-proto-rpc/ServerRegistry.hpp"
+
+export module streamr.protorpc:ServerRegistry;
+
+export namespace streamr::protorpc {
+
+using streamr::protorpc::Any;
+using streamr::protorpc::Empty;
+using streamr::protorpc::MethodOptions;
+using streamr::protorpc::ServerRegistry;
+
+} // namespace streamr::protorpc

--- a/packages/streamr-proto-rpc/modules/streamr.protorpc-StreamPrinter.cppm
+++ b/packages/streamr-proto-rpc/modules/streamr.protorpc-StreamPrinter.cppm
@@ -1,0 +1,13 @@
+// Façade partition over streamr-proto-rpc/StreamPrinter.hpp (see the
+// streamr.eventemitter partitions for the pattern rationale).
+module;
+
+#include "streamr-proto-rpc/StreamPrinter.hpp"
+
+export module streamr.protorpc:StreamPrinter;
+
+export namespace streamr::protorpc {
+
+using streamr::protorpc::StreamPrinter;
+
+} // namespace streamr::protorpc

--- a/packages/streamr-proto-rpc/modules/streamr.protorpc-protos.cppm
+++ b/packages/streamr-proto-rpc/modules/streamr.protorpc-protos.cppm
@@ -1,0 +1,18 @@
+// :protos partition — wraps the GENERATED protobuf header in the global
+// module fragment and re-exports the message/enum types that appear in
+// this package's public APIs. Generated protobuf code stays #include-based
+// permanently (protoc emits headers); this partition is how importers see
+// the types without re-parsing the .pb.h.
+module;
+
+#include "packages/proto-rpc/protos/ProtoRpc.pb.h"
+
+export module streamr.protorpc:protos;
+
+export namespace protorpc {
+
+using ::protorpc::RpcErrorType;
+using ::protorpc::RpcMessage;
+using enum ::protorpc::RpcErrorType;
+
+} // namespace protorpc

--- a/packages/streamr-proto-rpc/modules/streamr.protorpc.cppm
+++ b/packages/streamr-proto-rpc/modules/streamr.protorpc.cppm
@@ -1,0 +1,12 @@
+// Primary module interface unit of streamr.protorpc. Consumers write
+// `import streamr.protorpc;` and get every partition re-exported.
+export module streamr.protorpc;
+
+export import :protos;
+export import :Errors;
+export import :ProtoCallContext;
+export import :RpcCommunicator;
+export import :RpcCommunicatorClientApi;
+export import :RpcCommunicatorServerApi;
+export import :ServerRegistry;
+export import :StreamPrinter;

--- a/packages/streamr-proto-rpc/test/integration/ProtoRpcTest.cpp
+++ b/packages/streamr-proto-rpc/test/integration/ProtoRpcTest.cpp
@@ -1,27 +1,19 @@
+#include <future>
+#include <string>
 #include <gtest/gtest.h>
-#include <streamr-proto-rpc/RpcCommunicator.hpp>
-// #include <folly/Portability.h>
-// #include <folly/executors/CPUThreadPoolExecutor.h>
-// #include <folly/executors/ManualExecutor.h>
-// #include <folly/coro/Baton.h>
 #include <folly/experimental/coro/BlockingWait.h>
-// #include <folly/coro/Collect.h>
-// #include <folly/coro/CurrentExecutor.h>
-// #include <folly/coro/Generator.h>
-// #include <folly/coro/GtestHelpers.h>
-// #include <folly/coro/Mutex.h>
-// #include <folly/coro/Sleep.h>
-// #include <folly/coro/Task.h>
-// #include <folly/io/async/Request.h>
 #include "HelloRpc.client.pb.h"
 #include "TestProtos.client.pb.h"
 #include "WakeUpRpc.client.pb.h"
 #include "WakeUpRpc.server.pb.h"
-#include "streamr-eventemitter/EventEmitter.hpp"
-#include "streamr-proto-rpc/ProtoCallContext.hpp"
+
+import streamr.protorpc;
+import streamr.logger;
+import streamr.eventemitter;
 
 namespace streamr::protorpc {
 
+using streamr::logger::SLogger;
 using RpcCommunicatorType = RpcCommunicator<ProtoCallContext>;
 
 template <typename T>

--- a/packages/streamr-proto-rpc/test/unit/RpcCommunicatorTest.cpp
+++ b/packages/streamr-proto-rpc/test/unit/RpcCommunicatorTest.cpp
@@ -2,37 +2,32 @@
 #include <exception>
 #include <thread>
 #include <gtest/gtest.h>
-#include <streamr-proto-rpc/RpcCommunicator.hpp>
 // #include <folly/Portability.h>
 // #include <folly/executors/CPUThreadPoolExecutor.h>
 // #include <folly/executors/ManualExecutor.h>
 // #include <folly/coro/Baton.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/experimental/coro/BlockingWait.h>
-// #include <folly/coro/Collect.h>
-// #include <folly/coro/CurrentExecutor.h>
-// #include <folly/coro/Generator.h>
-// #include <folly/coro/GtestHelpers.h>
-// #include <folly/coro/Mutex.h>
-// #include <folly/coro/Sleep.h>
-// #include <folly/coro/Task.h>
-// #include <folly/io/async/Request.h>
 #include "HelloRpc.pb.h"
-#include "streamr-proto-rpc/Errors.hpp"
-#include "streamr-proto-rpc/ProtoCallContext.hpp"
-#include "streamr-proto-rpc/ServerRegistry.hpp"
+
+import streamr.protorpc;
+import streamr.logger;
 
 namespace streamr::protorpc {
 
 using namespace std::chrono_literals;
+using streamr::logger::SLogger;
 using RpcCommunicatorType = RpcCommunicator<ProtoCallContext>;
 class RpcCommunicatorTest : public ::testing::Test {
 public:
     RpcCommunicatorTest()
         : executor(folly::CPUThreadPoolExecutor(threadPoolSize)) {} // NOLINT
 
-    ~RpcCommunicatorTest() override {
+    ~RpcCommunicatorTest() override try {
         SLogger::warn("Deleting executor of RpcCommunicatorTest");
         SLogger::warn("RpcCommunicatorTypeTest executor deleted");
+    } catch (...) { // NOLINT(bugprone-empty-catch) dtor must not throw;
+                    // body is logging only
     }
 
 protected:
@@ -386,10 +381,19 @@ TEST_F(RpcCommunicatorTest, TestRpcTimeoutOnServerSide) {
             const RpcMessage& message,
             const std::string& /* requestId */,
             const ProtoCallContext& context) -> void {
+            // The lambda body is fully wrapped in try/catch; the residual
+            // exception-escape finding is a clangd-modules analysis
+            // artifact.
             thread = std::make_shared<std::thread>(
+                // NOLINTNEXTLINE(bugprone-exception-escape)
                 [&communicator1, message, context]() {
-                    SLogger::info("Starting thread for server");
-                    communicator1.handleIncomingMessage(message, context);
+                    try {
+                        SLogger::info("Starting thread for server");
+                        communicator1.handleIncomingMessage(message, context);
+                    } catch (...) { // NOLINT(bugprone-empty-catch) an
+                                    // exception escaping a thread body
+                                    // would std::terminate
+                    }
                 });
         });
     communicator1.setOutgoingMessageCallback(

--- a/packages/streamr-proto-rpc/test/unit/ServerRegistryTest.cpp
+++ b/packages/streamr-proto-rpc/test/unit/ServerRegistryTest.cpp
@@ -2,8 +2,8 @@
 
 #include <google/protobuf/any.pb.h>
 #include "HelloRpc.pb.h"
-#include "streamr-proto-rpc/ProtoCallContext.hpp"
-#include "streamr-proto-rpc/ServerRegistry.hpp"
+
+import streamr.protorpc;
 
 // BEGINNOLINT
 

--- a/packages/streamr-trackerless-network/StreamrModules.cmake
+++ b/packages/streamr-trackerless-network/StreamrModules.cmake
@@ -78,6 +78,26 @@ function(streamr_add_module_library TARGET)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
+# streamr_target_module_sources(<target> FILES <unit.cppm>...)
+#
+# Adds C++ module interface units to an EXISTING library target (used by
+# packages that already compile ordinary sources, e.g. generated protobuf
+# .cc files). Same effect as streamr_add_module_library() minus the
+# add_library().
+function(streamr_target_module_sources TARGET)
+    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    if(NOT ARG_FILES)
+        message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    target_sources(${TARGET}
+        PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        FILES ${ARG_FILES})
+    set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
+endfunction()
+
 # streamr_enable_imports(<target>)
 #
 # Enables module scanning on an existing target whose ordinary .cpp sources

--- a/packages/streamr-utils/StreamrModules.cmake
+++ b/packages/streamr-utils/StreamrModules.cmake
@@ -78,6 +78,26 @@ function(streamr_add_module_library TARGET)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
 endfunction()
 
+# streamr_target_module_sources(<target> FILES <unit.cppm>...)
+#
+# Adds C++ module interface units to an EXISTING library target (used by
+# packages that already compile ordinary sources, e.g. generated protobuf
+# .cc files). Same effect as streamr_add_module_library() minus the
+# add_library().
+function(streamr_target_module_sources TARGET)
+    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    if(NOT ARG_FILES)
+        message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    target_sources(${TARGET}
+        PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        FILES ${ARG_FILES})
+    set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    target_compile_features(${TARGET} PUBLIC cxx_std_26)
+endfunction()
+
 # streamr_enable_imports(<target>)
 #
 # Enables module scanning on an existing target whose ordinary .cpp sources


### PR DESCRIPTION
The first **`:protos` partition** — the pattern that carries the whole compile-time bet, rehearsed here on `ProtoRpc.pb.h` before Phase 2.4 applies it to dht's 12,000-line `DhtRpc.pb.h`.

## What's migrated

- **9 module units**: primary + `:protos` (wraps the generated `ProtoRpc.pb.h` in its GMF and exports `::protorpc::RpcMessage`/`RpcErrorType` + enumerators) + 7 partitions mirroring the public headers (Errors, ProtoCallContext, the RpcCommunicator stack, ServerRegistry, StreamPrinter). The module surface is added to the **existing** static library (which also compiles the generated `.pb.cc`) via the new `streamr_target_module_sources()` helper. The protoc codegen plugin stays include-based (build-time tool).
- Tests + both examples flipped to `import streamr.protorpc;` — **26/26 green**, including the generated client/server pb stubs interoperating with imported RpcCommunicator templates.

## The big find: protobuf is not GMF-clean (overlay patch)

Any protobuf header in a global module fragment fails on **every arm64 target** under Clang 22: `no matching function for call to 'VarintParseSlowArm'`. Mechanism: those helper overloads are `static` (TU-local), and implicit template instantiation in module units happens in *purview* context, where TU-local GMF entities are unusable. Verified with a 3-line repro; fixed with a **one-word overlay patch** (`static` → `inline`, ODR-safe, no behavior change) — `overlayports/protobuf/` with the usual JUSTIFICATION.md. First overlay since the 1.3 cleanup (now 4). Catching this here, at the cheapest phase, is exactly why proto-rpc precedes dht in the migration order. Note: the overlay changes `overlayports/**`, so CI vcpkg caches rebuild once on this PR (slower CI run, one-time).

## Other mechanisms established

- **Imported-target modules are usable only by direct consumers** — a target whose sources `import streamr.logger;` must link `streamr::streamr-logger` itself; BMI usability doesn't ride transitive linkage. (Direct import ⇒ direct dependency — good hygiene anyway.)
- **Export-alias rule**: partitions re-export aliases the package declares for types in its API signatures (`RpcMessage`, `RpcErrorType`, `Any`, `Empty`); incidental convenience aliases (`SLogger`) are not exported — importing TUs import the owning module instead.
- Library deps flipped INTERFACE/PRIVATE → PUBLIC: consumer build trees recompile the module units from the export, so the headers' full reach (protobuf, magic_enum included) must be usage requirements.
- The plan's "`extern "C"` test export" gate turned out stale — no `extern "C"` exists in this package (verified by grep).

## Verification

| Gate | Result |
|---|---|
| Package build (9 BMIs incl. `:protos` over generated code) | ✅ |
| Package tests via `import` | ✅ 26/26 |
| Downstream standalone builds (dht, trackerless-network) | ✅ unchanged |
| Root tree | ✅ 307/307 (one known-flaky socket test timed out under build load, passes idle — the documented pre-existing workstream) |
| Full lint | ✅ |
| iOS cross-build (incl. patched protobuf for arm64-ios) | this PR (`[iosbuild]`) |

## Next
Phase 2.4: **streamr-dht** — the major bench checkpoint. 45 partitions + `:protos` over the DhtRpc trio, 41 test TUs flip, and the baseline's #1 expensive header (`DhtRpc.pb.h`, 96 s cumulative) finally stops being re-parsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)