### PR TITLE
Modernization Phase 2.6: Part 2 closeout — consolidation memo, NDK r29 modules experiment [androidbuild]

### DIFF
--- a/.github/workflows/validateandroid.yml
+++ b/.github/workflows/validateandroid.yml
@@ -24,10 +24,11 @@ jobs:
           fetch-depth: 0
           submodules: true
           token: ${{ secrets.GITHUB_TOKEN }}
-      # The runner's default ANDROID_NDK is an older LTS (r27 = clang 18,
-      # whose C++ modules support is too immature). Use the latest stable
-      # NDK preinstalled on the image (r29 = clang 21) — StreamrModules.cmake
-      # enables the modules on Android when the NDK clang is >= 21.
+      # The runner's default ANDROID_NDK is an older LTS (r27). Use the
+      # latest stable NDK preinstalled on the image (r29 = clang 21).
+      # Modules build on r27+ too (StreamrModules.cmake floors at NDK
+      # clang 18) — building with the latest stable is hygiene, not a
+      # modules requirement.
       - name: use latest stable NDK
         run: |
           echo "ANDROID_NDK=$ANDROID_NDK_LATEST_HOME" >> "$GITHUB_ENV"

--- a/.github/workflows/validateandroid.yml
+++ b/.github/workflows/validateandroid.yml
@@ -24,6 +24,17 @@ jobs:
           fetch-depth: 0
           submodules: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      # The runner's default ANDROID_NDK is an older LTS (r27 = clang 18,
+      # whose C++ modules support is too immature). Use the latest stable
+      # NDK preinstalled on the image (r29 = clang 21) — StreamrModules.cmake
+      # enables the modules on Android when the NDK clang is >= 21.
+      - name: use latest stable NDK
+        run: |
+          echo "ANDROID_NDK=$ANDROID_NDK_LATEST_HOME" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> "$GITHUB_ENV"
+          "$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/darwin-arm64/bin/clang" --version | head -1
+        shell: bash
       - name: install
         uses: ./.github/workflows/reusable/cached-install
       # No lint step: linting is host-independent and runs on the

--- a/.github/workflows/validateandroid.yml
+++ b/.github/workflows/validateandroid.yml
@@ -33,7 +33,9 @@ jobs:
           echo "ANDROID_NDK=$ANDROID_NDK_LATEST_HOME" >> "$GITHUB_ENV"
           echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> "$GITHUB_ENV"
           echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> "$GITHUB_ENV"
-          "$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/darwin-arm64/bin/clang" --version | head -1
+          # NB: the prebuilt dir is named darwin-x86_64 even on ARM Macs
+          # (universal binaries under the legacy name).
+          "$ANDROID_NDK_LATEST_HOME"/toolchains/llvm/prebuilt/darwin-*/bin/clang --version | head -1
         shell: bash
       - name: install
         uses: ./.github/workflows/reusable/cached-install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,9 @@ set(VCPKG_INSTALLED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/build/vcpkg_installed)
 set (VCPKG_OVERLAY_TRIPLETS ENV{VCPKG_OVERLAY_TRIPLETS})
 set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# No C++ modules in the codebase yet: CMake >= 3.28 (CMP0155) would otherwise
-# scan all C++20+ sources for module imports, injecting GCC scanning flags
-# (-fmodules-ts, -fmodule-mapper, -fdeps-format) into compile_commands.json,
-# which clangd rejects. The modules migration will turn scanning back on.
+# Module scanning stays OFF globally so that non-module TUs keep clean
+# compile commands for clangd; targets with module units or import-using
+# sources opt back in via the StreamrModules.cmake helpers.
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 include(cmake/homebrewClang.cmake)
 

--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -632,7 +632,7 @@ before any consolidation gains.
   trackerless-network + proxyclient downstream builds unchanged; root
   tree 307/307; full lint green.
 
-## Phase 2.5 — trackerless-network + proxyclient, FINAL METRICS (PR pending)
+## Phase 2.5 — trackerless-network + proxyclient, FINAL METRICS ✅ (PR #33, merged)
 The migration surface is complete: every C++ package that exports an API
 now ships a module.
 - **streamr-trackerless-network**: `:protos` over the NetworkRpc trio
@@ -651,6 +651,26 @@ now ships a module.
 - New standing gate applied (2.4 lesson): a LOCAL RELEASE build+test of
   the migrated package (caught nothing this time — the folly/protobuf
   overlay patches hold).
+- **The Android smoke gate (first Android build since the 1.3 dependency
+  wave) earned its keep twice**:
+  1. Upstream's 2026 folly port silently dropped Android from its
+     `supports` expression → `./install.sh --android` failed outright at
+     dependency install. The folly overlay re-allows Android
+     (JUSTIFICATION.md updated); **folly 2026 builds fine on the NDK**.
+  2. **The NDK's clang (18/19) cannot build our modules** — observed:
+     `import streamr.json` fails to provide the `toJson` overload set
+     (known pre-clang-19/20 `export using` overload bugs). Resolution:
+     `STREAMR_MODULES_SUPPORTED=OFF` on Android in StreamrModules.cmake —
+     Android builds libraries textually from headers (the façade keeps
+     them as source of truth), module units are skipped
+     (`streamr_add_module_library` falls back to STATIC + stub source so
+     PUBLIC usage requirements stay identical), and test/example targets
+     (which import, and are never executed on Android) are not built.
+     The Android workflow also stops running lint (host-independent;
+     covered by validate.yml; import-using test files have no compile
+     commands on an Android tree).
+  **⇒ Android now has a hard dependency on headers — see the Phase 2.6
+  decision memo below.**
 
 ### FINAL FAÇADE-STAGE METRICS (vs Phase 2.0 baselines, macOS, idle)
 | Metric | Baseline | Final (7 packages migrated) | Target | Verdict |
@@ -658,6 +678,8 @@ now ships a module.
 | Clean root build | 102 s | **78 s (−24%)** | −25% | ✅ effectively met (78–88 s across repeats) |
 | `SLogger.hpp` touch | 62–70 s | 58 s (−6…−12%) | −40% | ❌ not yet — consolidation work |
 | `StreamID.hpp` touch | 19 s | 32 s (+68%) | −40% | ❌ regression — BMI-chain latency |
+| Expensive headers (ClangBuildAnalyzer) | `DhtRpc.pb.h` #1 (96 s, 33×); SLogger/Logger top-4 | `DhtRpc.pb.h` #9 (15.7 s, 6×); SLogger/Logger GONE from list; #1 = `gtest.h` (stays `#include` by design) | pb.h/folly leave the top | ✅ met |
+| Total frontend parse CPU | 859 s | 723 s (−16%, incl. the module units) | — | ✅ |
 
 **Honest reading**: the clean-build target is effectively met already at
 the façade stage (test TUs load BMIs instead of re-parsing header
@@ -676,6 +698,49 @@ sequencing; the numbers now quantify exactly why consolidation matters.
   clangd's `--experimental-modules-support` — canary in 2.1; fallback:
   exclude import-using files from clangd-tidy until clangd modules support
   stabilizes.
+
+## Phase 2.6 — Consolidation: DECISION MEMO (owner decision required)
+The planned end state (user-confirmed 2026-07): NO internal headers —
+all code in `.cppm` module units, `#include` only for third-party,
+generated proto, and the C API header. Consolidation is what delivers the
+so-far-unmet incremental-rebuild targets (a partition edit stops
+invalidating whole-package BMIs).
+
+**Consolidation is currently BLOCKED by a platform constraint discovered
+at the 2.5 Android gate**: the NDK's clang cannot build the modules, so
+Android compiles the libraries textually FROM THE HEADERS that
+consolidation would delete. Deleting internal headers breaks the Android
+build outright — including the shipping artifact (proxyclient `.so` /
+Kotlin wrapper).
+
+### Preconditions for starting consolidation
+1. **NDK ships a modules-capable clang** (>= 22, matching the rest of the
+   toolchain), or Android support is explicitly parked/dropped.
+2. clangd modules support matures enough to lint purview code (today it
+   mis-unifies preamble/BMI types; with code in partitions there is no
+   header fallback for the linter — coverage would regress from "full"
+   to "none" for consolidated code).
+3. The dht intra-package include cycles (connection/endpoint cluster)
+   must become a partition DAG — untangle or use coarse per-cluster
+   partitions (deferred from 2.4 by design).
+
+### What consolidation buys (quantified at the 2.4/2.5 checkpoints)
+- The −40% incremental-rebuild targets (currently: SLogger touch −6…−12%,
+  StreamID touch REGRESSED +68% from BMI-chain invalidation).
+- The final IWYU/ODR hygiene of the no-headers end state.
+
+### Recommended path (when unblocked)
+Leaf-first and interleaved as originally planned — eventemitter as the
+consolidation canary, one package per PR, `bench.sh` measured at every
+step (the 2.4 lesson: measure before generalizing), headers deleted
+per-package with a grep-enforced "nothing includes them" gate.
+
+### Interim posture (adopted now)
+The façade stage is COMPLETE and delivers: uniform `import streamr.<pkg>`
+consumption, −24% clean builds, 250+ tests through import, and module
+infrastructure exercised on macOS/Linux/iOS. Headers remain the linted
+source of truth; Android remains textual. This is a stable resting point
+— nothing rots by waiting for the NDK.
 
 ## Success metrics (measured macOS + Linux, end of Phase 2.5)
 - ≥25% clean-build wall-clock reduction (dev build with tests).

--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -669,8 +669,9 @@ now ships a module.
      The Android workflow also stops running lint (host-independent;
      covered by validate.yml; import-using test files have no compile
      commands on an Android tree).
-  **⇒ Android now has a hard dependency on headers — see the Phase 2.6
-  decision memo below.**
+     UPDATE (2.6): the failing NDK was the CI runner's default r27
+     (clang 18.0.2); the gate is now version-based and Android CI uses
+     NDK r29 (clang 21) — see the 2.6 memo.
 
 ### FINAL FAÇADE-STAGE METRICS (vs Phase 2.0 baselines, macOS, idle)
 | Metric | Baseline | Final (7 packages migrated) | Target | Verdict |
@@ -714,8 +715,12 @@ build outright — including the shipping artifact (proxyclient `.so` /
 Kotlin wrapper).
 
 ### Preconditions for starting consolidation
-1. **NDK ships a modules-capable clang** (>= 22, matching the rest of the
-   toolchain), or Android support is explicitly parked/dropped.
+1. **A modules-capable NDK clang on Android.** The 2.5 failure was on the
+   CI runner's default NDK r27 (clang 18.0.2). NDK r29 (latest stable,
+   Oct 2025) ships clang 21 — the Android CI now uses r29 and
+   StreamrModules.cmake gates Android modules on NDK clang >= 21
+   (validated on the Phase 2.6 PR's androidbuild leg). Older NDKs fall
+   back to the textual build automatically.
 2. clangd modules support matures enough to lint purview code (today it
    mis-unifies preamble/BMI types; with code in partitions there is no
    header fallback for the linter — coverage would regress from "full"

--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -657,21 +657,20 @@ now ships a module.
      `supports` expression → `./install.sh --android` failed outright at
      dependency install. The folly overlay re-allows Android
      (JUSTIFICATION.md updated); **folly 2026 builds fine on the NDK**.
-  2. **The NDK's clang (18/19) cannot build our modules** — observed:
-     `import streamr.json` fails to provide the `toJson` overload set
-     (known pre-clang-19/20 `export using` overload bugs). Resolution:
-     `STREAMR_MODULES_SUPPORTED=OFF` on Android in StreamrModules.cmake —
-     Android builds libraries textually from headers (the façade keeps
-     them as source of truth), module units are skipped
-     (`streamr_add_module_library` falls back to STATIC + stub source so
-     PUBLIC usage requirements stay identical), and test/example targets
-     (which import, and are never executed on Android) are not built.
-     The Android workflow also stops running lint (host-independent;
-     covered by validate.yml; import-using test files have no compile
-     commands on an Android tree).
-     UPDATE (2.6): the failing NDK was the CI runner's default r27
-     (clang 18.0.2); the gate is now version-based and Android CI uses
-     NDK r29 (clang 21) — see the 2.6 memo.
+  2. **`import streamr.json` failed on Android** — every imported name
+     reported as undeclared (the `toJson` overload set etc.). Diagnosed
+     AT THE TIME as NDK-clang `export using` overload bugs; resolved by
+     forcing `STREAMR_MODULES_SUPPORTED=OFF` on Android (libraries built
+     textually from headers, module units skipped via the STATIC +
+     stub-source fallback so PUBLIC usage requirements stay identical,
+     import-using test/example targets not built). The Android workflow
+     also stopped running lint (host-independent; covered by
+     validate.yml; import-using test files have no compile commands on
+     an Android tree).
+     CORRECTED in 2.6: the compiler was never the problem — the real
+     cause was a `-pthread` BMI configuration mismatch (see the 2.6
+     memo). Android now builds the modules on NDK r27+ (clang >= 18);
+     the textual fallback remains only for older NDKs.
 
 ### FINAL FAÇADE-STAGE METRICS (vs Phase 2.0 baselines, macOS, idle)
 | Metric | Baseline | Final (7 packages migrated) | Target | Verdict |
@@ -707,20 +706,30 @@ generated proto, and the C API header. Consolidation is what delivers the
 so-far-unmet incremental-rebuild targets (a partition edit stops
 invalidating whole-package BMIs).
 
-**Consolidation is currently BLOCKED by a platform constraint discovered
-at the 2.5 Android gate**: the NDK's clang cannot build the modules, so
-Android compiles the libraries textually FROM THE HEADERS that
-consolidation would delete. Deleting internal headers breaks the Android
-build outright — including the shipping artifact (proxyclient `.so` /
-Kotlin wrapper).
+**The 2.5 Android blocker is RESOLVED (2.6).** The Phase 2.5 failure
+(`import streamr.json` → every imported name "undeclared") was NOT an
+NDK-clang capability gap. Root cause, found by reproducing the CI
+failure locally and bisecting against NDK r27/r28/r29: the import-using
+test TUs compile with `-pthread` (inherited from GTest's
+`Threads::Threads`) while the module libraries' BMIs were compiled
+without it; on Android `-pthread` toggles a language option that clang
+validates when loading a module file
+(`-Wmodule-file-config-mismatch` — the FIRST error in the log; the
+"undeclared identifier" flood is its cascade), so the BMI silently
+fails to load. The raw NDK compilers (clang 18, 19 and 21) all compile
+and import the façade modules correctly when invoked by hand. Fix: the
+module-library helpers in StreamrModules.cmake make `-pthread` a PUBLIC
+compile option on Android, so the BMI and every importer always agree.
+Android CI keeps using the runner's latest stable NDK (r29, clang 21);
+`STREAMR_MODULES_SUPPORTED` keeps a version floor at the oldest
+verified NDK clang (18 = r27), with the textual fallback below it.
 
 ### Preconditions for starting consolidation
-1. **A modules-capable NDK clang on Android.** The 2.5 failure was on the
-   CI runner's default NDK r27 (clang 18.0.2). NDK r29 (latest stable,
-   Oct 2025) ships clang 21 — the Android CI now uses r29 and
-   StreamrModules.cmake gates Android modules on NDK clang >= 21
-   (validated on the Phase 2.6 PR's androidbuild leg). Older NDKs fall
-   back to the textual build automatically.
+1. ~~A modules-capable NDK on Android~~ **RESOLVED (2.6)** — the 2.5
+   failure was the `-pthread` BMI mismatch above, not the compiler.
+   Android builds the façade modules on NDK r27+ (verified locally on
+   r27 and r29 for streamr-json + streamr-eventemitter, and on the
+   Phase 2.6 PR's androidbuild leg for the full monorepo).
 2. clangd modules support matures enough to lint purview code (today it
    mis-unifies preamble/BMI types; with code in partitions there is no
    header fallback for the linter — coverage would regress from "full"
@@ -743,9 +752,10 @@ per-package with a grep-enforced "nothing includes them" gate.
 ### Interim posture (adopted now)
 The façade stage is COMPLETE and delivers: uniform `import streamr.<pkg>`
 consumption, −24% clean builds, 250+ tests through import, and module
-infrastructure exercised on macOS/Linux/iOS. Headers remain the linted
-source of truth; Android remains textual. This is a stable resting point
-— nothing rots by waiting for the NDK.
+infrastructure exercised on macOS/Linux/iOS/Android. Headers remain the
+linted source of truth. With the Android blocker resolved, consolidation
+is gated only by preconditions 2 (clangd lint coverage of purview code)
+and 3 (dht partition DAG). This is a stable resting point.
 
 ## Success metrics (measured macOS + Linux, end of Phase 2.5)
 - ≥25% clean-build wall-clock reduction (dev build with tests).

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Rules of thumb when writing import-using code:
 * A target whose sources `import` a module must link that module's target
   directly (`streamr::streamr-<pkg>`) and call
   `streamr_enable_imports(<target>)` — see `cmake/StreamrModules.cmake`.
-* **Android builds do not use modules** (the NDK's clang is too old):
-  libraries build textually from the headers and test targets are
-  skipped there. Handled automatically by `STREAMR_MODULES_SUPPORTED`
+* **Android needs NDK r29+** (clang 21) for the modules. With an older
+  NDK the libraries build textually from the headers and test targets
+  are skipped — handled automatically by `STREAMR_MODULES_SUPPORTED`
   in `StreamrModules.cmake`.
 
 The plan for consolidating code out of headers into the module units

--- a/README.md
+++ b/README.md
@@ -88,10 +88,14 @@ Rules of thumb when writing import-using code:
 * A target whose sources `import` a module must link that module's target
   directly (`streamr::streamr-<pkg>`) and call
   `streamr_enable_imports(<target>)` — see `cmake/StreamrModules.cmake`.
-* **Android needs NDK r29+** (clang 21) for the modules. With an older
-  NDK the libraries build textually from the headers and test targets
-  are skipped — handled automatically by `STREAMR_MODULES_SUPPORTED`
-  in `StreamrModules.cmake`.
+* **Android builds the modules with NDK r27+** (clang 18; the CI uses
+  the latest stable NDK, currently r29). With an older NDK the
+  libraries build textually from the headers and test targets are
+  skipped — handled automatically by `STREAMR_MODULES_SUPPORTED` in
+  `StreamrModules.cmake`. Note for module authors: the module-library
+  helpers make `-pthread` part of the PUBLIC interface on Android —
+  clang refuses to load a BMI whose POSIX-thread setting differs from
+  the importing TU's.
 
 The plan for consolidating code out of headers into the module units
 (and the platform preconditions for it) is in

--- a/README.md
+++ b/README.md
@@ -63,6 +63,40 @@ The codebase is built as C++26 (`CMAKE_CXX_STANDARD 26`, required) everywhere, b
 
 Practical rule: header-only features (ranges, `contains`, concepts, formatting of standard types, etc.) work everywhere; features needing runtime-library symbols (e.g. new locale facets, some `std::print`/filesystem edges) are gated by the iOS deployment target — the iOS build will tell you.
 
+#### C++ named modules
+
+Every API-exporting package ships a C++ named module (`streamr.json`,
+`streamr.logger`, `streamr.eventemitter`, `streamr.utils`,
+`streamr.protorpc`, `streamr.dht`, `streamr.trackerlessnetwork`). The
+package test suites consume them with a single `import streamr.<pkg>;`.
+
+The modules are currently *façades*: each package's `modules/` directory
+holds a coarse `:all` interface unit that includes the public headers in
+its global module fragment and re-exports the public names (plus a
+`:protos` unit over generated protobuf code where applicable). The
+headers remain the source of truth — `#include` and `import` consumers
+can be mixed freely.
+
+Rules of thumb when writing import-using code:
+
+* Include what you use: `import` does not leak transitive std/third-party
+  headers the way textual inclusion did.
+* Third-party libraries (folly, boost, gtest, protobuf) stay `#include`.
+* Do **not** also textually include monorepo headers that reach the same
+  third-party stacks in an import-using file — import the sibling module
+  instead (clangd's experimental modules support mis-diagnoses the mix).
+* A target whose sources `import` a module must link that module's target
+  directly (`streamr::streamr-<pkg>`) and call
+  `streamr_enable_imports(<target>)` — see `cmake/StreamrModules.cmake`.
+* **Android builds do not use modules** (the NDK's clang is too old):
+  libraries build textually from the headers and test targets are
+  skipped there. Handled automatically by `STREAMR_MODULES_SUPPORTED`
+  in `StreamrModules.cmake`.
+
+The plan for consolidating code out of headers into the module units
+(and the platform preconditions for it) is in
+[MODERNIZATION.md](MODERNIZATION.md).
+
 ### Install all the dependencies and build the SDK for MacOS and Linux
 
 ```bash

--- a/cmake/StreamrModules.cmake
+++ b/cmake/StreamrModules.cmake
@@ -10,16 +10,24 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang (18/19), whose C++ modules support is
-# too immature for the façade modules (known `export using` overload-set
-# bugs — observed: `import streamr.json;` fails to provide the toJson
-# overloads). Android consumes the ordinary headers instead (they remain the
-# source of truth during the façade stage), the module units are skipped,
-# and packages must not build their import-using test targets
-# (STREAMR_MODULES_SUPPORTED below guards them). Revisit when the NDK ships
-# clang >= 22 — consolidation (2.6) requires it, as headers disappear then.
+# Android builds use the NDK's clang, and modules support depends on its
+# version: NDK r27 ships clang 18, whose C++ modules support is too
+# immature for the façade modules (known `export using` overload-set bugs —
+# observed: `import streamr.json;` failed to provide the toJson overloads).
+# NDK r29 ships clang 21, which is expected to handle them. Gate on the
+# compiler version: with an older NDK, Android consumes the ordinary
+# headers instead (they remain the source of truth during the façade
+# stage), the module units are skipped, and import-using test/example
+# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    set(STREAMR_MODULES_SUPPORTED OFF)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+        set(STREAMR_MODULES_SUPPORTED ON)
+    else()
+        set(STREAMR_MODULES_SUPPORTED OFF)
+        message(STATUS
+            "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
+            "< 21 (use NDK r29+ for modules on Android)")
+    endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
 endif()

--- a/cmake/StreamrModules.cmake
+++ b/cmake/StreamrModules.cmake
@@ -10,23 +10,22 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang, and modules support depends on its
-# version: NDK r27 ships clang 18, whose C++ modules support is too
-# immature for the façade modules (known `export using` overload-set bugs —
-# observed: `import streamr.json;` failed to provide the toJson overloads).
-# NDK r29 ships clang 21, which is expected to handle them. Gate on the
-# compiler version: with an older NDK, Android consumes the ordinary
-# headers instead (they remain the source of truth during the façade
-# stage), the module units are skipped, and import-using test/example
-# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
+# Android builds use the NDK's clang. The façade modules build correctly
+# with NDK r27+ (clang 18) — the failure previously attributed to compiler
+# immaturity was a -pthread BMI configuration mismatch, fixed in the
+# helpers below. Keep a version floor at the oldest verified NDK clang
+# (18 = r27): with an older NDK, Android consumes the ordinary headers
+# instead (they remain the source of truth during the façade stage), the
+# module units are skipped, and import-using test/example targets are not
+# built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
         set(STREAMR_MODULES_SUPPORTED ON)
     else()
         set(STREAMR_MODULES_SUPPORTED OFF)
         message(STATUS
             "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
-            "< 21 (use NDK r29+ for modules on Android)")
+            "< 18 (use NDK r27+ for modules on Android)")
     endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
@@ -112,6 +111,15 @@ function(streamr_add_module_library TARGET)
     # BMI-compiling target on the consumer side and requires the standard
     # level to be part of the exported usage requirements.
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # Importers must agree with the BMI on POSIX-thread support: clang
+    # validates language options when loading a module file. On Android,
+    # -pthread is not implied — test executables inherit it from GTest's
+    # Threads::Threads while library targets do not, so a BMI built
+    # without it cannot be loaded by an import-using test TU (observed:
+    # -Wmodule-file-config-mismatch, then every imported name reported as
+    # undeclared). Making the flag part of the PUBLIC interface keeps the
+    # BMI and every importer consistent. No-op on other platforms.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_target_module_sources(<target> FILES <unit.cppm>...)
@@ -135,6 +143,8 @@ function(streamr_target_module_sources TARGET)
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # See streamr_add_module_library: BMI/importer -pthread consistency.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-dht/CMakeLists.txt
+++ b/packages/streamr-dht/CMakeLists.txt
@@ -5,10 +5,9 @@ include(homebrewClang.cmake)
 
 set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# No C++ modules in the codebase yet: CMake >= 3.28 (CMP0155) would otherwise
-# scan all C++20+ sources for module imports, injecting GCC scanning flags
-# (-fmodules-ts, -fmodule-mapper, -fdeps-format) into compile_commands.json,
-# which clangd rejects. The modules migration will turn scanning back on.
+# Module scanning stays OFF globally so that non-module TUs keep clean
+# compile commands for clangd; targets with module units or import-using
+# sources opt back in via the StreamrModules.cmake helpers.
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/packages/streamr-dht/StreamrModules.cmake
+++ b/packages/streamr-dht/StreamrModules.cmake
@@ -10,16 +10,24 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang (18/19), whose C++ modules support is
-# too immature for the façade modules (known `export using` overload-set
-# bugs — observed: `import streamr.json;` fails to provide the toJson
-# overloads). Android consumes the ordinary headers instead (they remain the
-# source of truth during the façade stage), the module units are skipped,
-# and packages must not build their import-using test targets
-# (STREAMR_MODULES_SUPPORTED below guards them). Revisit when the NDK ships
-# clang >= 22 — consolidation (2.6) requires it, as headers disappear then.
+# Android builds use the NDK's clang, and modules support depends on its
+# version: NDK r27 ships clang 18, whose C++ modules support is too
+# immature for the façade modules (known `export using` overload-set bugs —
+# observed: `import streamr.json;` failed to provide the toJson overloads).
+# NDK r29 ships clang 21, which is expected to handle them. Gate on the
+# compiler version: with an older NDK, Android consumes the ordinary
+# headers instead (they remain the source of truth during the façade
+# stage), the module units are skipped, and import-using test/example
+# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    set(STREAMR_MODULES_SUPPORTED OFF)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+        set(STREAMR_MODULES_SUPPORTED ON)
+    else()
+        set(STREAMR_MODULES_SUPPORTED OFF)
+        message(STATUS
+            "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
+            "< 21 (use NDK r29+ for modules on Android)")
+    endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
 endif()

--- a/packages/streamr-dht/StreamrModules.cmake
+++ b/packages/streamr-dht/StreamrModules.cmake
@@ -10,23 +10,22 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang, and modules support depends on its
-# version: NDK r27 ships clang 18, whose C++ modules support is too
-# immature for the façade modules (known `export using` overload-set bugs —
-# observed: `import streamr.json;` failed to provide the toJson overloads).
-# NDK r29 ships clang 21, which is expected to handle them. Gate on the
-# compiler version: with an older NDK, Android consumes the ordinary
-# headers instead (they remain the source of truth during the façade
-# stage), the module units are skipped, and import-using test/example
-# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
+# Android builds use the NDK's clang. The façade modules build correctly
+# with NDK r27+ (clang 18) — the failure previously attributed to compiler
+# immaturity was a -pthread BMI configuration mismatch, fixed in the
+# helpers below. Keep a version floor at the oldest verified NDK clang
+# (18 = r27): with an older NDK, Android consumes the ordinary headers
+# instead (they remain the source of truth during the façade stage), the
+# module units are skipped, and import-using test/example targets are not
+# built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
         set(STREAMR_MODULES_SUPPORTED ON)
     else()
         set(STREAMR_MODULES_SUPPORTED OFF)
         message(STATUS
             "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
-            "< 21 (use NDK r29+ for modules on Android)")
+            "< 18 (use NDK r27+ for modules on Android)")
     endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
@@ -112,6 +111,15 @@ function(streamr_add_module_library TARGET)
     # BMI-compiling target on the consumer side and requires the standard
     # level to be part of the exported usage requirements.
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # Importers must agree with the BMI on POSIX-thread support: clang
+    # validates language options when loading a module file. On Android,
+    # -pthread is not implied — test executables inherit it from GTest's
+    # Threads::Threads while library targets do not, so a BMI built
+    # without it cannot be loaded by an import-using test TU (observed:
+    # -Wmodule-file-config-mismatch, then every imported name reported as
+    # undeclared). Making the flag part of the PUBLIC interface keeps the
+    # BMI and every importer consistent. No-op on other platforms.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_target_module_sources(<target> FILES <unit.cppm>...)
@@ -135,6 +143,8 @@ function(streamr_target_module_sources TARGET)
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # See streamr_add_module_library: BMI/importer -pthread consistency.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-eventemitter/CMakeLists.txt
+++ b/packages/streamr-eventemitter/CMakeLists.txt
@@ -3,10 +3,9 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
 set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# No C++ modules in the codebase yet: CMake >= 3.28 (CMP0155) would otherwise
-# scan all C++20+ sources for module imports, injecting GCC scanning flags
-# (-fmodules-ts, -fmodule-mapper, -fdeps-format) into compile_commands.json,
-# which clangd rejects. The modules migration will turn scanning back on.
+# Module scanning stays OFF globally so that non-module TUs keep clean
+# compile commands for clangd; targets with module units or import-using
+# sources opt back in via the StreamrModules.cmake helpers.
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 include(homebrewClang.cmake)
 

--- a/packages/streamr-eventemitter/StreamrModules.cmake
+++ b/packages/streamr-eventemitter/StreamrModules.cmake
@@ -10,16 +10,24 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang (18/19), whose C++ modules support is
-# too immature for the façade modules (known `export using` overload-set
-# bugs — observed: `import streamr.json;` fails to provide the toJson
-# overloads). Android consumes the ordinary headers instead (they remain the
-# source of truth during the façade stage), the module units are skipped,
-# and packages must not build their import-using test targets
-# (STREAMR_MODULES_SUPPORTED below guards them). Revisit when the NDK ships
-# clang >= 22 — consolidation (2.6) requires it, as headers disappear then.
+# Android builds use the NDK's clang, and modules support depends on its
+# version: NDK r27 ships clang 18, whose C++ modules support is too
+# immature for the façade modules (known `export using` overload-set bugs —
+# observed: `import streamr.json;` failed to provide the toJson overloads).
+# NDK r29 ships clang 21, which is expected to handle them. Gate on the
+# compiler version: with an older NDK, Android consumes the ordinary
+# headers instead (they remain the source of truth during the façade
+# stage), the module units are skipped, and import-using test/example
+# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    set(STREAMR_MODULES_SUPPORTED OFF)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+        set(STREAMR_MODULES_SUPPORTED ON)
+    else()
+        set(STREAMR_MODULES_SUPPORTED OFF)
+        message(STATUS
+            "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
+            "< 21 (use NDK r29+ for modules on Android)")
+    endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
 endif()

--- a/packages/streamr-eventemitter/StreamrModules.cmake
+++ b/packages/streamr-eventemitter/StreamrModules.cmake
@@ -10,23 +10,22 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang, and modules support depends on its
-# version: NDK r27 ships clang 18, whose C++ modules support is too
-# immature for the façade modules (known `export using` overload-set bugs —
-# observed: `import streamr.json;` failed to provide the toJson overloads).
-# NDK r29 ships clang 21, which is expected to handle them. Gate on the
-# compiler version: with an older NDK, Android consumes the ordinary
-# headers instead (they remain the source of truth during the façade
-# stage), the module units are skipped, and import-using test/example
-# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
+# Android builds use the NDK's clang. The façade modules build correctly
+# with NDK r27+ (clang 18) — the failure previously attributed to compiler
+# immaturity was a -pthread BMI configuration mismatch, fixed in the
+# helpers below. Keep a version floor at the oldest verified NDK clang
+# (18 = r27): with an older NDK, Android consumes the ordinary headers
+# instead (they remain the source of truth during the façade stage), the
+# module units are skipped, and import-using test/example targets are not
+# built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
         set(STREAMR_MODULES_SUPPORTED ON)
     else()
         set(STREAMR_MODULES_SUPPORTED OFF)
         message(STATUS
             "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
-            "< 21 (use NDK r29+ for modules on Android)")
+            "< 18 (use NDK r27+ for modules on Android)")
     endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
@@ -112,6 +111,15 @@ function(streamr_add_module_library TARGET)
     # BMI-compiling target on the consumer side and requires the standard
     # level to be part of the exported usage requirements.
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # Importers must agree with the BMI on POSIX-thread support: clang
+    # validates language options when loading a module file. On Android,
+    # -pthread is not implied — test executables inherit it from GTest's
+    # Threads::Threads while library targets do not, so a BMI built
+    # without it cannot be loaded by an import-using test TU (observed:
+    # -Wmodule-file-config-mismatch, then every imported name reported as
+    # undeclared). Making the flag part of the PUBLIC interface keeps the
+    # BMI and every importer consistent. No-op on other platforms.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_target_module_sources(<target> FILES <unit.cppm>...)
@@ -135,6 +143,8 @@ function(streamr_target_module_sources TARGET)
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # See streamr_add_module_library: BMI/importer -pthread consistency.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-json/CMakeLists.txt
+++ b/packages/streamr-json/CMakeLists.txt
@@ -3,10 +3,9 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 include(homebrewClang.cmake)
 set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# No C++ modules in the codebase yet: CMake >= 3.28 (CMP0155) would otherwise
-# scan all C++20+ sources for module imports, injecting GCC scanning flags
-# (-fmodules-ts, -fmodule-mapper, -fdeps-format) into compile_commands.json,
-# which clangd rejects. The modules migration will turn scanning back on.
+# Module scanning stays OFF globally so that non-module TUs keep clean
+# compile commands for clangd; targets with module units or import-using
+# sources opt back in via the StreamrModules.cmake helpers.
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDES Off)

--- a/packages/streamr-json/StreamrModules.cmake
+++ b/packages/streamr-json/StreamrModules.cmake
@@ -10,16 +10,24 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang (18/19), whose C++ modules support is
-# too immature for the façade modules (known `export using` overload-set
-# bugs — observed: `import streamr.json;` fails to provide the toJson
-# overloads). Android consumes the ordinary headers instead (they remain the
-# source of truth during the façade stage), the module units are skipped,
-# and packages must not build their import-using test targets
-# (STREAMR_MODULES_SUPPORTED below guards them). Revisit when the NDK ships
-# clang >= 22 — consolidation (2.6) requires it, as headers disappear then.
+# Android builds use the NDK's clang, and modules support depends on its
+# version: NDK r27 ships clang 18, whose C++ modules support is too
+# immature for the façade modules (known `export using` overload-set bugs —
+# observed: `import streamr.json;` failed to provide the toJson overloads).
+# NDK r29 ships clang 21, which is expected to handle them. Gate on the
+# compiler version: with an older NDK, Android consumes the ordinary
+# headers instead (they remain the source of truth during the façade
+# stage), the module units are skipped, and import-using test/example
+# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    set(STREAMR_MODULES_SUPPORTED OFF)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+        set(STREAMR_MODULES_SUPPORTED ON)
+    else()
+        set(STREAMR_MODULES_SUPPORTED OFF)
+        message(STATUS
+            "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
+            "< 21 (use NDK r29+ for modules on Android)")
+    endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
 endif()

--- a/packages/streamr-json/StreamrModules.cmake
+++ b/packages/streamr-json/StreamrModules.cmake
@@ -10,23 +10,22 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang, and modules support depends on its
-# version: NDK r27 ships clang 18, whose C++ modules support is too
-# immature for the façade modules (known `export using` overload-set bugs —
-# observed: `import streamr.json;` failed to provide the toJson overloads).
-# NDK r29 ships clang 21, which is expected to handle them. Gate on the
-# compiler version: with an older NDK, Android consumes the ordinary
-# headers instead (they remain the source of truth during the façade
-# stage), the module units are skipped, and import-using test/example
-# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
+# Android builds use the NDK's clang. The façade modules build correctly
+# with NDK r27+ (clang 18) — the failure previously attributed to compiler
+# immaturity was a -pthread BMI configuration mismatch, fixed in the
+# helpers below. Keep a version floor at the oldest verified NDK clang
+# (18 = r27): with an older NDK, Android consumes the ordinary headers
+# instead (they remain the source of truth during the façade stage), the
+# module units are skipped, and import-using test/example targets are not
+# built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
         set(STREAMR_MODULES_SUPPORTED ON)
     else()
         set(STREAMR_MODULES_SUPPORTED OFF)
         message(STATUS
             "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
-            "< 21 (use NDK r29+ for modules on Android)")
+            "< 18 (use NDK r27+ for modules on Android)")
     endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
@@ -112,6 +111,15 @@ function(streamr_add_module_library TARGET)
     # BMI-compiling target on the consumer side and requires the standard
     # level to be part of the exported usage requirements.
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # Importers must agree with the BMI on POSIX-thread support: clang
+    # validates language options when loading a module file. On Android,
+    # -pthread is not implied — test executables inherit it from GTest's
+    # Threads::Threads while library targets do not, so a BMI built
+    # without it cannot be loaded by an import-using test TU (observed:
+    # -Wmodule-file-config-mismatch, then every imported name reported as
+    # undeclared). Making the flag part of the PUBLIC interface keeps the
+    # BMI and every importer consistent. No-op on other platforms.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_target_module_sources(<target> FILES <unit.cppm>...)
@@ -135,6 +143,8 @@ function(streamr_target_module_sources TARGET)
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # See streamr_add_module_library: BMI/importer -pthread consistency.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-libstreamrproxyclient/CMakeLists.txt
+++ b/packages/streamr-libstreamrproxyclient/CMakeLists.txt
@@ -4,10 +4,9 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 include(homebrewClang.cmake)
 set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# No C++ modules in the codebase yet: CMake >= 3.28 (CMP0155) would otherwise
-# scan all C++20+ sources for module imports, injecting GCC scanning flags
-# (-fmodules-ts, -fmodule-mapper, -fdeps-format) into compile_commands.json,
-# which clangd rejects. The modules migration will turn scanning back on.
+# Module scanning stays OFF globally so that non-module TUs keep clean
+# compile commands for clangd; targets with module units or import-using
+# sources opt back in via the StreamrModules.cmake helpers.
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDES Off)

--- a/packages/streamr-libstreamrproxyclient/StreamrModules.cmake
+++ b/packages/streamr-libstreamrproxyclient/StreamrModules.cmake
@@ -10,16 +10,24 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang (18/19), whose C++ modules support is
-# too immature for the façade modules (known `export using` overload-set
-# bugs — observed: `import streamr.json;` fails to provide the toJson
-# overloads). Android consumes the ordinary headers instead (they remain the
-# source of truth during the façade stage), the module units are skipped,
-# and packages must not build their import-using test targets
-# (STREAMR_MODULES_SUPPORTED below guards them). Revisit when the NDK ships
-# clang >= 22 — consolidation (2.6) requires it, as headers disappear then.
+# Android builds use the NDK's clang, and modules support depends on its
+# version: NDK r27 ships clang 18, whose C++ modules support is too
+# immature for the façade modules (known `export using` overload-set bugs —
+# observed: `import streamr.json;` failed to provide the toJson overloads).
+# NDK r29 ships clang 21, which is expected to handle them. Gate on the
+# compiler version: with an older NDK, Android consumes the ordinary
+# headers instead (they remain the source of truth during the façade
+# stage), the module units are skipped, and import-using test/example
+# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    set(STREAMR_MODULES_SUPPORTED OFF)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+        set(STREAMR_MODULES_SUPPORTED ON)
+    else()
+        set(STREAMR_MODULES_SUPPORTED OFF)
+        message(STATUS
+            "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
+            "< 21 (use NDK r29+ for modules on Android)")
+    endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
 endif()

--- a/packages/streamr-libstreamrproxyclient/StreamrModules.cmake
+++ b/packages/streamr-libstreamrproxyclient/StreamrModules.cmake
@@ -10,23 +10,22 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang, and modules support depends on its
-# version: NDK r27 ships clang 18, whose C++ modules support is too
-# immature for the façade modules (known `export using` overload-set bugs —
-# observed: `import streamr.json;` failed to provide the toJson overloads).
-# NDK r29 ships clang 21, which is expected to handle them. Gate on the
-# compiler version: with an older NDK, Android consumes the ordinary
-# headers instead (they remain the source of truth during the façade
-# stage), the module units are skipped, and import-using test/example
-# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
+# Android builds use the NDK's clang. The façade modules build correctly
+# with NDK r27+ (clang 18) — the failure previously attributed to compiler
+# immaturity was a -pthread BMI configuration mismatch, fixed in the
+# helpers below. Keep a version floor at the oldest verified NDK clang
+# (18 = r27): with an older NDK, Android consumes the ordinary headers
+# instead (they remain the source of truth during the façade stage), the
+# module units are skipped, and import-using test/example targets are not
+# built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
         set(STREAMR_MODULES_SUPPORTED ON)
     else()
         set(STREAMR_MODULES_SUPPORTED OFF)
         message(STATUS
             "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
-            "< 21 (use NDK r29+ for modules on Android)")
+            "< 18 (use NDK r27+ for modules on Android)")
     endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
@@ -112,6 +111,15 @@ function(streamr_add_module_library TARGET)
     # BMI-compiling target on the consumer side and requires the standard
     # level to be part of the exported usage requirements.
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # Importers must agree with the BMI on POSIX-thread support: clang
+    # validates language options when loading a module file. On Android,
+    # -pthread is not implied — test executables inherit it from GTest's
+    # Threads::Threads while library targets do not, so a BMI built
+    # without it cannot be loaded by an import-using test TU (observed:
+    # -Wmodule-file-config-mismatch, then every imported name reported as
+    # undeclared). Making the flag part of the PUBLIC interface keeps the
+    # BMI and every importer consistent. No-op on other platforms.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_target_module_sources(<target> FILES <unit.cppm>...)
@@ -135,6 +143,8 @@ function(streamr_target_module_sources TARGET)
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # See streamr_add_module_library: BMI/importer -pthread consistency.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-logger/CMakeLists.txt
+++ b/packages/streamr-logger/CMakeLists.txt
@@ -3,10 +3,9 @@ include(homebrewClang.cmake)
 
 set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# No C++ modules in the codebase yet: CMake >= 3.28 (CMP0155) would otherwise
-# scan all C++20+ sources for module imports, injecting GCC scanning flags
-# (-fmodules-ts, -fmodule-mapper, -fdeps-format) into compile_commands.json,
-# which clangd rejects. The modules migration will turn scanning back on.
+# Module scanning stays OFF globally so that non-module TUs keep clean
+# compile commands for clangd; targets with module units or import-using
+# sources opt back in via the StreamrModules.cmake helpers.
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDES Off)
 

--- a/packages/streamr-logger/StreamrModules.cmake
+++ b/packages/streamr-logger/StreamrModules.cmake
@@ -10,16 +10,24 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang (18/19), whose C++ modules support is
-# too immature for the façade modules (known `export using` overload-set
-# bugs — observed: `import streamr.json;` fails to provide the toJson
-# overloads). Android consumes the ordinary headers instead (they remain the
-# source of truth during the façade stage), the module units are skipped,
-# and packages must not build their import-using test targets
-# (STREAMR_MODULES_SUPPORTED below guards them). Revisit when the NDK ships
-# clang >= 22 — consolidation (2.6) requires it, as headers disappear then.
+# Android builds use the NDK's clang, and modules support depends on its
+# version: NDK r27 ships clang 18, whose C++ modules support is too
+# immature for the façade modules (known `export using` overload-set bugs —
+# observed: `import streamr.json;` failed to provide the toJson overloads).
+# NDK r29 ships clang 21, which is expected to handle them. Gate on the
+# compiler version: with an older NDK, Android consumes the ordinary
+# headers instead (they remain the source of truth during the façade
+# stage), the module units are skipped, and import-using test/example
+# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    set(STREAMR_MODULES_SUPPORTED OFF)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+        set(STREAMR_MODULES_SUPPORTED ON)
+    else()
+        set(STREAMR_MODULES_SUPPORTED OFF)
+        message(STATUS
+            "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
+            "< 21 (use NDK r29+ for modules on Android)")
+    endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
 endif()

--- a/packages/streamr-logger/StreamrModules.cmake
+++ b/packages/streamr-logger/StreamrModules.cmake
@@ -10,23 +10,22 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang, and modules support depends on its
-# version: NDK r27 ships clang 18, whose C++ modules support is too
-# immature for the façade modules (known `export using` overload-set bugs —
-# observed: `import streamr.json;` failed to provide the toJson overloads).
-# NDK r29 ships clang 21, which is expected to handle them. Gate on the
-# compiler version: with an older NDK, Android consumes the ordinary
-# headers instead (they remain the source of truth during the façade
-# stage), the module units are skipped, and import-using test/example
-# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
+# Android builds use the NDK's clang. The façade modules build correctly
+# with NDK r27+ (clang 18) — the failure previously attributed to compiler
+# immaturity was a -pthread BMI configuration mismatch, fixed in the
+# helpers below. Keep a version floor at the oldest verified NDK clang
+# (18 = r27): with an older NDK, Android consumes the ordinary headers
+# instead (they remain the source of truth during the façade stage), the
+# module units are skipped, and import-using test/example targets are not
+# built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
         set(STREAMR_MODULES_SUPPORTED ON)
     else()
         set(STREAMR_MODULES_SUPPORTED OFF)
         message(STATUS
             "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
-            "< 21 (use NDK r29+ for modules on Android)")
+            "< 18 (use NDK r27+ for modules on Android)")
     endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
@@ -112,6 +111,15 @@ function(streamr_add_module_library TARGET)
     # BMI-compiling target on the consumer side and requires the standard
     # level to be part of the exported usage requirements.
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # Importers must agree with the BMI on POSIX-thread support: clang
+    # validates language options when loading a module file. On Android,
+    # -pthread is not implied — test executables inherit it from GTest's
+    # Threads::Threads while library targets do not, so a BMI built
+    # without it cannot be loaded by an import-using test TU (observed:
+    # -Wmodule-file-config-mismatch, then every imported name reported as
+    # undeclared). Making the flag part of the PUBLIC interface keeps the
+    # BMI and every importer consistent. No-op on other platforms.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_target_module_sources(<target> FILES <unit.cppm>...)
@@ -135,6 +143,8 @@ function(streamr_target_module_sources TARGET)
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # See streamr_add_module_library: BMI/importer -pthread consistency.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-proto-rpc/CMakeLists.txt
+++ b/packages/streamr-proto-rpc/CMakeLists.txt
@@ -5,10 +5,9 @@ include(homebrewClang.cmake)
 
 set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# No C++ modules in the codebase yet: CMake >= 3.28 (CMP0155) would otherwise
-# scan all C++20+ sources for module imports, injecting GCC scanning flags
-# (-fmodules-ts, -fmodule-mapper, -fdeps-format) into compile_commands.json,
-# which clangd rejects. The modules migration will turn scanning back on.
+# Module scanning stays OFF globally so that non-module TUs keep clean
+# compile commands for clangd; targets with module units or import-using
+# sources opt back in via the StreamrModules.cmake helpers.
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/packages/streamr-proto-rpc/CMakeLists.txt
+++ b/packages/streamr-proto-rpc/CMakeLists.txt
@@ -90,19 +90,26 @@ file(WRITE "${CMAKE_BINARY_DIR}/streamr-proto-rpc-config.cmake"
     "endif()\n"
     "include(${CMAKE_BINARY_DIR}/streamr-proto-rpc-config-in.cmake)\n")
 
-# Test/example targets import the modules — skip them where modules are
-# unsupported (Android; they are never executed there anyway).
-if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
+# The protoc codegen plugin is host tooling (invoked by proto.sh to
+# regenerate the checked-in *.pb.* files) — never built for cross
+# targets: vcpkg does not provide protobuf::libprotoc for Android/iOS
+# and the plugin runs on the developer machine anyway. (Previously this
+# sat inside the modules block below and was skipped on Android only as
+# a side effect of the modules gate being OFF there.)
+if(NOT CMAKE_CROSSCOMPILING)
     add_executable(protobuf-streamr-plugin src/PluginCodeGeneratorMain.cpp include/streamr-proto-rpc/PluginCodeGenerator.hpp)
 
     target_include_directories(
         protobuf-streamr-plugin PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include>)
 
-    target_link_libraries(protobuf-streamr-plugin 
+    target_link_libraries(protobuf-streamr-plugin
         PRIVATE protobuf::libprotobuf protobuf::libprotoc)
+endif()
 
-
+# Test/example targets import the modules — skip them where modules are
+# unsupported (they are never executed on Android anyway).
+if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
     enable_testing()
     find_package(GTest CONFIG REQUIRED)
 

--- a/packages/streamr-proto-rpc/StreamrModules.cmake
+++ b/packages/streamr-proto-rpc/StreamrModules.cmake
@@ -10,16 +10,24 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang (18/19), whose C++ modules support is
-# too immature for the façade modules (known `export using` overload-set
-# bugs — observed: `import streamr.json;` fails to provide the toJson
-# overloads). Android consumes the ordinary headers instead (they remain the
-# source of truth during the façade stage), the module units are skipped,
-# and packages must not build their import-using test targets
-# (STREAMR_MODULES_SUPPORTED below guards them). Revisit when the NDK ships
-# clang >= 22 — consolidation (2.6) requires it, as headers disappear then.
+# Android builds use the NDK's clang, and modules support depends on its
+# version: NDK r27 ships clang 18, whose C++ modules support is too
+# immature for the façade modules (known `export using` overload-set bugs —
+# observed: `import streamr.json;` failed to provide the toJson overloads).
+# NDK r29 ships clang 21, which is expected to handle them. Gate on the
+# compiler version: with an older NDK, Android consumes the ordinary
+# headers instead (they remain the source of truth during the façade
+# stage), the module units are skipped, and import-using test/example
+# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    set(STREAMR_MODULES_SUPPORTED OFF)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+        set(STREAMR_MODULES_SUPPORTED ON)
+    else()
+        set(STREAMR_MODULES_SUPPORTED OFF)
+        message(STATUS
+            "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
+            "< 21 (use NDK r29+ for modules on Android)")
+    endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
 endif()

--- a/packages/streamr-proto-rpc/StreamrModules.cmake
+++ b/packages/streamr-proto-rpc/StreamrModules.cmake
@@ -10,23 +10,22 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang, and modules support depends on its
-# version: NDK r27 ships clang 18, whose C++ modules support is too
-# immature for the façade modules (known `export using` overload-set bugs —
-# observed: `import streamr.json;` failed to provide the toJson overloads).
-# NDK r29 ships clang 21, which is expected to handle them. Gate on the
-# compiler version: with an older NDK, Android consumes the ordinary
-# headers instead (they remain the source of truth during the façade
-# stage), the module units are skipped, and import-using test/example
-# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
+# Android builds use the NDK's clang. The façade modules build correctly
+# with NDK r27+ (clang 18) — the failure previously attributed to compiler
+# immaturity was a -pthread BMI configuration mismatch, fixed in the
+# helpers below. Keep a version floor at the oldest verified NDK clang
+# (18 = r27): with an older NDK, Android consumes the ordinary headers
+# instead (they remain the source of truth during the façade stage), the
+# module units are skipped, and import-using test/example targets are not
+# built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
         set(STREAMR_MODULES_SUPPORTED ON)
     else()
         set(STREAMR_MODULES_SUPPORTED OFF)
         message(STATUS
             "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
-            "< 21 (use NDK r29+ for modules on Android)")
+            "< 18 (use NDK r27+ for modules on Android)")
     endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
@@ -112,6 +111,15 @@ function(streamr_add_module_library TARGET)
     # BMI-compiling target on the consumer side and requires the standard
     # level to be part of the exported usage requirements.
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # Importers must agree with the BMI on POSIX-thread support: clang
+    # validates language options when loading a module file. On Android,
+    # -pthread is not implied — test executables inherit it from GTest's
+    # Threads::Threads while library targets do not, so a BMI built
+    # without it cannot be loaded by an import-using test TU (observed:
+    # -Wmodule-file-config-mismatch, then every imported name reported as
+    # undeclared). Making the flag part of the PUBLIC interface keeps the
+    # BMI and every importer consistent. No-op on other platforms.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_target_module_sources(<target> FILES <unit.cppm>...)
@@ -135,6 +143,8 @@ function(streamr_target_module_sources TARGET)
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # See streamr_add_module_library: BMI/importer -pthread consistency.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-trackerless-network/CMakeLists.txt
+++ b/packages/streamr-trackerless-network/CMakeLists.txt
@@ -5,10 +5,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/homebrewClang.cmake)
 
 set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# No C++ modules in the codebase yet: CMake >= 3.28 (CMP0155) would otherwise
-# scan all C++20+ sources for module imports, injecting GCC scanning flags
-# (-fmodules-ts, -fmodule-mapper, -fdeps-format) into compile_commands.json,
-# which clangd rejects. The modules migration will turn scanning back on.
+# Module scanning stays OFF globally so that non-module TUs keep clean
+# compile commands for clangd; targets with module units or import-using
+# sources opt back in via the StreamrModules.cmake helpers.
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/packages/streamr-trackerless-network/StreamrModules.cmake
+++ b/packages/streamr-trackerless-network/StreamrModules.cmake
@@ -10,16 +10,24 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang (18/19), whose C++ modules support is
-# too immature for the façade modules (known `export using` overload-set
-# bugs — observed: `import streamr.json;` fails to provide the toJson
-# overloads). Android consumes the ordinary headers instead (they remain the
-# source of truth during the façade stage), the module units are skipped,
-# and packages must not build their import-using test targets
-# (STREAMR_MODULES_SUPPORTED below guards them). Revisit when the NDK ships
-# clang >= 22 — consolidation (2.6) requires it, as headers disappear then.
+# Android builds use the NDK's clang, and modules support depends on its
+# version: NDK r27 ships clang 18, whose C++ modules support is too
+# immature for the façade modules (known `export using` overload-set bugs —
+# observed: `import streamr.json;` failed to provide the toJson overloads).
+# NDK r29 ships clang 21, which is expected to handle them. Gate on the
+# compiler version: with an older NDK, Android consumes the ordinary
+# headers instead (they remain the source of truth during the façade
+# stage), the module units are skipped, and import-using test/example
+# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    set(STREAMR_MODULES_SUPPORTED OFF)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+        set(STREAMR_MODULES_SUPPORTED ON)
+    else()
+        set(STREAMR_MODULES_SUPPORTED OFF)
+        message(STATUS
+            "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
+            "< 21 (use NDK r29+ for modules on Android)")
+    endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
 endif()

--- a/packages/streamr-trackerless-network/StreamrModules.cmake
+++ b/packages/streamr-trackerless-network/StreamrModules.cmake
@@ -10,23 +10,22 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang, and modules support depends on its
-# version: NDK r27 ships clang 18, whose C++ modules support is too
-# immature for the façade modules (known `export using` overload-set bugs —
-# observed: `import streamr.json;` failed to provide the toJson overloads).
-# NDK r29 ships clang 21, which is expected to handle them. Gate on the
-# compiler version: with an older NDK, Android consumes the ordinary
-# headers instead (they remain the source of truth during the façade
-# stage), the module units are skipped, and import-using test/example
-# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
+# Android builds use the NDK's clang. The façade modules build correctly
+# with NDK r27+ (clang 18) — the failure previously attributed to compiler
+# immaturity was a -pthread BMI configuration mismatch, fixed in the
+# helpers below. Keep a version floor at the oldest verified NDK clang
+# (18 = r27): with an older NDK, Android consumes the ordinary headers
+# instead (they remain the source of truth during the façade stage), the
+# module units are skipped, and import-using test/example targets are not
+# built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
         set(STREAMR_MODULES_SUPPORTED ON)
     else()
         set(STREAMR_MODULES_SUPPORTED OFF)
         message(STATUS
             "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
-            "< 21 (use NDK r29+ for modules on Android)")
+            "< 18 (use NDK r27+ for modules on Android)")
     endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
@@ -112,6 +111,15 @@ function(streamr_add_module_library TARGET)
     # BMI-compiling target on the consumer side and requires the standard
     # level to be part of the exported usage requirements.
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # Importers must agree with the BMI on POSIX-thread support: clang
+    # validates language options when loading a module file. On Android,
+    # -pthread is not implied — test executables inherit it from GTest's
+    # Threads::Threads while library targets do not, so a BMI built
+    # without it cannot be loaded by an import-using test TU (observed:
+    # -Wmodule-file-config-mismatch, then every imported name reported as
+    # undeclared). Making the flag part of the PUBLIC interface keeps the
+    # BMI and every importer consistent. No-op on other platforms.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_target_module_sources(<target> FILES <unit.cppm>...)
@@ -135,6 +143,8 @@ function(streamr_target_module_sources TARGET)
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # See streamr_add_module_library: BMI/importer -pthread consistency.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_enable_imports(<target>)

--- a/packages/streamr-utils/CMakeLists.txt
+++ b/packages/streamr-utils/CMakeLists.txt
@@ -10,10 +10,9 @@ set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
 
 set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# No C++ modules in the codebase yet: CMake >= 3.28 (CMP0155) would otherwise
-# scan all C++20+ sources for module imports, injecting GCC scanning flags
-# (-fmodules-ts, -fmodule-mapper, -fdeps-format) into compile_commands.json,
-# which clangd rejects. The modules migration will turn scanning back on.
+# Module scanning stays OFF globally so that non-module TUs keep clean
+# compile commands for clangd; targets with module units or import-using
+# sources opt back in via the StreamrModules.cmake helpers.
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 project(streamr-utils CXX)

--- a/packages/streamr-utils/StreamrModules.cmake
+++ b/packages/streamr-utils/StreamrModules.cmake
@@ -10,16 +10,24 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang (18/19), whose C++ modules support is
-# too immature for the façade modules (known `export using` overload-set
-# bugs — observed: `import streamr.json;` fails to provide the toJson
-# overloads). Android consumes the ordinary headers instead (they remain the
-# source of truth during the façade stage), the module units are skipped,
-# and packages must not build their import-using test targets
-# (STREAMR_MODULES_SUPPORTED below guards them). Revisit when the NDK ships
-# clang >= 22 — consolidation (2.6) requires it, as headers disappear then.
+# Android builds use the NDK's clang, and modules support depends on its
+# version: NDK r27 ships clang 18, whose C++ modules support is too
+# immature for the façade modules (known `export using` overload-set bugs —
+# observed: `import streamr.json;` failed to provide the toJson overloads).
+# NDK r29 ships clang 21, which is expected to handle them. Gate on the
+# compiler version: with an older NDK, Android consumes the ordinary
+# headers instead (they remain the source of truth during the façade
+# stage), the module units are skipped, and import-using test/example
+# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    set(STREAMR_MODULES_SUPPORTED OFF)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+        set(STREAMR_MODULES_SUPPORTED ON)
+    else()
+        set(STREAMR_MODULES_SUPPORTED OFF)
+        message(STATUS
+            "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
+            "< 21 (use NDK r29+ for modules on Android)")
+    endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
 endif()

--- a/packages/streamr-utils/StreamrModules.cmake
+++ b/packages/streamr-utils/StreamrModules.cmake
@@ -10,23 +10,22 @@
 # OFF globally (clean compile commands for clangd), and the helpers below
 # re-enable scanning per target.
 
-# Android builds use the NDK's clang, and modules support depends on its
-# version: NDK r27 ships clang 18, whose C++ modules support is too
-# immature for the façade modules (known `export using` overload-set bugs —
-# observed: `import streamr.json;` failed to provide the toJson overloads).
-# NDK r29 ships clang 21, which is expected to handle them. Gate on the
-# compiler version: with an older NDK, Android consumes the ordinary
-# headers instead (they remain the source of truth during the façade
-# stage), the module units are skipped, and import-using test/example
-# targets are not built (STREAMR_MODULES_SUPPORTED guards them).
+# Android builds use the NDK's clang. The façade modules build correctly
+# with NDK r27+ (clang 18) — the failure previously attributed to compiler
+# immaturity was a -pthread BMI configuration mismatch, fixed in the
+# helpers below. Keep a version floor at the oldest verified NDK clang
+# (18 = r27): with an older NDK, Android consumes the ordinary headers
+# instead (they remain the source of truth during the façade stage), the
+# module units are skipped, and import-using test/example targets are not
+# built (STREAMR_MODULES_SUPPORTED guards them).
 if(VCPKG_TARGET_TRIPLET MATCHES "android" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
         set(STREAMR_MODULES_SUPPORTED ON)
     else()
         set(STREAMR_MODULES_SUPPORTED OFF)
         message(STATUS
             "C++ modules disabled: NDK clang ${CMAKE_CXX_COMPILER_VERSION} "
-            "< 21 (use NDK r29+ for modules on Android)")
+            "< 18 (use NDK r27+ for modules on Android)")
     endif()
 else()
     set(STREAMR_MODULES_SUPPORTED ON)
@@ -112,6 +111,15 @@ function(streamr_add_module_library TARGET)
     # BMI-compiling target on the consumer side and requires the standard
     # level to be part of the exported usage requirements.
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # Importers must agree with the BMI on POSIX-thread support: clang
+    # validates language options when loading a module file. On Android,
+    # -pthread is not implied — test executables inherit it from GTest's
+    # Threads::Threads while library targets do not, so a BMI built
+    # without it cannot be loaded by an import-using test TU (observed:
+    # -Wmodule-file-config-mismatch, then every imported name reported as
+    # undeclared). Making the flag part of the PUBLIC interface keeps the
+    # BMI and every importer consistent. No-op on other platforms.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_target_module_sources(<target> FILES <unit.cppm>...)
@@ -135,6 +143,8 @@ function(streamr_target_module_sources TARGET)
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)
+    # See streamr_add_module_library: BMI/importer -pthread consistency.
+    target_compile_options(${TARGET} PUBLIC $<$<PLATFORM_ID:Android>:-pthread>)
 endfunction()
 
 # streamr_enable_imports(<target>)


### PR DESCRIPTION
Closeout of Part 2 — **and the consolidation decision, which is yours to make.** (This PR grew one substantive fix along the way: the Android modules blocker turned out not to be a blocker at all — see below.)

## The Android resolution (found while closing out)

The Phase 2.5 Android failure (`import streamr.json` → every imported name "undeclared") was **not** an NDK-clang capability gap. Reproducing the CI build locally against NDK r27/r28/r29 showed all three raw compilers (clang 18/19/21) build and import the façade modules correctly. The real cause, always truncated out of the CI annotation tail: a **`-pthread` BMI configuration mismatch** — test TUs compile with `-pthread` (inherited from GTest's `Threads::Threads`), the module libraries' BMIs were built without it, and on Android clang validates that language option when loading a module file (`-Wmodule-file-config-mismatch`), so the BMI silently fails to load and every imported name cascades to "undeclared". Only the thread-less leaf packages (json, eventemitter) could mismatch — the folly-linking packages already inherited `-pthread` into their BMIs.

**Fixes in this PR:**
- `StreamrModules.cmake` helpers make `-pthread` a PUBLIC compile option on Android (genexpr; no-op elsewhere) so BMIs and importers always agree.
- The Android `STREAMR_MODULES_SUPPORTED` floor drops from clang 21 to clang 18 (= NDK r27, oldest verified); textual fallback below that.
- `protobuf-streamr-plugin` (host codegen tooling) gets its own `NOT CMAKE_CROSSCOMPILING` guard — it was only ever skipped on Android as a side effect of the modules gate being OFF.
- The Android workflow keeps building with the runner's latest stable NDK (r29 = clang 21) — hygiene, no longer a modules requirement.

**Result: the androidbuild leg on this PR builds the full monorepo — all 7 module packages, tests included — for arm64-android with modules ON.** Android is no longer a consolidation blocker.

## The decision memo (now in MODERNIZATION.md)

The planned Phase 2.6 — move all code into module purview, delete every internal header — remains gated by two preconditions (the third is resolved above):
1. ~~A modules-capable NDK on Android~~ **RESOLVED in this PR.**
2. clangd can lint purview code (today it can't — and consolidated code would have no header fallback for the linter, so coverage would regress from full to none).
3. dht's include cycles become a partition DAG.

**Recommendation: defer, and treat the façade stage as the stable resting point** — now purely on lint-coverage grounds (2) plus the dht untangling (3). Nothing rots by waiting: headers stay the linted source of truth on every platform, and consolidation resumes leaf-first (eventemitter canary, measured per package) when clangd's modules support matures. If you'd rather trade lint coverage for the incremental-build wins now, say so and I'll re-plan.

## Also in this PR

- **Final ClangBuildAnalyzer trace — the third success metric is met**: `DhtRpc.pb.h` fell from **#1 (96 s, 33 inclusions) to #9 (15.7 s, 6 inclusions)**; `SLogger.hpp`/`Logger.hpp` left the expensive-headers list entirely; the new #1 is `gtest.h`, which stays `#include` by design. Total frontend parse CPU: 859 s → 723 s (−16 %) even with the module units added.
- README: developer documentation for the modules (import rules, the sibling-import rule, the direct-link rule, the Android `-pthread` note).
- The stale "No C++ modules in the codebase yet" comments updated in all 9 CMakeLists (comment-only).
- The 2.5 section's Android record corrected honestly (what we believed then vs. what was true).

## Part 2 final scorecard

| Success metric | Verdict |
|---|---|
| Clean build −25 % | ✅ −24 % (effectively met) |
| Expensive headers: pb.h/folly leave the top | ✅ met decisively |
| Incremental −40 % | ❌ requires consolidation (quantified why) |

Part 1 (toolchain) + Part 2 façade stage are complete: LLVM 22 + libc++ everywhere, vcpkg 2026.06, iOS 26 device-verified, 7 packages shipping modules on macOS/Linux/iOS **and Android**, 250+ tests through `import`, all four platform gates green, and a measured, honest record of every decision in MODERNIZATION.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)