### PR TITLE
Document final disposition of the disabled TS interop tests

### DIFF
--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -109,6 +109,16 @@ Android NDK r28+.
   current, slimmer TS setup. Diagnosis ruled out external-server dependence
   (all three run fully against a local `--local` subscriber on
   127.0.0.1:44211).
+- **FINAL DISPOSITION (post-modernization, owner decision 2026-07):** the
+  tests stay disabled in this repository and the harness will NOT be
+  revived here. The streamr network TS packages have changed a lot since
+  2024, and the TS interop harness (currently the
+  `native-ts-integration` submodule) will be rewritten in a separate
+  project. The disabled `add_test` blocks in
+  `packages/streamr-trackerless-network/CMakeLists.txt` and
+  `packages/streamr-libstreamrproxyclient/CMakeLists.txt` and the
+  `run-ts-*`/`run-ts-integration-tests.sh` scripts remain as reference
+  for that rewrite.
 
 ## Phase 1.2 — Compiler upgrades + CI image modernization ✅ (PR #23, merged)
 - macOS: dead `llvm@17` → latest keg-only Homebrew `llvm` (22.x), located via

--- a/packages/streamr-libstreamrproxyclient/CMakeLists.txt
+++ b/packages/streamr-libstreamrproxyclient/CMakeLists.txt
@@ -118,11 +118,13 @@ if (NOT IOS)
         include(GoogleTest)
         gtest_discover_tests(streamr-streamrproxyclient-test-integration)
         gtest_discover_tests(streamrproxyclient-cpp-wrapper-test)
-        # TEMPORARILY DISABLED: these tests build the whole streamr-dev/network
-        # TS monorepo at a 2024 commit (ts-integration/install.sh), which no
-        # longer works on current CI runners, and compiling the whole
-        # repository is not necessary anymore. Re-enable against a current,
-        # slimmer TS setup after the toolchain/modules modernization.
+        # DISABLED: these tests build the whole streamr-dev/network TS
+        # monorepo at a 2024 commit (ts-integration/install.sh), which no
+        # longer works on current CI runners. The streamr network TS
+        # packages have changed a lot since 2024 — the TS interop harness
+        # will be rewritten in a separate project (see MODERNIZATION.md,
+        # "Interim — ts-integration tests"). Kept as reference for that
+        # rewrite.
         # add_test(
         #     NAME ts-end-to-end-test
         #     COMMAND "${CMAKE_CURRENT_LIST_DIR}/run-ts-end-to-end-tests.sh"

--- a/packages/streamr-trackerless-network/CMakeLists.txt
+++ b/packages/streamr-trackerless-network/CMakeLists.txt
@@ -164,11 +164,13 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
          # gtest_discover_tests(streamr-trackerless-network-test-unit)
          #gtest_discover_tests(streamr-trackerless-network-test-integration)
      
-         # TEMPORARILY DISABLED: this test builds the whole streamr-dev/network
-         # TS monorepo at a 2024 commit (ts-integration/install.sh), which no
-         # longer works on current CI runners, and compiling the whole
-         # repository is not necessary anymore. Re-enable against a current,
-         # slimmer TS setup after the toolchain/modules modernization.
+         # DISABLED: this test builds the whole streamr-dev/network TS
+         # monorepo at a 2024 commit (ts-integration/install.sh), which no
+         # longer works on current CI runners. The streamr network TS
+         # packages have changed a lot since 2024 — the TS interop harness
+         # will be rewritten in a separate project (see MODERNIZATION.md,
+         # "Interim — ts-integration tests"). Kept as reference for that
+         # rewrite.
          # add_test(
          #    NAME ts-integration-test
          #    COMMAND "${CMAKE_CURRENT_LIST_DIR}/run-ts-integration-tests.sh"


### PR DESCRIPTION
Documentation-only closeout of the last parked workstream from the modernization.

The `ts-integration-test` / `ts-end-to-end-test` / `ts-multiple-messages-test` trio (disabled since PR #22) will **not** be revived in this repository: the streamr network TS packages have changed a lot since the 2024 pin the harness was built against, and the TS interop harness will be rewritten in a **separate project**.

- MODERNIZATION.md's "Interim — ts-integration tests" section records the final disposition.
- The `DISABLED` comments in the two CMakeLists now state the decision and point at the memo, instead of promising an in-repo revival.
- The disabled `add_test` blocks, the `run-ts-*` scripts, and the `native-ts-integration` submodule are kept untouched as reference for the rewrite.

For context (useful for the rewrite project): the harness's low-level subscriber uses `@streamr/trackerless-network` / `@streamr/dht` / `@streamr/utils`, which are published on npm (currently 103.3.1), so the new harness can depend on published packages instead of building the network monorepo from source. All three tests run fully against a local `--local` subscriber on 127.0.0.1:44211 — no external servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)