### PR TITLE
Record clangd 22.1.8 modules re-canary: consolidation blocker narrowed to one failure class

### DIFF
--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -749,10 +749,34 @@ verified NDK clang (18 = r27), with the textual fallback below it.
    Android builds the façade modules on NDK r27+ (verified locally on
    r27 and r29 for streamr-json + streamr-eventemitter, and on the
    Phase 2.6 PR's androidbuild leg for the full monorepo).
-2. clangd modules support matures enough to lint purview code (today it
-   mis-unifies preamble/BMI types; with code in partitions there is no
-   header fallback for the linter — coverage would regress from "full"
-   to "none" for consolidated code).
+2. clangd modules support matures enough to lint purview code (with code
+   in partitions there is no header fallback for the linter).
+   **RE-CANARY 2026-07-04 (clangd 22.1.8) — much narrower than first
+   recorded:**
+   - Module interface units themselves (`clangd --check=<unit>.cppm
+     --compile-commands-dir=<pkg>/build`) lint CLEAN, including the
+     heavyweight folly/protobuf GMF units (`streamr.dht-all.cppm`). The
+     only diagnostics are `misc-unused-using-decls` false positives on
+     the `export using` re-export blocks — suppressible, and gone at
+     consolidation anyway (consolidated code lives in purview, no
+     re-export blocks).
+   - Import-using consumers (e.g. `toJsonTest.cpp`) lint CLEAN — clangd
+     loads the build tree's BMIs through the compile command's
+     `-fmodule-file=` flags; no experimental flag needed.
+   - **The ONE remaining failure class: preamble/BMI std-type
+     unification.** When a std type crosses the module boundary in an
+     API (e.g. `Branded<std::string>` = `EthereumAddress`), clangd
+     treats the preamble's textual `std::string` (from `<string>`/gtest
+     includes) and the BMI's `std::string` as distinct types → spurious
+     "no matching constructor/function" (the still-excluded
+     `toEthereumAddressOrENSNameTest.cpp`). Post-consolidation this
+     class would hit any consumer passing std types to imported APIs —
+     this is what still blocks consolidation.
+   - Re-canary each LLVM release; the only case to retest is the
+     std-unification one: `cd packages/streamr-utils && clangd
+     --check=test/unit/toEthereumAddressOrENSNameTest.cpp
+     --compile-commands-dir=build` — precondition met when it reports
+     no type-mismatch diagnostics.
 3. ~~The dht intra-package include cycles (connection/endpoint cluster)
    must become a partition DAG~~ **RESOLVED (post-2.6)** — a monorepo-wide
    analysis (include edges + forward-declaration edges, which are what


### PR DESCRIPTION
Docs-only. With preconditions 1 (Android) and 3 (header DAG) resolved, I re-ran the clangd modules canary against the current toolchain (clangd 22.1.8) to get a precise reading on the last gate — precondition 2, "clangd can lint purview code". The verdict is **much narrower** than the memo's 2.1-era wording:

**What now works (tested with `clangd --check` + each package's compile database):**
- **Module interface units lint clean** — including the heavyweight folly/protobuf GMF unit `streamr.dht-all.cppm`. The only diagnostics are `misc-unused-using-decls` false positives on the `export using` re-export blocks: suppressible, and moot after consolidation (consolidated code lives in purview; there are no re-export blocks).
- **Import-using consumers lint clean** — clangd loads the build tree's BMIs through the compile command's `-fmodule-file=` flags. No `--experimental-modules-support` needed.

**The one remaining failure class:** preamble/BMI **std-type unification**. When a std type crosses the module boundary in an API — e.g. `EthereumAddress` = `Branded<std::string>` — clangd treats the preamble's textual `std::string` (from `<string>`/gtest includes) and the BMI's `std::string` as distinct types, producing spurious "no matching constructor/function" diagnostics. This is exactly the still-excluded `toEthereumAddressOrENSNameTest.cpp`, and post-consolidation it would hit any consumer passing std types to imported APIs. This class alone is what still blocks consolidation.

The memo now records a one-command re-canary recipe to run on each LLVM release; the moment that single case reports clean, all three consolidation preconditions are green and the go/no-go is purely an owner decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)