### PR TITLE
CI speed: skip standalone builds on Linux legs, cache the root build tree per platform [androidbuild] [iosbuild]

### DIFF
--- a/.github/workflows/reusable/cached-install/action.yml
+++ b/.github/workflows/reusable/cached-install/action.yml
@@ -51,6 +51,57 @@ runs:
           ${{ runner.arch }}-${{ runner.os }}-${{ steps.keys.outputs.platform }}-installed-v2-
         path: |
           ./build/vcpkg_installed
+    # Ninja decides what to rebuild by comparing source mtimes against the
+    # state recorded in the cached build tree. A fresh checkout stamps every
+    # file with the checkout time, which would force a full rebuild — so
+    # reset every tracked file's mtime to its last-change commit time (the
+    # same rule the run that SAVED the cache used; requires the workflows'
+    # fetch-depth: 0). Single pass over git log, a few seconds.
+    - name: restore source mtimes
+      run: |
+        python3 - <<'PYEOF'
+        import subprocess, os
+        tracked = set(subprocess.run(['git','ls-files'], capture_output=True, text=True).stdout.splitlines())
+        log = subprocess.run(['git','log','--format=%ct','--name-only','--no-renames'], capture_output=True, text=True).stdout
+        seen, t = set(), None
+        for line in log.splitlines():
+            if not line:
+                continue
+            if line not in tracked and line.isdigit():
+                t = int(line)
+                continue
+            if line in tracked and line not in seen:
+                seen.add(line)
+                try:
+                    os.utime(line, (t, t))
+                except FileNotFoundError:
+                    pass
+            if len(seen) == len(tracked):
+                break
+        print(f"restored mtimes for {len(seen)}/{len(tracked)} tracked files")
+        PYEOF
+      shell: bash
+    # Build-tree cache (MODERNIZATION.md "After the consolidation: CI
+    # speed", item 2): restore the previous ROOT build tree so Ninja
+    # recompiles only what the pull request touched. vcpkg_installed is
+    # excluded (it has its own cache above); the per-package standalone
+    # trees are NOT cached — at ~8 x 0.5-1.5 GB they would blow the shared
+    # 10 GB actions-cache budget (the macOS leg rebuilds them as the
+    # packaging check; the Linux legs skip them via --no-standalone).
+    # Saved from main-branch runs only, so entries rotate once per merge
+    # instead of once per push, and a broken PR tree can never poison the
+    # cache (lesson from the corrupted arm64-ios dependency cache).
+    - name: cache build tree
+      id: cache-buildtree
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ runner.arch }}-${{ runner.os }}-${{ steps.keys.outputs.platform }}-buildtree-v1-${{ steps.keys.outputs.vcpkg_sha }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.arch }}-${{ runner.os }}-${{ steps.keys.outputs.platform }}-buildtree-v1-${{ steps.keys.outputs.vcpkg_sha }}-
+          ${{ runner.arch }}-${{ runner.os }}-${{ steps.keys.outputs.platform }}-buildtree-v1-
+        path: |
+          ./build
+          !./build/vcpkg_installed
     - name: install-prerequisities
       run:
         source install-prerequisities.sh
@@ -60,7 +111,7 @@ runs:
         # Composite steps run under bash -e -o pipefail: disarm around the
         # pipeline or a failure aborts the script before we can annotate.
         set +e +o pipefail
-        ./install.sh --prod ${ARCHFLAGS:-} 2>&1 | tee install-output.log
+        ./install.sh --prod ${ARCHFLAGS:-} ${INSTALL_EXTRA_FLAGS:-} 2>&1 | tee install-output.log
         EXITCODE=${PIPESTATUS[0]}
         if [ "$EXITCODE" -ne 0 ]; then
           # Surface failure context as error annotations so failures are
@@ -103,3 +154,13 @@ runs:
         key: ${{ runner.arch }}-${{ runner.os }}-${{ steps.keys.outputs.platform }}-installed-v2-${{ steps.keys.outputs.vcpkg_sha }}-${{ hashFiles('./vcpkg.json', './overlaytriplets/**', './overlayports/**') }}
         path: |
           ./build/vcpkg_installed
+    - name: cache build tree save
+      id: cache-buildtree-save
+      # Success-only and main-only: PR runs consume, merge runs publish.
+      if: github.ref == 'refs/heads/main' && steps.cache-buildtree.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ runner.arch }}-${{ runner.os }}-${{ steps.keys.outputs.platform }}-buildtree-v1-${{ steps.keys.outputs.vcpkg_sha }}-${{ github.sha }}
+        path: |
+          ./build
+          !./build/vcpkg_installed

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,7 +28,21 @@ jobs:
         # ubuntu-latest = 24.04: ubuntu-26.04 is still a preview image —
         # revisit when GA.
         os: [macos-26, ubuntu-latest, linux-arm64-runner]
+        # The standalone-package check (each package built in its own tree)
+        # validates packaging structure, which is host-independent — the
+        # macOS leg runs it, the Linux legs build only the root tree and
+        # lint against its compile database (MODERNIZATION.md "After the
+        # consolidation: CI speed", item 1).
+        include:
+          - os: macos-26
+            install_extra: ""
+          - os: ubuntu-latest
+            install_extra: "--no-standalone"
+          - os: linux-arm64-runner
+            install_extra: "--no-standalone"
     runs-on: ${{ matrix.os }}
+    env:
+      INSTALL_EXTRA_FLAGS: ${{ matrix.install_extra }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -1211,6 +1211,35 @@ the build structure the caches would key on:
 4. **Randomize test ports, then run ctest in parallel** — tests
    currently use fixed ports and must run serially.
 
+**IMPLEMENTED (items 1 + 2, after C-8 and the wrapper modules, as
+planned):**
+- `install.sh --no-standalone` skips the per-package standalone builds;
+  the ubuntu and linux-arm64 legs pass it (via INSTALL_EXTRA_FLAGS in
+  validate.yml) and lint against the ROOT tree's compile database —
+  every package lint.sh falls back to `../../build` when its standalone
+  database is absent. The macOS leg keeps the full standalone loop as
+  the packaging-structure check; iOS keeps it because the XCFramework
+  is assembled from the per-package outputs (`--no-standalone --ios` is
+  rejected).
+- The cached-install action now caches the ROOT build tree per platform
+  (key: platform + vcpkg SHA + commit; prefix restore-keys), excluding
+  vcpkg_installed (own cache) and the per-package trees (8 × 0.5–1.5 GB
+  would blow the shared 10 GB budget). SAVED ONLY FROM MAIN-BRANCH RUNS
+  — pull requests consume, merges publish; a broken PR tree can never
+  poison the cache (the corrupted arm64-ios entry lesson). Because
+  Ninja compares source mtimes against the recorded build state, and a
+  fresh checkout stamps everything with checkout time, the action first
+  resets every tracked file's mtime to its last-change commit time
+  (single git-log pass; needs the workflows' fetch-depth: 0) — so a
+  restored tree rebuilds exactly the pull request's touched cone.
+- Item 3 (ccache) remains a fallback if this proves fragile; item 4
+  (port randomization + parallel ctest) remains open.
+- Measurement protocol: the first post-merge main run populates the
+  caches (slow once per platform); the next pull request measures the
+  warm path. Record against: pre-caching PR legs ubuntu ~45-50 min,
+  arm64 ~44-45 min, macos ~72-103 min, iOS ~68-97 min, Android
+  ~91-123 min.
+
 ### Interim posture (adopted now)
 The façade stage is COMPLETE and delivers: uniform `import streamr.<pkg>`
 consumption, −24% clean builds, 250+ tests through import, and module

--- a/install.sh
+++ b/install.sh
@@ -37,11 +37,13 @@ while [[ "$#" -gt 0 ]]; do
         --android) TARGET_TRIPLET="arm64-android"; CHAINLOAD_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake";;
         # Skip the per-package standalone builds and build only the root
         # tree (MODERNIZATION.md "After the consolidation: CI speed"). The
-        # standalone builds validate that each package still works as an
-        # independent vcpkg-style unit — that check is host-independent, so
-        # CI runs it on the macOS leg only; the other host legs pass this
-        # flag. Not allowed with --ios: the XCFramework is assembled from
-        # the per-package build outputs.
+        # root tree is self-contained — sibling find_package calls are
+        # guarded with if(NOT TARGET ...) in the package CMakeLists — so no
+        # standalone build dirs are needed. The full standalone build
+        # validates that each package works as an independent vcpkg-style
+        # unit; that check is host-independent, so CI runs it on the macOS
+        # leg only and the other host legs pass this flag. Not allowed with
+        # --ios: the XCFramework is assembled from the per-package outputs.
         --no-standalone) STANDALONE_PACKAGES=false ;;
         *) echo "Unknown parameter passed: $1. Usage: ./install.sh [--prod] [--ios] [--android] [--no-standalone]"; exit 1 ;;
     esac

--- a/install.sh
+++ b/install.sh
@@ -28,15 +28,30 @@ PLATFORM=""
 ANDROID_ABI="arm64-v8a"
 ANDROID_PLATFORM=24
 
+STANDALONE_PACKAGES=true
+
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --prod) PROD_BUILD=true ;;
         --ios) TARGET_TRIPLET="arm64-ios"; CHAINLOAD_TOOLCHAIN_FILE="$(pwd)/overlaytriplets/arm64-ios.cmake"; PLATFORM="OS64"; CREATE_XCFRAMEWORK=true ;;
         --android) TARGET_TRIPLET="arm64-android"; CHAINLOAD_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake";;
-        *) echo "Unknown parameter passed: $1. Usage: ./install.sh [--prod] [--ios] [--android]"; exit 1 ;;
+        # Skip the per-package standalone builds and build only the root
+        # tree (MODERNIZATION.md "After the consolidation: CI speed"). The
+        # standalone builds validate that each package still works as an
+        # independent vcpkg-style unit — that check is host-independent, so
+        # CI runs it on the macOS leg only; the other host legs pass this
+        # flag. Not allowed with --ios: the XCFramework is assembled from
+        # the per-package build outputs.
+        --no-standalone) STANDALONE_PACKAGES=false ;;
+        *) echo "Unknown parameter passed: $1. Usage: ./install.sh [--prod] [--ios] [--android] [--no-standalone]"; exit 1 ;;
     esac
     shift
 done
+
+if [ "$STANDALONE_PACKAGES" = false ] && [ "$TARGET_TRIPLET" = "arm64-ios" ]; then
+    echo "Error: --no-standalone cannot be combined with --ios (the XCFramework is built from the per-package outputs)."
+    exit 1
+fi
 
 # Set build type based on the --prod flag
 if [ "$PROD_BUILD" = true ]; then
@@ -61,6 +76,7 @@ else
 fi
 
 # Call build for all monorepo packages in their own build directories
+if [ "$STANDALONE_PACKAGES" = true ]; then
 for package in $(cat MonorepoPackages.cmake | grep -v "set(MonorepoPackages" | grep -v ")"); do
     cd packages/$package/build
     if [ -n "$TARGET_TRIPLET" ]; then
@@ -85,6 +101,7 @@ for package in $(cat MonorepoPackages.cmake | grep -v "set(MonorepoPackages" | g
     fi
     cd ../../..
 done
+fi
 
 # Call build for the root project
 echo "Building root project"

--- a/packages/streamr-dht/CMakeLists.txt
+++ b/packages/streamr-dht/CMakeLists.txt
@@ -22,10 +22,23 @@ project(dht CXX)
 # add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
 # add_link_options(-fsanitize=address -fno-omit-frame-pointer)
 
-find_package(streamr-utils CONFIG REQUIRED)
-find_package(streamr-logger CONFIG REQUIRED)
-find_package(streamr-proto-rpc CONFIG REQUIRED)
-find_package(streamr-eventemitter CONFIG REQUIRED)
+# Sibling monorepo packages: find_package only when the target is not
+# already in this build tree (in the root single-tree build the sibling
+# was added via add_subdirectory — the guard makes the root tree
+# self-contained, so it configures without the standalone per-package
+# build dirs; MODERNIZATION.md "After the consolidation: CI speed").
+if(NOT TARGET streamr::streamr-utils)
+    find_package(streamr-utils CONFIG REQUIRED)
+endif()
+if(NOT TARGET streamr::streamr-logger)
+    find_package(streamr-logger CONFIG REQUIRED)
+endif()
+if(NOT TARGET streamr::streamr-proto-rpc)
+    find_package(streamr-proto-rpc CONFIG REQUIRED)
+endif()
+if(NOT TARGET streamr::streamr-eventemitter)
+    find_package(streamr-eventemitter CONFIG REQUIRED)
+endif()
 find_package(Protobuf REQUIRED)
 find_package(Boost CONFIG REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)

--- a/packages/streamr-dht/lint.sh
+++ b/packages/streamr-dht/lint.sh
@@ -3,6 +3,15 @@
 set -e
 
 FILES=$(find . -type d \( -name src -o -name test -o -name include \) ! -path '*/build/*' ! -path '*/proto/*' -print0 | xargs -0 -I{} find {} -type f \( -name "*.hpp" -o -name "*.cpp" \) -print0 | xargs -0 echo)
+# Compile database: the standalone build dir when present, else the root
+# tree's (the Linux CI legs skip the standalone builds — MODERNIZATION.md
+# "After the consolidation: CI speed" — and lint against the root tree,
+# which compiles the same sources).
+COMPILE_DB=./build
+if [ ! -f ./build/compile_commands.json ]; then
+    COMPILE_DB=../../build
+fi
+
 echo "Running clangd-tidy on $FILES"
 
 # ConnectionLockingTest.cpp is excluded from clangd-tidy (owner-approved
@@ -16,7 +25,7 @@ echo "Running clangd-tidy on $FILES"
 # unification false positive (spurious std::string-vs-std::string
 # mismatch). The compiler accepts and runs the file on every platform.
 TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/integration/ConnectionLockingTest.cpp' | grep -v 'test/unit/PendingConnectionTest.cpp' | tr '\n' ' ')
-clangd-tidy -p ./build $TIDY_FILES
+clangd-tidy -p "$COMPILE_DB" $TIDY_FILES
 
 echo "Running clang-format --dry-run on $FILES"
 ../../run-clang-format.py $FILES
@@ -32,7 +41,7 @@ echo "Running clang-format --dry-run on $FILES"
 MODULE_FILES=$(find ./modules -type f -name "*.cppm" ! -path './modules/gen/*' 2>/dev/null | xargs echo)
 if [ -n "$MODULE_FILES" ]; then
     echo "Running clangd-tidy on $MODULE_FILES"
-    clangd-tidy -p ./build $MODULE_FILES
+    clangd-tidy -p "$COMPILE_DB" $MODULE_FILES
 
     echo "Running clang-format --dry-run on $MODULE_FILES"
     ../../run-clang-format.py $MODULE_FILES

--- a/packages/streamr-eventemitter/lint.sh
+++ b/packages/streamr-eventemitter/lint.sh
@@ -3,9 +3,18 @@
 set -e
 
 FILES=$(find . -type d \( -name src -o -name include -o -name test \) ! -path '*/build/*' ! -path '*/proto/*' -print0 | xargs -0 -I{} find {} -type f \( -name "*.hpp" -o -name "*.cpp" \) -print0 | xargs -0 echo)
+# Compile database: the standalone build dir when present, else the root
+# tree's (the Linux CI legs skip the standalone builds — MODERNIZATION.md
+# "After the consolidation: CI speed" — and lint against the root tree,
+# which compiles the same sources).
+COMPILE_DB=./build
+if [ ! -f ./build/compile_commands.json ]; then
+    COMPILE_DB=../../build
+fi
+
 echo "Running clangd-tidy on $FILES"
 
-clangd-tidy -p ./build $FILES
+clangd-tidy -p "$COMPILE_DB" $FILES
 
 echo "Running clang-format --dry-run on $FILES"
 ../../run-clang-format.py $FILES
@@ -16,7 +25,7 @@ echo "Running clang-format --dry-run on $FILES"
 MODULE_FILES=$(find ./modules -type f -name "*.cppm" 2>/dev/null | xargs echo)
 if [ -n "$MODULE_FILES" ]; then
     echo "Running clangd-tidy on $MODULE_FILES"
-    clangd-tidy -p ./build $MODULE_FILES
+    clangd-tidy -p "$COMPILE_DB" $MODULE_FILES
 
     echo "Running clang-format --dry-run on $MODULE_FILES"
     ../../run-clang-format.py $MODULE_FILES

--- a/packages/streamr-json/lint.sh
+++ b/packages/streamr-json/lint.sh
@@ -3,9 +3,18 @@
 set -e
 
 FILES=$(find . -type d \( -name src -o -name include -o -name test \) ! -path '*/build/*' ! -path '*/proto/*' -print0 | xargs -0 -I{} find {} -type f \( -name "*.hpp" -o -name "*.cpp" \) -print0 | xargs -0 echo)
+# Compile database: the standalone build dir when present, else the root
+# tree's (the Linux CI legs skip the standalone builds — MODERNIZATION.md
+# "After the consolidation: CI speed" — and lint against the root tree,
+# which compiles the same sources).
+COMPILE_DB=./build
+if [ ! -f ./build/compile_commands.json ]; then
+    COMPILE_DB=../../build
+fi
+
 echo "Running clangd-tidy on $FILES"
 
-clangd-tidy -p ./build $FILES
+clangd-tidy -p "$COMPILE_DB" $FILES
 
 echo "Running clang-format --dry-run on $FILES"
 ../../run-clang-format.py $FILES
@@ -16,7 +25,7 @@ echo "Running clang-format --dry-run on $FILES"
 MODULE_FILES=$(find ./modules -type f -name "*.cppm" 2>/dev/null | xargs echo)
 if [ -n "$MODULE_FILES" ]; then
     echo "Running clangd-tidy on $MODULE_FILES"
-    clangd-tidy -p ./build $MODULE_FILES
+    clangd-tidy -p "$COMPILE_DB" $MODULE_FILES
 
     echo "Running clang-format --dry-run on $MODULE_FILES"
     ../../run-clang-format.py $MODULE_FILES

--- a/packages/streamr-libstreamrproxyclient/CMakeLists.txt
+++ b/packages/streamr-libstreamrproxyclient/CMakeLists.txt
@@ -41,10 +41,23 @@ add_library(streamrproxyclient SHARED
 streamr_enable_imports(streamrproxyclient)
 
 set_target_properties(streamrproxyclient PROPERTIES VERSION ${SHAREDLIB_VERSION} SOVERSION ${SHAREDLIB_SOVERSION})
-find_package(streamr-trackerless-network CONFIG REQUIRED)
-find_package(streamr-dht CONFIG REQUIRED)
-find_package(streamr-logger CONFIG REQUIRED)
-find_package(streamr-utils CONFIG REQUIRED)
+# Sibling monorepo packages: find_package only when the target is not
+# already in this build tree (in the root single-tree build the sibling
+# was added via add_subdirectory — the guard makes the root tree
+# self-contained, so it configures without the standalone per-package
+# build dirs; MODERNIZATION.md "After the consolidation: CI speed").
+if(NOT TARGET streamr::streamr-trackerless-network)
+    find_package(streamr-trackerless-network CONFIG REQUIRED)
+endif()
+if(NOT TARGET streamr::streamr-dht)
+    find_package(streamr-dht CONFIG REQUIRED)
+endif()
+if(NOT TARGET streamr::streamr-logger)
+    find_package(streamr-logger CONFIG REQUIRED)
+endif()
+if(NOT TARGET streamr::streamr-utils)
+    find_package(streamr-utils CONFIG REQUIRED)
+endif()
 find_package(ada CONFIG REQUIRED)
 
 target_include_directories(streamrproxyclient PUBLIC include)

--- a/packages/streamr-libstreamrproxyclient/CMakeLists.txt
+++ b/packages/streamr-libstreamrproxyclient/CMakeLists.txt
@@ -28,6 +28,14 @@ set (ANDROID_LIBRARY_VERSION ${STREAMRPROXYCLIENT_VERSION})
 
 project(streamr-streamrproxyclient CXX)
 
+# The library target links Folly::folly directly, so find it HERE,
+# unconditionally: it used to arrive only as a side effect of the
+# sibling packages' export configs (which run find_package(folly)), and
+# on iOS the test block below — which also finds folly — is skipped.
+# With the sibling find_package calls guarded out in the root
+# single-tree build, this file must find its own direct dependencies.
+find_package(folly CONFIG REQUIRED)
+
 # C++ modules support (guards, policies, helpers) — must come after
 # project() because it inspects the compiler id.
 include(${CMAKE_CURRENT_SOURCE_DIR}/StreamrModules.cmake)

--- a/packages/streamr-libstreamrproxyclient/lint.sh
+++ b/packages/streamr-libstreamrproxyclient/lint.sh
@@ -3,6 +3,15 @@
 set -e
 
 FILES=$(find . -type d \( -name src -o -name include -o -name test \) ! -path '*/build/*' ! -path '*/android/*' ! -path '*/android-library-module/*' ! -path '*/ios/*' ! -path '*/proto/*' -print0 | xargs -0 -I{} find {} -type f \( -name "*.hpp" -o -name "*.cpp" \) -print0 | xargs -0 echo)
+# Compile database: the standalone build dir when present, else the root
+# tree's (the Linux CI legs skip the standalone builds — MODERNIZATION.md
+# "After the consolidation: CI speed" — and lint against the root tree,
+# which compiles the same sources).
+COMPILE_DB=./build
+if [ ! -f ./build/compile_commands.json ]; then
+    COMPILE_DB=../../build
+fi
+
 echo "Running clangd-tidy on $FILES"
 
 # src/streamrproxyclient.cpp is excluded from clangd-tidy
@@ -14,7 +23,7 @@ echo "Running clangd-tidy on $FILES"
 # platform and clang-format still checks it; revisit when CI runners
 # grow or clangd's module memory use shrinks.
 TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'src/streamrproxyclient.cpp' | tr '\n' ' ')
-clangd-tidy -j 1 -p ./build $TIDY_FILES
+clangd-tidy -j 1 -p "$COMPILE_DB" $TIDY_FILES
 
 echo "Running clang-format --dry-run on $FILES"
 ../../run-clang-format.py $FILES

--- a/packages/streamr-logger/CMakeLists.txt
+++ b/packages/streamr-logger/CMakeLists.txt
@@ -56,27 +56,32 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
   streamr_enable_imports(env_category_tests)
   target_link_libraries(env_category_tests PRIVATE streamr-logger)
   enable_testing()
+  # COMMAND by target name: resolves to the binary built in THIS tree —
+  # correct in both the root single-tree build and the standalone build.
+  # (The former hard-coded ${CMAKE_CURRENT_LIST_DIR}/build/... path made
+  # the root-tree ctest silently run the STANDALONE binary; surfaced by
+  # the --no-standalone CI legs, which have no standalone dirs.)
   add_test(
     NAME env_category_fatal_and_info_log_test
-    COMMAND "${CMAKE_CURRENT_LIST_DIR}/build/env_category_tests" 1
+    COMMAND env_category_tests 1
   )
   set_property(TEST env_category_fatal_and_info_log_test PROPERTY ENVIRONMENT "LOG_LEVEL_test=fatal")
 
   add_test(
     NAME env_category_fatal_and_fatal_log_test
-    COMMAND "${CMAKE_CURRENT_LIST_DIR}/build/env_category_tests" 2
+    COMMAND env_category_tests 2
   )
   set_property(TEST env_category_fatal_and_fatal_log_test PROPERTY ENVIRONMENT "LOG_LEVEL_test=fatal")
 
   add_test(
     NAME env_category_fatal_and_error_log_test
-    COMMAND "${CMAKE_CURRENT_LIST_DIR}/build/env_category_tests" 3
+    COMMAND env_category_tests 3
   )
   set_property(TEST env_category_fatal_and_error_log_test PROPERTY ENVIRONMENT "LOG_LEVEL_test=fatal")
 
   add_test(
     NAME env_category_wrongly_written_as_fatal_and_info_log_test
-    COMMAND "${CMAKE_CURRENT_LIST_DIR}/build/env_category_tests" 4
+    COMMAND env_category_tests 4
   )
   set_property(TEST env_category_wrongly_written_as_fatal_and_info_log_test PROPERTY ENVIRONMENT "LOG_LEVEL=\"\"")
 endif()

--- a/packages/streamr-logger/CMakeLists.txt
+++ b/packages/streamr-logger/CMakeLists.txt
@@ -21,7 +21,14 @@ project(logger CXX)
 
 set(CMAKE_FIND_USE_PACKAGE_ROOT_PATH ON)
 find_package(folly CONFIG REQUIRED)
-find_package(streamr-json CONFIG REQUIRED)
+# Sibling monorepo packages: find_package only when the target is not
+# already in this build tree (in the root single-tree build the sibling
+# was added via add_subdirectory — the guard makes the root tree
+# self-contained, so it configures without the standalone per-package
+# build dirs; MODERNIZATION.md "After the consolidation: CI speed").
+if(NOT TARGET streamr::streamr-json)
+    find_package(streamr-json CONFIG REQUIRED)
+endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/packages/streamr-logger/lint.sh
+++ b/packages/streamr-logger/lint.sh
@@ -3,9 +3,18 @@
 set -e
 
 FILES=$(find . -type d \( -name src -o -name include -o -name test \) ! -path '*/build/*' ! -path '*/proto/*' -print0 | xargs -0 -I{} find {} -type f \( -name "*.hpp" -o -name "*.cpp" \) -print0 | xargs -0 echo)
+# Compile database: the standalone build dir when present, else the root
+# tree's (the Linux CI legs skip the standalone builds — MODERNIZATION.md
+# "After the consolidation: CI speed" — and lint against the root tree,
+# which compiles the same sources).
+COMPILE_DB=./build
+if [ ! -f ./build/compile_commands.json ]; then
+    COMPILE_DB=../../build
+fi
+
 echo "Running clangd-tidy on $FILES"
 
-clangd-tidy -p ./build $FILES
+clangd-tidy -p "$COMPILE_DB" $FILES
 
 echo "Running clang-format --dry-run on $FILES"
 ../../run-clang-format.py $FILES
@@ -16,7 +25,7 @@ echo "Running clang-format --dry-run on $FILES"
 MODULE_FILES=$(find ./modules -type f -name "*.cppm" 2>/dev/null | xargs echo)
 if [ -n "$MODULE_FILES" ]; then
     echo "Running clangd-tidy on $MODULE_FILES"
-    clangd-tidy -p ./build $MODULE_FILES
+    clangd-tidy -p "$COMPILE_DB" $MODULE_FILES
 
     echo "Running clang-format --dry-run on $MODULE_FILES"
     ../../run-clang-format.py $MODULE_FILES

--- a/packages/streamr-proto-rpc/CMakeLists.txt
+++ b/packages/streamr-proto-rpc/CMakeLists.txt
@@ -18,9 +18,20 @@ set (VCPKG_OVERLAY_TRIPLETS ENV{VCPKG_OVERLAY_TRIPLETS})
 set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
 
 project(proto-rpc CXX)
-find_package(streamr-logger CONFIG REQUIRED)
-find_package(streamr-eventemitter CONFIG REQUIRED)
-find_package(streamr-utils CONFIG REQUIRED)
+# Sibling monorepo packages: find_package only when the target is not
+# already in this build tree (in the root single-tree build the sibling
+# was added via add_subdirectory — the guard makes the root tree
+# self-contained, so it configures without the standalone per-package
+# build dirs; MODERNIZATION.md "After the consolidation: CI speed").
+if(NOT TARGET streamr::streamr-logger)
+    find_package(streamr-logger CONFIG REQUIRED)
+endif()
+if(NOT TARGET streamr::streamr-eventemitter)
+    find_package(streamr-eventemitter CONFIG REQUIRED)
+endif()
+if(NOT TARGET streamr::streamr-utils)
+    find_package(streamr-utils CONFIG REQUIRED)
+endif()
 find_package(Protobuf REQUIRED)
 find_package(Boost CONFIG REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)

--- a/packages/streamr-proto-rpc/lint.sh
+++ b/packages/streamr-proto-rpc/lint.sh
@@ -3,6 +3,15 @@
 set -e
 
 FILES=$(find . -type d \( -name src -o -name include -o -name test \) ! -path '*/build/*' ! -path '*/proto/*' -print0 | xargs -0 -I{} find {} -type f \( -name "*.hpp" -o -name "*.cpp" \) ! -name "PluginCodeGenerator.hpp" -print0 | xargs -0 echo)
+# Compile database: the standalone build dir when present, else the root
+# tree's (the Linux CI legs skip the standalone builds — MODERNIZATION.md
+# "After the consolidation: CI speed" — and lint against the root tree,
+# which compiles the same sources).
+COMPILE_DB=./build
+if [ ! -f ./build/compile_commands.json ]; then
+    COMPILE_DB=../../build
+fi
+
 echo "Running clangd-tidy on $FILES"
 
 # test/unit/RpcCommunicatorTest.cpp is excluded from clangd-tidy
@@ -16,7 +25,7 @@ echo "Running clangd-tidy on $FILES"
 # accepts the file, and the COMPILER accepts it on every platform;
 # clang-format still checks it. Revisit on each clangd release.
 TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/unit/RpcCommunicatorTest.cpp' | tr '\n' ' ')
-clangd-tidy -p ./build $TIDY_FILES
+clangd-tidy -p "$COMPILE_DB" $TIDY_FILES
 
 echo "Running clang-format --dry-run on $FILES"
 ../../run-clang-format.py $FILES
@@ -29,7 +38,7 @@ echo "Running clang-format --dry-run on $FILES"
 MODULE_FILES=$(find ./modules -type f -name "*.cppm" 2>/dev/null | xargs echo)
 if [ -n "$MODULE_FILES" ]; then
     echo "Running clangd-tidy on $MODULE_FILES"
-    clangd-tidy -p ./build $MODULE_FILES
+    clangd-tidy -p "$COMPILE_DB" $MODULE_FILES
 
     echo "Running clang-format --dry-run on $MODULE_FILES"
     ../../run-clang-format.py $MODULE_FILES

--- a/packages/streamr-trackerless-network/CMakeLists.txt
+++ b/packages/streamr-trackerless-network/CMakeLists.txt
@@ -19,11 +19,26 @@ set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
 
 project(trackerless-network CXX)
 
-find_package(streamr-utils CONFIG REQUIRED)
-find_package(streamr-logger CONFIG REQUIRED)
-find_package(streamr-proto-rpc CONFIG REQUIRED)
-find_package(streamr-eventemitter CONFIG REQUIRED)
-find_package(streamr-dht CONFIG REQUIRED)
+# Sibling monorepo packages: find_package only when the target is not
+# already in this build tree (in the root single-tree build the sibling
+# was added via add_subdirectory — the guard makes the root tree
+# self-contained, so it configures without the standalone per-package
+# build dirs; MODERNIZATION.md "After the consolidation: CI speed").
+if(NOT TARGET streamr::streamr-utils)
+    find_package(streamr-utils CONFIG REQUIRED)
+endif()
+if(NOT TARGET streamr::streamr-logger)
+    find_package(streamr-logger CONFIG REQUIRED)
+endif()
+if(NOT TARGET streamr::streamr-proto-rpc)
+    find_package(streamr-proto-rpc CONFIG REQUIRED)
+endif()
+if(NOT TARGET streamr::streamr-eventemitter)
+    find_package(streamr-eventemitter CONFIG REQUIRED)
+endif()
+if(NOT TARGET streamr::streamr-dht)
+    find_package(streamr-dht CONFIG REQUIRED)
+endif()
 find_package(Protobuf REQUIRED)
 find_package(Boost CONFIG REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)

--- a/packages/streamr-trackerless-network/lint.sh
+++ b/packages/streamr-trackerless-network/lint.sh
@@ -5,8 +5,17 @@ set -e
 SRCFILES=$(find src -type f \( -name "*.hpp" -o -name "*.cpp" \) -not -path '*/proto/*' | sort | uniq | tr '\n' ' ')
 
 if [ -n "$SRCFILES" ]; then
-    echo "Running clangd-tidy on $SRCFILES"
-    clangd-tidy -p ./build $SRCFILES
+    # Compile database: the standalone build dir when present, else the root
+# tree's (the Linux CI legs skip the standalone builds — MODERNIZATION.md
+# "After the consolidation: CI speed" — and lint against the root tree,
+# which compiles the same sources).
+COMPILE_DB=./build
+if [ ! -f ./build/compile_commands.json ]; then
+    COMPILE_DB=../../build
+fi
+
+echo "Running clangd-tidy on $SRCFILES"
+    clangd-tidy -p "$COMPILE_DB" $SRCFILES
 
     echo "Running clang-format --dry-run on $SRCFILES"
     ../../run-clang-format.py $SRCFILES
@@ -15,7 +24,7 @@ fi
 TESTFILES=$(find test -type f \( -name "*.hpp" -o -name "*.cpp" \) -not -path '*/ts-integration/*' | sort | uniq | tr '\n' ' ')
 echo "Running clangd-tidy on $TESTFILES"
 
-clangd-tidy -p ./build $TESTFILES
+clangd-tidy -p "$COMPILE_DB" $TESTFILES
 
 echo "Running clang-format --dry-run on $TESTFILES"
 ../../run-clang-format.py $TESTFILES
@@ -31,7 +40,7 @@ echo "Running clang-format --dry-run on $TESTFILES"
 MODULE_FILES=$(find ./modules -type f -name "*.cppm" ! -path './modules/gen/*' 2>/dev/null | xargs echo)
 if [ -n "$MODULE_FILES" ]; then
     echo "Running clangd-tidy on $MODULE_FILES"
-    clangd-tidy -p ./build $MODULE_FILES
+    clangd-tidy -p "$COMPILE_DB" $MODULE_FILES
 
     echo "Running clang-format --dry-run on $MODULE_FILES"
     ../../run-clang-format.py $MODULE_FILES

--- a/packages/streamr-utils/CMakeLists.txt
+++ b/packages/streamr-utils/CMakeLists.txt
@@ -23,8 +23,17 @@ project(streamr-utils CXX)
 find_package(folly CONFIG REQUIRED)
 find_package(Boost CONFIG REQUIRED)
 find_package(cryptopp CONFIG REQUIRED)
-find_package(streamr-eventemitter CONFIG REQUIRED)
-find_package(streamr-logger CONFIG REQUIRED)
+# Sibling monorepo packages: find_package only when the target is not
+# already in this build tree (in the root single-tree build the sibling
+# was added via add_subdirectory — the guard makes the root tree
+# self-contained, so it configures without the standalone per-package
+# build dirs; MODERNIZATION.md "After the consolidation: CI speed").
+if(NOT TARGET streamr::streamr-eventemitter)
+    find_package(streamr-eventemitter CONFIG REQUIRED)
+endif()
+if(NOT TARGET streamr::streamr-logger)
+    find_package(streamr-logger CONFIG REQUIRED)
+endif()
 
 if(NOT TARGET Boost::uuid)
   add_library(Boost::uuid INTERFACE IMPORTED)

--- a/packages/streamr-utils/lint.sh
+++ b/packages/streamr-utils/lint.sh
@@ -3,6 +3,15 @@
 set -e
 
 FILES=$(find . -type d \( -name src -o -name include -o -name test \) ! -path '*/build/*' ! -path '*/proto/*' -print0 | xargs -0 -I{} find {} -type f \( -name "*.hpp" -o -name "*.cpp" \) -print0 | xargs -0 echo)
+# Compile database: the standalone build dir when present, else the root
+# tree's (the Linux CI legs skip the standalone builds — MODERNIZATION.md
+# "After the consolidation: CI speed" — and lint against the root tree,
+# which compiles the same sources).
+COMPILE_DB=./build
+if [ ! -f ./build/compile_commands.json ]; then
+    COMPILE_DB=../../build
+fi
+
 echo "Running clangd-tidy on $FILES"
 
 # toEthereumAddressOrENSNameTest.cpp: clangd's experimental modules
@@ -12,7 +21,7 @@ echo "Running clangd-tidy on $FILES"
 # matures. The compiler still fully typechecks it on every build and
 # clang-format still covers it.
 TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'toEthereumAddressOrENSNameTest.cpp' | tr '\n' ' ')
-clangd-tidy -p ./build $TIDY_FILES
+clangd-tidy -p "$COMPILE_DB" $TIDY_FILES
 
 echo "Running clang-format --dry-run on $FILES"
 ../../run-clang-format.py $FILES
@@ -23,7 +32,7 @@ echo "Running clang-format --dry-run on $FILES"
 MODULE_FILES=$(find ./modules -type f -name "*.cppm" 2>/dev/null | xargs echo)
 if [ -n "$MODULE_FILES" ]; then
     echo "Running clangd-tidy on $MODULE_FILES"
-    clangd-tidy -p ./build $MODULE_FILES
+    clangd-tidy -p "$COMPILE_DB" $MODULE_FILES
 
     echo "Running clang-format --dry-run on $MODULE_FILES"
     ../../run-clang-format.py $MODULE_FILES


### PR DESCRIPTION
# CI speed: items 1 + 2 of the approved plan

The final step of the modernization work: the two highest-payoff items from the "After the consolidation: CI speed" plan in MODERNIZATION.md, followed by a measurement round.

## Item 1 — stop building the monorepo twice per job

`install.sh` used to build every package standalone **and** the whole root tree, on every leg. The standalone builds validate that each package still works as an independent unit — a host-independent check. Now:

- New `install.sh --no-standalone` flag builds only the root tree. The **ubuntu and linux-arm64 legs** pass it (via a matrix variable in validate.yml).
- The **macOS leg** keeps the full standalone loop as the designated packaging check.
- **iOS** keeps it too, necessarily — the XCFramework is assembled from the per-package outputs (`--no-standalone --ios` is rejected with an explanation).
- Package lint scripts fall back to the **root tree's compile database** when the standalone one is absent (`-p ../../build`), so the Linux legs keep full lint coverage. Verified locally by hiding a package's database and re-running its lint.

## Item 2 — cache the root build tree per platform

The cached-install action now restores the previous root build tree (excluding `vcpkg_installed`, which has its own cache), so Ninja recompiles only what a pull request actually touched — this is where the consolidation's precise module dependency graph pays off in CI.

Two design points worth reviewing:

- **Source mtime restoration.** Ninja decides what to rebuild by comparing source timestamps against the recorded build state, and a fresh checkout stamps every file with checkout time — which would force a full rebuild every time. The action therefore first resets every tracked file's mtime to its *last-change commit time* (one pass over `git log`, a few seconds, verified locally on 703 files). Unchanged files get the same timestamp the saving run recorded; only the pull request's touched files look new.
- **Saved from main-branch runs only.** Pull requests consume the cache, merges publish it. This keeps cache growth to one entry per platform per merge instead of per push, and — the lesson from the corrupted arm64-ios dependency cache — a broken or half-built PR tree can never poison what other runs restore.

The per-package standalone trees are deliberately **not** cached: at roughly 8 × 0.5–1.5 GB per platform they would blow the repository's shared 10 GB actions-cache budget. ccache remains the documented fallback if this approach proves fragile; test-port randomization + parallel ctest remains the one open item.

## Measurement round

This PR's own run is a cold-cache run (nothing saves build trees until it merges). The measurement protocol, recorded in MODERNIZATION.md: the first post-merge main run populates the caches, and the **next pull request** measures the warm path. Baseline to beat (pre-caching PR legs): ubuntu ~45–50 min, linux-arm64 ~44–45 min, macOS ~72–103 min, iOS ~68–97 min, Android ~91–123 min. The Linux legs should already improve on *this* run from item 1 alone (they skip eight standalone builds). I will run and report the warm-path measurements right after the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)