### PR TITLE
Phase 0.2: test-utility foundation

### DIFF
--- a/cmake/StreamrModules.cmake
+++ b/cmake/StreamrModules.cmake
@@ -80,7 +80,9 @@ endif()
 #
 # Defines <target> as a STATIC library whose C++ module interface units are
 # the given files (FILE_SET CXX_MODULES, rooted at the package's modules/
-# directory). STATIC rather than INTERFACE: module interface units are
+# directory unless overridden with BASE_DIRS <dir> — e.g. test-only module
+# units living under test/utils). STATIC rather than INTERFACE: module
+# interface units are
 # compiled TUs, so even a previously header-only package gains a compiled
 # archive when it grows a module.
 #
@@ -88,16 +90,19 @@ endif()
 # as a STATIC library — with a generated stub source instead of module
 # units — so callers can keep using PUBLIC include dirs/links identically.
 function(streamr_add_module_library TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_add_module_library(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     add_library(${TARGET} STATIC)
     if(STREAMR_MODULES_SUPPORTED)
         target_sources(${TARGET}
             PUBLIC
             FILE_SET CXX_MODULES
-            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+            BASE_DIRS ${ARG_BASE_DIRS}
             FILES ${ARG_FILES})
         set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     else()
@@ -136,9 +141,12 @@ endfunction()
 # .cc files). Same effect as streamr_add_module_library() minus the
 # add_library(). No-op where modules are unsupported.
 function(streamr_target_module_sources TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     if(NOT STREAMR_MODULES_SUPPORTED)
         return()
@@ -146,7 +154,7 @@ function(streamr_target_module_sources TARGET)
     target_sources(${TARGET}
         PUBLIC
         FILE_SET CXX_MODULES
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        BASE_DIRS ${ARG_BASE_DIRS}
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)

--- a/packages/streamr-dht/CMakeLists.txt
+++ b/packages/streamr-dht/CMakeLists.txt
@@ -137,6 +137,20 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         PUBLIC GTest::gtest
     )
 
+    # Test-only helpers (mock factories, gtest assertion formatters)
+    # ported from the TS package's test/utils; a module library of its
+    # own so both test targets can import streamr.dht.TestUtils.
+    streamr_add_module_library(streamr-dht-test-utils
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/test/utils
+        FILES ${CMAKE_CURRENT_SOURCE_DIR}/test/utils/TestUtils.cppm)
+    target_include_directories(streamr-dht-test-utils
+        PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/proto>)
+    target_link_libraries(streamr-dht-test-utils
+        PUBLIC streamr-dht
+        PUBLIC streamr::streamr-utils
+        PUBLIC GTest::gtest
+    )
+
     add_executable(streamr-dht-test-unit
         test/unit/WebsocketClientConnectionTest.cpp
         test/unit/WebsocketClientConnectorRpcLocalTest.cpp
@@ -177,6 +191,7 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         test/unit/WebsocketServerConnectionTest.cpp
         test/unit/WebsocketServerTest.cpp
         test/unit/ListeningRpcCommunicatorTest.cpp
+        test/unit/CustomMatchersTest.cpp
     )
 
     target_include_directories(streamr-dht-test-unit
@@ -191,6 +206,7 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
     streamr_enable_imports(streamr-dht-test-unit)
     target_link_libraries(streamr-dht-test-unit
         PUBLIC streamr-dht
+        PUBLIC streamr-dht-test-utils
         PUBLIC streamr::streamr-logger
         PUBLIC streamr::streamr-eventemitter
         PUBLIC streamr::streamr-utils
@@ -214,6 +230,7 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
     streamr_enable_imports(streamr-dht-test-integration)
     target_link_libraries(streamr-dht-test-integration
         PUBLIC streamr-dht
+        PUBLIC streamr-dht-test-utils
         PUBLIC streamr::streamr-logger
         PUBLIC streamr::streamr-eventemitter
         PUBLIC streamr::streamr-utils

--- a/packages/streamr-dht/StreamrModules.cmake
+++ b/packages/streamr-dht/StreamrModules.cmake
@@ -80,7 +80,9 @@ endif()
 #
 # Defines <target> as a STATIC library whose C++ module interface units are
 # the given files (FILE_SET CXX_MODULES, rooted at the package's modules/
-# directory). STATIC rather than INTERFACE: module interface units are
+# directory unless overridden with BASE_DIRS <dir> — e.g. test-only module
+# units living under test/utils). STATIC rather than INTERFACE: module
+# interface units are
 # compiled TUs, so even a previously header-only package gains a compiled
 # archive when it grows a module.
 #
@@ -88,16 +90,19 @@ endif()
 # as a STATIC library — with a generated stub source instead of module
 # units — so callers can keep using PUBLIC include dirs/links identically.
 function(streamr_add_module_library TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_add_module_library(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     add_library(${TARGET} STATIC)
     if(STREAMR_MODULES_SUPPORTED)
         target_sources(${TARGET}
             PUBLIC
             FILE_SET CXX_MODULES
-            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+            BASE_DIRS ${ARG_BASE_DIRS}
             FILES ${ARG_FILES})
         set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     else()
@@ -136,9 +141,12 @@ endfunction()
 # .cc files). Same effect as streamr_add_module_library() minus the
 # add_library(). No-op where modules are unsupported.
 function(streamr_target_module_sources TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     if(NOT STREAMR_MODULES_SUPPORTED)
         return()
@@ -146,7 +154,7 @@ function(streamr_target_module_sources TARGET)
     target_sources(${TARGET}
         PUBLIC
         FILE_SET CXX_MODULES
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        BASE_DIRS ${ARG_BASE_DIRS}
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)

--- a/packages/streamr-dht/test/unit/CustomMatchersTest.cpp
+++ b/packages/streamr-dht/test/unit/CustomMatchersTest.cpp
@@ -1,0 +1,46 @@
+// Ported from packages/dht/test/unit/customMatchers.test.ts
+// (v103.8.0-rc.3). Jest's expect().toEqualPeerDescriptor(...) becomes
+// EXPECT_PRED_FORMAT2 with the assertion formatters from
+// streamr.dht.TestUtils; jest's .toThrow(message) checks on the matcher
+// become EXPECT_NONFATAL_FAILURE substring checks.
+#include <gtest/gtest-spi.h>
+#include <gtest/gtest.h>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+import streamr.dht.TestUtils;
+
+using streamr::dht::testutils::assertEqualPeerDescriptors;
+using streamr::dht::testutils::assertNotEqualPeerDescriptors;
+using streamr::dht::testutils::createMockPeerDescriptor;
+
+TEST(CustomMatchers, HappyPath) {
+    auto peerDescriptor = createMockPeerDescriptor();
+    peerDescriptor.mutable_websocket()->set_port(1);
+    peerDescriptor.mutable_websocket()->set_host("x");
+    peerDescriptor.mutable_websocket()->set_tls(true);
+    const auto copy = peerDescriptor;
+    EXPECT_PRED_FORMAT2(assertEqualPeerDescriptors, peerDescriptor, copy);
+}
+
+TEST(CustomMatchers, NoMatch) {
+    EXPECT_PRED_FORMAT2(
+        assertNotEqualPeerDescriptors,
+        createMockPeerDescriptor(),
+        createMockPeerDescriptor());
+}
+
+TEST(CustomMatchers, ErrorMessageNormal) {
+    const auto actual = createMockPeerDescriptor();
+    const auto expected = createMockPeerDescriptor();
+    EXPECT_NONFATAL_FAILURE(
+        EXPECT_PRED_FORMAT2(assertEqualPeerDescriptors, expected, actual),
+        "PeerDescriptor nodeId values don't match");
+}
+
+TEST(CustomMatchers, ErrorMessageInverse) {
+    const auto peerDescriptor = createMockPeerDescriptor();
+    EXPECT_NONFATAL_FAILURE(
+        EXPECT_PRED_FORMAT2(
+            assertNotEqualPeerDescriptors, peerDescriptor, peerDescriptor),
+        "PeerDescriptors are equal");
+}

--- a/packages/streamr-dht/test/utils/TestUtils.cppm
+++ b/packages/streamr-dht/test/utils/TestUtils.cppm
@@ -1,0 +1,191 @@
+// Module streamr.dht.TestUtils
+// Test-only helpers shared by this package's test targets. Ported from
+// packages/dht/test/utils/utils.ts and packages/dht/test/utils/
+// customMatchers.ts (v103.8.0-rc.3); only the small factories the
+// current tests need are here — the larger ones (createMockConnection-
+// DhtNode etc.) are ported by the plan phase that first needs them
+// (trackerless-network-completion-plan.md, phase 0.2).
+module;
+
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+#include "packages/dht/protos/DhtRpc.pb.h"
+#include "packages/proto-rpc/protos/ProtoRpc.pb.h"
+
+export module streamr.dht.TestUtils;
+
+import streamr.dht.Identifiers;
+import streamr.utils.Uuid;
+
+using streamr::utils::Uuid;
+
+export namespace streamr::dht::testutils {
+
+using ::dht::ClosestPeersRequest;
+using ::dht::ConnectivityMethod;
+using ::dht::NodeType;
+using ::dht::PeerDescriptor;
+using ::protorpc::RpcMessage;
+
+// Ported from createMockPeerDescriptor() (test/utils/utils.ts). The TS
+// version merges a Partial<PeerDescriptor> over the defaults; in C++ the
+// caller mutates the returned descriptor instead.
+inline PeerDescriptor createMockPeerDescriptor() {
+    PeerDescriptor descriptor;
+    descriptor.set_nodeid(
+        Identifiers::getRawFromDhtAddress(
+            Identifiers::createRandomDhtAddress()));
+    descriptor.set_type(NodeType::NODEJS);
+    return descriptor;
+}
+
+// Ported from createWrappedClosestPeersRequest() (test/utils/utils.ts).
+inline RpcMessage createWrappedClosestPeersRequest(
+    const PeerDescriptor& sourceDescriptor) {
+    ClosestPeersRequest routedMessage;
+    routedMessage.set_nodeid(sourceDescriptor.nodeid());
+    routedMessage.set_requestid(Uuid::v4());
+
+    RpcMessage rpcWrapper;
+    rpcWrapper.mutable_body()->PackFrom(routedMessage);
+    (*rpcWrapper.mutable_header())["method"] = "closestPeersRequest";
+    (*rpcWrapper.mutable_header())["request"] = "request";
+    rpcWrapper.set_requestid(Uuid::v4());
+    return rpcWrapper;
+}
+
+// Ported from customMatchers.ts. Jest extends expect() with
+// toEqualPeerDescriptor; the gtest equivalent is a predicate-formatter
+// used through EXPECT_PRED_FORMAT2, which produces the same per-field
+// failure messages. (Not EXPECT_TRUE(result) on an AssertionResult:
+// see the clangd note in ConnectionLockStatesTest.cpp.)
+namespace detail {
+
+inline std::string formErrorMessage(
+    const std::string& field,
+    const std::string& expected,
+    const std::string& actual) {
+    return "PeerDescriptor " + field +
+        " values don't match:\nExpected: " + expected + "\nReceived: " + actual;
+}
+
+inline std::string toOutput(bool present, const ConnectivityMethod& method) {
+    if (!present) {
+        return "undefined";
+    }
+    std::ostringstream output;
+    output << "{port: " << method.port() << ", host: '" << method.host()
+           << "', tls: " << (method.tls() ? "true" : "false") << "}";
+    return output.str();
+}
+
+inline void expectEqualConnectivityMethod(
+    const std::string& field,
+    bool expectedPresent,
+    const ConnectivityMethod& expected,
+    bool actualPresent,
+    const ConnectivityMethod& actual,
+    std::vector<std::string>& messages) {
+    const bool equal = (expectedPresent == actualPresent) &&
+        (!expectedPresent ||
+         (expected.port() == actual.port() &&
+          expected.host() == actual.host() && expected.tls() == actual.tls()));
+    if (!equal) {
+        messages.push_back(formErrorMessage(
+            field,
+            toOutput(expectedPresent, expected),
+            toOutput(actualPresent, actual)));
+    }
+}
+
+inline std::vector<std::string> collectPeerDescriptorDifferences(
+    const PeerDescriptor& expected, const PeerDescriptor& actual) {
+    std::vector<std::string> messages;
+    if (expected.nodeid() != actual.nodeid()) {
+        messages.push_back(formErrorMessage(
+            "nodeId",
+            Identifiers::getDhtAddressFromRaw(DhtAddressRaw{expected.nodeid()}),
+            Identifiers::getDhtAddressFromRaw(DhtAddressRaw{actual.nodeid()})));
+    }
+    if (expected.type() != actual.type()) {
+        const auto typeName = [](NodeType type) -> std::string {
+            return type == NodeType::NODEJS ? "NODEJS" : "BROWSER";
+        };
+        messages.push_back(formErrorMessage(
+            "type", typeName(expected.type()), typeName(actual.type())));
+    }
+    expectEqualConnectivityMethod(
+        "udp",
+        expected.has_udp(),
+        expected.udp(),
+        actual.has_udp(),
+        actual.udp(),
+        messages);
+    expectEqualConnectivityMethod(
+        "tcp",
+        expected.has_tcp(),
+        expected.tcp(),
+        actual.has_tcp(),
+        actual.tcp(),
+        messages);
+    expectEqualConnectivityMethod(
+        "websocket",
+        expected.has_websocket(),
+        expected.websocket(),
+        actual.has_websocket(),
+        actual.websocket(),
+        messages);
+    if (expected.region() != actual.region()) {
+        messages.push_back(formErrorMessage(
+            "region",
+            std::to_string(expected.region()),
+            std::to_string(actual.region())));
+    }
+    return messages;
+}
+
+inline std::string joinMessages(const std::vector<std::string>& messages) {
+    std::string joined;
+    for (const auto& message : messages) {
+        if (!joined.empty()) {
+            joined += "\n\n";
+        }
+        joined += message;
+    }
+    return joined;
+}
+
+} // namespace detail
+
+// Usage: EXPECT_PRED_FORMAT2(assertEqualPeerDescriptors, expected, actual)
+inline testing::AssertionResult assertEqualPeerDescriptors(
+    const char* /*expectedExpression*/,
+    const char* /*actualExpression*/,
+    const PeerDescriptor& expected,
+    const PeerDescriptor& actual) {
+    const auto messages =
+        detail::collectPeerDescriptorDifferences(expected, actual);
+    if (!messages.empty()) {
+        return testing::AssertionFailure() << detail::joinMessages(messages);
+    }
+    return testing::AssertionSuccess();
+}
+
+// The equivalent of jest's .not.toEqualPeerDescriptor(...).
+inline testing::AssertionResult assertNotEqualPeerDescriptors(
+    const char* /*expectedExpression*/,
+    const char* /*actualExpression*/,
+    const PeerDescriptor& expected,
+    const PeerDescriptor& actual) {
+    const auto messages =
+        detail::collectPeerDescriptorDifferences(expected, actual);
+    if (messages.empty()) {
+        return testing::AssertionFailure() << "PeerDescriptors are equal";
+    }
+    return testing::AssertionSuccess();
+}
+
+} // namespace streamr::dht::testutils

--- a/packages/streamr-eventemitter/StreamrModules.cmake
+++ b/packages/streamr-eventemitter/StreamrModules.cmake
@@ -80,7 +80,9 @@ endif()
 #
 # Defines <target> as a STATIC library whose C++ module interface units are
 # the given files (FILE_SET CXX_MODULES, rooted at the package's modules/
-# directory). STATIC rather than INTERFACE: module interface units are
+# directory unless overridden with BASE_DIRS <dir> — e.g. test-only module
+# units living under test/utils). STATIC rather than INTERFACE: module
+# interface units are
 # compiled TUs, so even a previously header-only package gains a compiled
 # archive when it grows a module.
 #
@@ -88,16 +90,19 @@ endif()
 # as a STATIC library — with a generated stub source instead of module
 # units — so callers can keep using PUBLIC include dirs/links identically.
 function(streamr_add_module_library TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_add_module_library(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     add_library(${TARGET} STATIC)
     if(STREAMR_MODULES_SUPPORTED)
         target_sources(${TARGET}
             PUBLIC
             FILE_SET CXX_MODULES
-            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+            BASE_DIRS ${ARG_BASE_DIRS}
             FILES ${ARG_FILES})
         set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     else()
@@ -136,9 +141,12 @@ endfunction()
 # .cc files). Same effect as streamr_add_module_library() minus the
 # add_library(). No-op where modules are unsupported.
 function(streamr_target_module_sources TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     if(NOT STREAMR_MODULES_SUPPORTED)
         return()
@@ -146,7 +154,7 @@ function(streamr_target_module_sources TARGET)
     target_sources(${TARGET}
         PUBLIC
         FILE_SET CXX_MODULES
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        BASE_DIRS ${ARG_BASE_DIRS}
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)

--- a/packages/streamr-json/StreamrModules.cmake
+++ b/packages/streamr-json/StreamrModules.cmake
@@ -80,7 +80,9 @@ endif()
 #
 # Defines <target> as a STATIC library whose C++ module interface units are
 # the given files (FILE_SET CXX_MODULES, rooted at the package's modules/
-# directory). STATIC rather than INTERFACE: module interface units are
+# directory unless overridden with BASE_DIRS <dir> — e.g. test-only module
+# units living under test/utils). STATIC rather than INTERFACE: module
+# interface units are
 # compiled TUs, so even a previously header-only package gains a compiled
 # archive when it grows a module.
 #
@@ -88,16 +90,19 @@ endif()
 # as a STATIC library — with a generated stub source instead of module
 # units — so callers can keep using PUBLIC include dirs/links identically.
 function(streamr_add_module_library TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_add_module_library(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     add_library(${TARGET} STATIC)
     if(STREAMR_MODULES_SUPPORTED)
         target_sources(${TARGET}
             PUBLIC
             FILE_SET CXX_MODULES
-            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+            BASE_DIRS ${ARG_BASE_DIRS}
             FILES ${ARG_FILES})
         set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     else()
@@ -136,9 +141,12 @@ endfunction()
 # .cc files). Same effect as streamr_add_module_library() minus the
 # add_library(). No-op where modules are unsupported.
 function(streamr_target_module_sources TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     if(NOT STREAMR_MODULES_SUPPORTED)
         return()
@@ -146,7 +154,7 @@ function(streamr_target_module_sources TARGET)
     target_sources(${TARGET}
         PUBLIC
         FILE_SET CXX_MODULES
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        BASE_DIRS ${ARG_BASE_DIRS}
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)

--- a/packages/streamr-libstreamrproxyclient/StreamrModules.cmake
+++ b/packages/streamr-libstreamrproxyclient/StreamrModules.cmake
@@ -80,7 +80,9 @@ endif()
 #
 # Defines <target> as a STATIC library whose C++ module interface units are
 # the given files (FILE_SET CXX_MODULES, rooted at the package's modules/
-# directory). STATIC rather than INTERFACE: module interface units are
+# directory unless overridden with BASE_DIRS <dir> — e.g. test-only module
+# units living under test/utils). STATIC rather than INTERFACE: module
+# interface units are
 # compiled TUs, so even a previously header-only package gains a compiled
 # archive when it grows a module.
 #
@@ -88,16 +90,19 @@ endif()
 # as a STATIC library — with a generated stub source instead of module
 # units — so callers can keep using PUBLIC include dirs/links identically.
 function(streamr_add_module_library TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_add_module_library(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     add_library(${TARGET} STATIC)
     if(STREAMR_MODULES_SUPPORTED)
         target_sources(${TARGET}
             PUBLIC
             FILE_SET CXX_MODULES
-            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+            BASE_DIRS ${ARG_BASE_DIRS}
             FILES ${ARG_FILES})
         set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     else()
@@ -136,9 +141,12 @@ endfunction()
 # .cc files). Same effect as streamr_add_module_library() minus the
 # add_library(). No-op where modules are unsupported.
 function(streamr_target_module_sources TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     if(NOT STREAMR_MODULES_SUPPORTED)
         return()
@@ -146,7 +154,7 @@ function(streamr_target_module_sources TARGET)
     target_sources(${TARGET}
         PUBLIC
         FILE_SET CXX_MODULES
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        BASE_DIRS ${ARG_BASE_DIRS}
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)

--- a/packages/streamr-logger/StreamrModules.cmake
+++ b/packages/streamr-logger/StreamrModules.cmake
@@ -80,7 +80,9 @@ endif()
 #
 # Defines <target> as a STATIC library whose C++ module interface units are
 # the given files (FILE_SET CXX_MODULES, rooted at the package's modules/
-# directory). STATIC rather than INTERFACE: module interface units are
+# directory unless overridden with BASE_DIRS <dir> — e.g. test-only module
+# units living under test/utils). STATIC rather than INTERFACE: module
+# interface units are
 # compiled TUs, so even a previously header-only package gains a compiled
 # archive when it grows a module.
 #
@@ -88,16 +90,19 @@ endif()
 # as a STATIC library — with a generated stub source instead of module
 # units — so callers can keep using PUBLIC include dirs/links identically.
 function(streamr_add_module_library TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_add_module_library(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     add_library(${TARGET} STATIC)
     if(STREAMR_MODULES_SUPPORTED)
         target_sources(${TARGET}
             PUBLIC
             FILE_SET CXX_MODULES
-            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+            BASE_DIRS ${ARG_BASE_DIRS}
             FILES ${ARG_FILES})
         set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     else()
@@ -136,9 +141,12 @@ endfunction()
 # .cc files). Same effect as streamr_add_module_library() minus the
 # add_library(). No-op where modules are unsupported.
 function(streamr_target_module_sources TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     if(NOT STREAMR_MODULES_SUPPORTED)
         return()
@@ -146,7 +154,7 @@ function(streamr_target_module_sources TARGET)
     target_sources(${TARGET}
         PUBLIC
         FILE_SET CXX_MODULES
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        BASE_DIRS ${ARG_BASE_DIRS}
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)

--- a/packages/streamr-proto-rpc/StreamrModules.cmake
+++ b/packages/streamr-proto-rpc/StreamrModules.cmake
@@ -80,7 +80,9 @@ endif()
 #
 # Defines <target> as a STATIC library whose C++ module interface units are
 # the given files (FILE_SET CXX_MODULES, rooted at the package's modules/
-# directory). STATIC rather than INTERFACE: module interface units are
+# directory unless overridden with BASE_DIRS <dir> — e.g. test-only module
+# units living under test/utils). STATIC rather than INTERFACE: module
+# interface units are
 # compiled TUs, so even a previously header-only package gains a compiled
 # archive when it grows a module.
 #
@@ -88,16 +90,19 @@ endif()
 # as a STATIC library — with a generated stub source instead of module
 # units — so callers can keep using PUBLIC include dirs/links identically.
 function(streamr_add_module_library TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_add_module_library(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     add_library(${TARGET} STATIC)
     if(STREAMR_MODULES_SUPPORTED)
         target_sources(${TARGET}
             PUBLIC
             FILE_SET CXX_MODULES
-            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+            BASE_DIRS ${ARG_BASE_DIRS}
             FILES ${ARG_FILES})
         set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     else()
@@ -136,9 +141,12 @@ endfunction()
 # .cc files). Same effect as streamr_add_module_library() minus the
 # add_library(). No-op where modules are unsupported.
 function(streamr_target_module_sources TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     if(NOT STREAMR_MODULES_SUPPORTED)
         return()
@@ -146,7 +154,7 @@ function(streamr_target_module_sources TARGET)
     target_sources(${TARGET}
         PUBLIC
         FILE_SET CXX_MODULES
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        BASE_DIRS ${ARG_BASE_DIRS}
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)

--- a/packages/streamr-trackerless-network/CMakeLists.txt
+++ b/packages/streamr-trackerless-network/CMakeLists.txt
@@ -134,7 +134,22 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         PUBLIC GTest::gtest
     )
 
+    # Test-only helpers (mock factories) ported from the TS package's
+    # test/utils; a module library of its own so the test targets can
+    # import streamr.trackerlessnetwork.TestUtils.
+    streamr_add_module_library(streamr-trackerless-network-test-utils
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/test/utils
+        FILES ${CMAKE_CURRENT_SOURCE_DIR}/test/utils/TestUtils.cppm)
+    target_include_directories(streamr-trackerless-network-test-utils
+        PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/proto>)
+    target_link_libraries(streamr-trackerless-network-test-utils
+        PUBLIC streamr-trackerless-network
+        PUBLIC streamr::streamr-dht
+        PUBLIC streamr::streamr-utils
+    )
+
     add_executable(streamr-trackerless-network-test-unit
+        test/unit/TestUtilsTest.cpp
         test/unit/ProxyClientTest.cpp
         test/unit/ProxyConnectionRpcLocalTest.cpp
         test/unit/ProxyConnectionRpcRemoteTest.cpp
@@ -160,6 +175,7 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
     streamr_enable_imports(streamr-trackerless-network-test-unit)
     target_link_libraries(streamr-trackerless-network-test-unit
         PUBLIC streamr-trackerless-network
+        PUBLIC streamr-trackerless-network-test-utils
         PUBLIC streamr::streamr-logger
         PUBLIC GTest::gtest
         streamr-trackerless-network-test-main
@@ -184,8 +200,8 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
      )
      
      if (NOT (${VCPKG_TARGET_TRIPLET} MATCHES "android"))
-         #include(GoogleTest)
-         # gtest_discover_tests(streamr-trackerless-network-test-unit)
+         include(GoogleTest)
+         gtest_discover_tests(streamr-trackerless-network-test-unit)
          #gtest_discover_tests(streamr-trackerless-network-test-integration)
      
          # DISABLED: this test builds the whole streamr-dev/network TS

--- a/packages/streamr-trackerless-network/StreamrModules.cmake
+++ b/packages/streamr-trackerless-network/StreamrModules.cmake
@@ -80,7 +80,9 @@ endif()
 #
 # Defines <target> as a STATIC library whose C++ module interface units are
 # the given files (FILE_SET CXX_MODULES, rooted at the package's modules/
-# directory). STATIC rather than INTERFACE: module interface units are
+# directory unless overridden with BASE_DIRS <dir> — e.g. test-only module
+# units living under test/utils). STATIC rather than INTERFACE: module
+# interface units are
 # compiled TUs, so even a previously header-only package gains a compiled
 # archive when it grows a module.
 #
@@ -88,16 +90,19 @@ endif()
 # as a STATIC library — with a generated stub source instead of module
 # units — so callers can keep using PUBLIC include dirs/links identically.
 function(streamr_add_module_library TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_add_module_library(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     add_library(${TARGET} STATIC)
     if(STREAMR_MODULES_SUPPORTED)
         target_sources(${TARGET}
             PUBLIC
             FILE_SET CXX_MODULES
-            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+            BASE_DIRS ${ARG_BASE_DIRS}
             FILES ${ARG_FILES})
         set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     else()
@@ -136,9 +141,12 @@ endfunction()
 # .cc files). Same effect as streamr_add_module_library() minus the
 # add_library(). No-op where modules are unsupported.
 function(streamr_target_module_sources TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     if(NOT STREAMR_MODULES_SUPPORTED)
         return()
@@ -146,7 +154,7 @@ function(streamr_target_module_sources TARGET)
     target_sources(${TARGET}
         PUBLIC
         FILE_SET CXX_MODULES
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        BASE_DIRS ${ARG_BASE_DIRS}
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)

--- a/packages/streamr-trackerless-network/test/unit/TestUtilsTest.cpp
+++ b/packages/streamr-trackerless-network/test/unit/TestUtilsTest.cpp
@@ -1,0 +1,67 @@
+// Verifies the test utilities ported from
+// packages/trackerless-network/test/utils/utils.ts (v103.8.0-rc.3).
+// The TS version has no dedicated test for these factories; this file
+// pins down the field mapping so later ported tests can rely on it.
+//
+// NB: the NetworkRpc types are consumed ONLY through the
+// streamr.trackerlessnetwork.protos module (no textual NetworkRpc.pb.h
+// include): NetworkRpc's generated types live in the global namespace,
+// and clangd 22 fails to merge global-namespace declarations that
+// arrive both textually and through an imported BMI (every member call
+// on them is then diagnosed ambiguous; the compiler is fine).
+#include <gtest/gtest.h>
+
+import streamr.trackerlessnetwork.protos;
+import streamr.trackerlessnetwork.TestUtils;
+import streamr.utils.BinaryUtils;
+import streamr.utils.EthereumAddress;
+import streamr.utils.StreamPartID;
+
+using streamr::trackerlessnetwork::testutils::createStreamMessage;
+using streamr::trackerlessnetwork::testutils::MockConnectionLocker;
+using streamr::utils::BinaryUtils;
+using streamr::utils::StreamPartIDUtils;
+using streamr::utils::toEthereumAddress;
+
+TEST(TestUtils, CreateStreamMessageSetsAllFields) {
+    const auto publisherId =
+        toEthereumAddress("0x1234567890123456789012345678901234567890");
+    const auto streamPartId = StreamPartIDUtils::parse("stream#7");
+    const auto msg = createStreamMessage(
+        "{\"hello\":1}", streamPartId, publisherId, 1000, 5);
+
+    EXPECT_EQ(msg.messageid().streamid(), "stream");
+    EXPECT_EQ(msg.messageid().streampartition(), 7);
+    EXPECT_EQ(msg.messageid().timestamp(), 1000);
+    EXPECT_EQ(msg.messageid().sequencenumber(), 5);
+    EXPECT_EQ(
+        msg.messageid().publisherid(),
+        BinaryUtils::hexToBinaryString(publisherId));
+    // Expected value spelled out (not "messageChain0-" + publisherId):
+    // clangd 22 misresolves string concatenation that mixes the textual
+    // and BMI-delivered std::string declarations in this TU.
+    EXPECT_EQ(
+        msg.messageid().messagechainid(),
+        "messageChain0-0x1234567890123456789012345678901234567890");
+    EXPECT_EQ(msg.signaturetype(), SignatureType::ECDSA_SECP256K1_EVM);
+    EXPECT_EQ(msg.contentmessage().content(), "{\"hello\":1}");
+    EXPECT_EQ(msg.contentmessage().contenttype(), ContentType::JSON);
+    EXPECT_EQ(msg.contentmessage().encryptiontype(), EncryptionType::NONE);
+}
+
+TEST(TestUtils, CreateStreamMessageDefaultsTimestampAndSequenceNumber) {
+    const auto publisherId =
+        toEthereumAddress("0x1234567890123456789012345678901234567890");
+    const auto streamPartId = StreamPartIDUtils::parse("stream#0");
+    const auto msg = createStreamMessage("x", streamPartId, publisherId);
+
+    EXPECT_GT(msg.messageid().timestamp(), 0);
+    EXPECT_EQ(msg.messageid().sequencenumber(), 0);
+}
+
+TEST(TestUtils, MockConnectionLockerReportsZeroCounts) {
+    MockConnectionLocker locker;
+    EXPECT_EQ(locker.getLocalLockedConnectionCount(), 0);
+    EXPECT_EQ(locker.getRemoteLockedConnectionCount(), 0);
+    EXPECT_EQ(locker.getWeakLockedConnectionCount(), 0);
+}

--- a/packages/streamr-trackerless-network/test/utils/TestUtils.cppm
+++ b/packages/streamr-trackerless-network/test/utils/TestUtils.cppm
@@ -1,0 +1,89 @@
+// Module streamr.trackerlessnetwork.TestUtils
+// Test-only helpers shared by this package's test targets. Ported from
+// packages/trackerless-network/test/utils/utils.ts (v103.8.0-rc.3);
+// only the small factories the current tests need are here — the larger
+// ones (createMockContentDeliveryLayerNodeAndDhtNode etc.) are ported by
+// the plan phase that first needs them
+// (trackerless-network-completion-plan.md, phase 0.2).
+module;
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include "packages/dht/protos/DhtRpc.pb.h"
+#include "packages/network/protos/NetworkRpc.pb.h"
+
+export module streamr.trackerlessnetwork.TestUtils;
+
+import streamr.dht.ConnectionLocker;
+import streamr.dht.Identifiers;
+import streamr.utils.BinaryUtils;
+import streamr.utils.EthereumAddress;
+import streamr.utils.StreamPartID;
+
+using ::dht::PeerDescriptor;
+using streamr::dht::DhtAddress;
+using streamr::dht::connection::ConnectionLocker;
+using streamr::dht::connection::LockID;
+using streamr::utils::BinaryUtils;
+using streamr::utils::EthereumAddress;
+using streamr::utils::StreamPartID;
+using streamr::utils::StreamPartIDUtils;
+
+export namespace streamr::trackerlessnetwork::testutils {
+
+// Ported from createStreamMessage() (test/utils/utils.ts). The TS
+// publisherId parameter is a UserID (branded hex string); the closest
+// C++ counterpart is EthereumAddress.
+inline StreamMessage createStreamMessage(
+    const std::string& content,
+    const StreamPartID& streamPartId,
+    const EthereumAddress& publisherId,
+    std::optional<int64_t> timestamp = std::nullopt,
+    std::optional<int32_t> sequenceNumber = std::nullopt) {
+    StreamMessage msg;
+    auto* messageId = msg.mutable_messageid();
+    messageId->set_streamid(StreamPartIDUtils::getStreamID(streamPartId));
+    messageId->set_streampartition(
+        StreamPartIDUtils::getStreamPartition(streamPartId).value_or(0));
+    messageId->set_sequencenumber(sequenceNumber.value_or(0));
+    messageId->set_timestamp(timestamp.value_or(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count()));
+    messageId->set_publisherid(BinaryUtils::hexToBinaryString(publisherId));
+    messageId->set_messagechainid("messageChain0-" + publisherId);
+
+    msg.set_signaturetype(SignatureType::ECDSA_SECP256K1_EVM);
+    msg.set_signature(BinaryUtils::hexToBinaryString("0x1234"));
+    auto* contentMessage = msg.mutable_contentmessage();
+    contentMessage->set_encryptiontype(EncryptionType::NONE);
+    contentMessage->set_contenttype(ContentType::JSON);
+    contentMessage->set_content(content);
+    return msg;
+}
+
+// Ported from mockConnectionLocker (test/utils/utils.ts): a no-op
+// ConnectionLocker for components that require one but whose locking
+// behavior is irrelevant to the test.
+class MockConnectionLocker : public ConnectionLocker {
+public:
+    ~MockConnectionLocker() override = default;
+
+    void lockConnection(
+        PeerDescriptor /*targetDescriptor*/, LockID /*lockId*/) override {}
+    void unlockConnection(
+        PeerDescriptor /*targetDescriptor*/, LockID /*lockId*/) override {}
+    void weakLockConnection(
+        const DhtAddress& /*targetDescriptor*/,
+        const LockID& /*lockId*/) override {}
+    void weakUnlockConnection(
+        const DhtAddress& /*targetDescriptor*/,
+        const LockID& /*lockId*/) override {}
+    [[nodiscard]] size_t getLocalLockedConnectionCount() override { return 0; }
+    [[nodiscard]] size_t getRemoteLockedConnectionCount() override { return 0; }
+    [[nodiscard]] size_t getWeakLockedConnectionCount() override { return 0; }
+};
+
+} // namespace streamr::trackerlessnetwork::testutils

--- a/packages/streamr-utils/StreamrModules.cmake
+++ b/packages/streamr-utils/StreamrModules.cmake
@@ -80,7 +80,9 @@ endif()
 #
 # Defines <target> as a STATIC library whose C++ module interface units are
 # the given files (FILE_SET CXX_MODULES, rooted at the package's modules/
-# directory). STATIC rather than INTERFACE: module interface units are
+# directory unless overridden with BASE_DIRS <dir> — e.g. test-only module
+# units living under test/utils). STATIC rather than INTERFACE: module
+# interface units are
 # compiled TUs, so even a previously header-only package gains a compiled
 # archive when it grows a module.
 #
@@ -88,16 +90,19 @@ endif()
 # as a STATIC library — with a generated stub source instead of module
 # units — so callers can keep using PUBLIC include dirs/links identically.
 function(streamr_add_module_library TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_add_module_library(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     add_library(${TARGET} STATIC)
     if(STREAMR_MODULES_SUPPORTED)
         target_sources(${TARGET}
             PUBLIC
             FILE_SET CXX_MODULES
-            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+            BASE_DIRS ${ARG_BASE_DIRS}
             FILES ${ARG_FILES})
         set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     else()
@@ -136,9 +141,12 @@ endfunction()
 # .cc files). Same effect as streamr_add_module_library() minus the
 # add_library(). No-op where modules are unsupported.
 function(streamr_target_module_sources TARGET)
-    cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+    cmake_parse_arguments(ARG "" "BASE_DIRS" "FILES" ${ARGN})
     if(NOT ARG_FILES)
         message(FATAL_ERROR "streamr_target_module_sources(${TARGET}): FILES is required")
+    endif()
+    if(NOT ARG_BASE_DIRS)
+        set(ARG_BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
     endif()
     if(NOT STREAMR_MODULES_SUPPORTED)
         return()
@@ -146,7 +154,7 @@ function(streamr_target_module_sources TARGET)
     target_sources(${TARGET}
         PUBLIC
         FILE_SET CXX_MODULES
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules
+        BASE_DIRS ${ARG_BASE_DIRS}
         FILES ${ARG_FILES})
     set_target_properties(${TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
     target_compile_features(${TARGET} PUBLIC cxx_std_26)


### PR DESCRIPTION
## Summary

Second PR of the trackerless-network completion effort (plan phase 0.2): ports the small TypeScript test factories that both packages' upcoming ported tests lean on.

### New test-utility modules
- **`streamr.dht.TestUtils`** (`packages/streamr-dht/test/utils/TestUtils.cppm`): `createMockPeerDescriptor`, `createWrappedClosestPeersRequest`, and the `customMatchers.ts` `toEqualPeerDescriptor` jest matcher translated to gtest predicate-formatters (`assertEqualPeerDescriptors` / `assertNotEqualPeerDescriptors`) producing the same per-field failure messages. `customMatchers.test.ts` is ported as `CustomMatchersTest.cpp` (jest `.toThrow(...)` checks become `EXPECT_NONFATAL_FAILURE` substring checks).
- **`streamr.trackerlessnetwork.TestUtils`**: `createStreamMessage` (field mapping pinned by `TestUtilsTest.cpp`) and `MockConnectionLocker`.

### Build-system enablers (called out for review)
- `StreamrModules.cmake` helpers gain an optional **`BASE_DIRS`** argument so test-only module units can live under `test/utils/` without joining the package `modules/*.cppm` glob. Propagated to all eight per-package copies, matching how previous StreamrModules changes landed. Phase 0.3's simulator will use the same mechanism.
- **`gtest_discover_tests(streamr-trackerless-network-test-unit)` re-enabled.** It was commented out, so the package's unit tests were built but never registered with ctest — they (and anything added to them) silently never ran. All 15 pass; the suite grows from 316 to 331 tests. The integration-test discovery stays disabled (the known ts-integration situation).

### clangd notes
Two more clangd 22 false-positive patterns hit and documented in-code: generated proto types in the **global** namespace (NetworkRpc has no proto package) arriving both textually and via an imported BMI make clangd flag every member call as ambiguous — fixed by consuming them only through `import streamr.trackerlessnetwork.protos`; and string concatenation mixing textual/BMI `std::string` declarations. DhtRpc types (namespaced) are unaffected.

## Test plan
- [x] Full monorepo build (macOS arm64, Debug)
- [x] `./test.sh` — 331/331 tests pass (15 trackerless unit tests newly registered, 4 ported CustomMatchers tests, 3 TestUtils pinning tests)
- [x] `./lint.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)