### PR TITLE
CI: drop the standalone loop from the macOS leg; let main runs finish — the warm-cache measurement round [androidbuild] [iosbuild]

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,13 +29,15 @@ jobs:
         # revisit when GA.
         os: [macos-26, ubuntu-latest, linux-arm64-runner]
         # The standalone-package check (each package built in its own tree)
-        # validates packaging structure, which is host-independent — the
-        # macOS leg runs it, the Linux legs build only the root tree and
-        # lint against its compile database (MODERNIZATION.md "After the
-        # consolidation: CI speed", item 1).
+        # validates packaging structure, which is host-independent — and
+        # the iOS job necessarily builds every package standalone (the
+        # XCFramework is assembled from the per-package outputs), so it
+        # carries that check. All validate legs build only the root tree
+        # and lint against its compile database (MODERNIZATION.md "After
+        # the consolidation: CI speed", item 1; owner decision 2026-07-06).
         include:
           - os: macos-26
-            install_extra: ""
+            install_extra: "--no-standalone"
           - os: ubuntu-latest
             install_extra: "--no-standalone"
           - os: linux-arm64-runner

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,8 +13,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: build-${{ github.head_ref }}
-  cancel-in-progress: true
+  # head_ref is empty on push events, so all main pushes share one group —
+  # with unconditional cancel-in-progress every merge killed the previous
+  # main run mid-flight (observed twice on 2026-07-06), which also kept the
+  # build-tree caches from being saved. PR pushes still cancel their own
+  # superseded runs; main runs are left to finish.
+  group: build-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   install-lint-test:

--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -1236,11 +1236,25 @@ planned):**
   restored tree rebuilds exactly the pull request's touched cone.
 - Item 3 (ccache) remains a fallback if this proves fragile; item 4
   (port randomization + parallel ctest) remains open.
-- Measurement protocol: the first post-merge main run populates the
-  caches (slow once per platform); the next pull request measures the
-  warm path. Record against: pre-caching PR legs ubuntu ~45-50 min,
-  arm64 ~44-45 min, macos ~72-103 min, iOS ~68-97 min, Android
-  ~91-123 min.
+- **MEASURED (PR #54, 2026-07-06).** All legs green:
+
+  | Leg | before this work | measured | state |
+  |---|---|---|---|
+  | ubuntu | 45–52 min | **5 min** | warm build tree |
+  | linux-arm64 | 44–45 min | **11 min** | warm build tree |
+  | macOS | 103–115 min | **36 min** | COLD, no standalone loop |
+  | iOS | 68–97 min | 73 min | warm tree + #52 proto-drift rebuild; keeps the standalone loop (XCFramework) |
+  | Android | 91–123 min | 70 min | cold (its tree fell to cache eviction); improves after main saves |
+
+  The ubuntu warm path is the headline: five minutes for checkout,
+  dependency restore, build-tree restore, drift rebuild, lint and
+  tests. macOS improves further once a main run saves its tree, and
+  Android once its tree survives in the cache budget. Follow-ups noted:
+  the shared 10 GB actions-cache budget is now the binding constraint
+  (three build trees ≈ 6.4 GB + two dependency-cache generations —
+  the plan's NuGet-feed option for dependency caches is the relief
+  valve), and item 4 (test-port randomization + parallel ctest) remains
+  open.
 
 ### Interim posture (adopted now)
 The façade stage is COMPLETE and delivers: uniform `import streamr.<pkg>`

--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -1214,13 +1214,15 @@ the build structure the caches would key on:
 **IMPLEMENTED (items 1 + 2, after C-8 and the wrapper modules, as
 planned):**
 - `install.sh --no-standalone` skips the per-package standalone builds;
-  the ubuntu and linux-arm64 legs pass it (via INSTALL_EXTRA_FLAGS in
-  validate.yml) and lint against the ROOT tree's compile database —
-  every package lint.sh falls back to `../../build` when its standalone
-  database is absent. The macOS leg keeps the full standalone loop as
-  the packaging-structure check; iOS keeps it because the XCFramework
-  is assembled from the per-package outputs (`--no-standalone --ios` is
-  rejected).
+  ALL validate legs pass it (via INSTALL_EXTRA_FLAGS in validate.yml)
+  and lint against the ROOT tree's compile database — every package
+  lint.sh falls back to `../../build` when its standalone database is
+  absent. The packaging-structure check is carried by the iOS job,
+  which builds every package standalone by construction (the
+  XCFramework is assembled from the per-package outputs;
+  `--no-standalone --ios` is rejected). Owner decision 2026-07-06: the
+  macOS leg originally kept the loop as the designated check; that
+  duplication was dropped since the iOS job already covers it.
 - The cached-install action now caches the ROOT build tree per platform
   (key: platform + vcpkg SHA + commit; prefix restore-keys), excluding
   vcpkg_installed (own cache) and the per-package trees (8 × 0.5–1.5 GB

--- a/install.sh
+++ b/install.sh
@@ -41,9 +41,10 @@ while [[ "$#" -gt 0 ]]; do
         # guarded with if(NOT TARGET ...) in the package CMakeLists — so no
         # standalone build dirs are needed. The full standalone build
         # validates that each package works as an independent vcpkg-style
-        # unit; that check is host-independent, so CI runs it on the macOS
-        # leg only and the other host legs pass this flag. Not allowed with
-        # --ios: the XCFramework is assembled from the per-package outputs.
+        # unit; that check is host-independent and the iOS CI job runs it by
+        # construction (the XCFramework is assembled from the per-package
+        # outputs), so ALL validate legs pass this flag. Not allowed with
+        # --ios for the same reason.
         --no-standalone) STANDALONE_PACKAGES=false ;;
         *) echo "Unknown parameter passed: $1. Usage: ./install.sh [--prod] [--ios] [--android] [--no-standalone]"; exit 1 ;;
     esac


### PR DESCRIPTION
# CI follow-up: macOS joins --no-standalone, main runs stop cancelling each other

Two small changes, and this pull request's own CI run doubles as the **warm-cache measurement round**.

## Changes

1. **macOS leg passes `--no-standalone` too** (owner decision): the iOS job necessarily builds every package standalone — the XCFramework is assembled from the per-package outputs — so it carries the packaging-structure check, and the macOS validate leg's standalone loop was duplicate coverage. All three validate legs now build only the root tree.

2. **Main-branch runs are allowed to finish.** `concurrency.group` used `github.head_ref`, which is empty on push events — so every merge to main shared one group and, with unconditional `cancel-in-progress`, killed the previous main run mid-flight. This happened twice today (each merge cancelled the prior run's macOS leg after ~110 minutes) and also prevented the build-tree caches from being saved. The group is now keyed by ref name and cancel-in-progress applies only off main: pull-request pushes still cancel their own superseded runs, merges no longer cancel each other.

## Measurement round

Current cache state when this run starts: Linux build trees saved (from the #52 main run's completed legs), iOS tree saved (from the #51 merge run); no macOS host tree yet (its saves kept getting cancelled — see change 2). So this run measures:

- **ubuntu / linux-arm64: the warm path** — restore the saved tree, rebuild only the drift since #52/#53.
- **macOS: the new cold configuration** — root tree only, no standalone loop (was 103–115 min with the loop).
- **iOS: warm-ish** — restores the #51-era tree with the #52 proto adoption as drift.
- **Android: cold** (its earlier tree fell to cache eviction pressure) — establishes the baseline the next run improves on.

Reference numbers (pre-#51 PR legs): ubuntu ~45–52, arm64 ~44–45, macOS ~72–108, iOS ~68–97, Android ~91–123 minutes. After #51 (cold, Linux legs only improved by skipping standalone builds): ubuntu 16, arm64 11–13. I will post the measured board as a comment when the run completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)