### PR TITLE
Phase A0: connection-layer locking discipline + simultaneous-connect convergence

### DIFF
--- a/packages/streamr-dht/CMakeLists.txt
+++ b/packages/streamr-dht/CMakeLists.txt
@@ -22,6 +22,19 @@ project(dht CXX)
 # add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
 # add_link_options(-fsanitize=address -fno-omit-frame-pointer)
 
+# Opt-in ThreadSanitizer build for the connection-layer concurrency work
+# (phase A0). Enable with -DSTREAMR_DHT_TSAN=ON and run the
+# --gtest_repeat stress loops under it. NOTE: the vcpkg dependencies
+# (folly, protobuf, ...) are NOT built with TSAN, so their internals show
+# up as uninstrumented and some reports need a suppressions file; this is
+# a developer aid, not yet a clean CI leg (tracked in
+# trackerless-network-completion-plan.md phase A0).
+option(STREAMR_DHT_TSAN "Build streamr-dht with ThreadSanitizer" OFF)
+if(STREAMR_DHT_TSAN)
+    add_compile_options(-fsanitize=thread -fno-omit-frame-pointer -g)
+    add_link_options(-fsanitize=thread)
+endif()
+
 # Sibling monorepo packages: find_package only when the target is not
 # already in this build tree (in the root single-tree build the sibling
 # was added via add_subdirectory — the guard makes the root tree

--- a/packages/streamr-dht/modules/connection/ConnectionManager.cppm
+++ b/packages/streamr-dht/modules/connection/ConnectionManager.cppm
@@ -103,13 +103,19 @@ private:
     std::atomic<ConnectionManagerState> state = ConnectionManagerState::IDLE;
     std::map<DhtAddress, std::shared_ptr<Endpoint>> endpoints;
     std::recursive_mutex endpointsMutex;
+    // Monotonic counter handed to Endpoint::setConnecting so an endpoint
+    // adopts pending connections in tie-break decision order even when the
+    // setConnecting() calls race across threads; guarded by endpointsMutex.
+    // See acceptNewConnection().
+    uint64_t connectingSequenceCounter = 0;
 
-    void addEndpoint(
-        const std::shared_ptr<IPendingConnection>& pendingConnection) {
-        SLogger::debug("ConnectionManager::addEndpoint start");
-
-        auto peerDescriptor = pendingConnection->getPeerDescriptor();
-        auto nodeId = Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor);
+    // Constructs an Endpoint for the peer and wires its listeners; pure
+    // construction with no call-outs, so acceptNewConnection() may run
+    // it while holding endpointsMutex. The caller inserts the endpoint
+    // into the container and starts it connecting.
+    [[nodiscard]] std::shared_ptr<Endpoint> createEndpoint(
+        const PeerDescriptor& peerDescriptor, const DhtAddress& nodeId) {
+        SLogger::debug("ConnectionManager::createEndpoint start");
 
         auto endpoint = Endpoint::newInstance(
             peerDescriptor, [this, peerDescriptor, nodeId]() {
@@ -134,14 +140,8 @@ private:
             this->emit<transport::transportevents::Connected>(peerDescriptor);
         });
 
-        {
-            SLogger::debug("Trying to acquire mutex lock in addEndpoint");
-            std::scoped_lock lock(this->endpointsMutex);
-            SLogger::debug("Acquired mutex lock in addEndpoint");
-            this->endpoints[nodeId] = endpoint;
-        }
-        endpoint->changeToConnectingState(pendingConnection);
-        SLogger::debug("ConnectionManager::addEndpoint end");
+        SLogger::debug("ConnectionManager::createEndpoint end");
+        return endpoint;
     }
 
 public:
@@ -247,7 +247,10 @@ public:
         SLogger::trace("Starting ConnectionManager...");
         this->connectorFacade->start(
             [this](const std::shared_ptr<IPendingConnection>& connection) {
-                return this->onNewConnection(connection);
+                // Connections handed to us by the connector are incoming,
+                // i.e. initiated by the remote peer.
+                return this->onNewConnection(
+                    connection, /*isLocalInitiated=*/false);
             },
             [this](const DhtAddress& nodeId) {
                 return this->hasConnection(nodeId);
@@ -335,44 +338,62 @@ public:
         SLogger::trace("Sending message: " + debugMessage);
         SLogger::debug("Traced sending message details");
 
+        // endpointsMutex is held only for the container lookups;
+        // createConnection/onNewConnection and the endpoint queries lead
+        // into the connector facade and the endpoint state machine, and
+        // holding the container lock across them nests it with the
+        // endpoint mutex (phase-A0 locking policy: no call-outs under
+        // endpointsMutex).
         std::shared_ptr<Endpoint> endpoint;
         {
             SLogger::debug("Trying to acquire mutex lock in send");
             std::scoped_lock lock(this->endpointsMutex);
             SLogger::debug("Acquired mutex lock in send");
-
-            if (!this->endpoints.contains(nodeId)) {
-                SLogger::debug("Node ID not found in endpoints");
-                if (sendOptions.connect) {
-                    SLogger::debug("Creating new connection");
-                    std::shared_ptr<IPendingConnection> connection =
-                        this->connectorFacade->createConnection(peerDescriptor);
-
-                    SLogger::debug("Created new connection");
-                    this->onNewConnection(connection);
-                    SLogger::debug("Handled new connection");
-                    if (!this->endpoints.contains(nodeId)) {
-                        SLogger::debug(
-                            "Node ID not found in endpoints after creating new connection, this means that the connection failed");
-                        throw SendFailed(
-                            "No connection to target, connection failed");
-                    }
-                } else {
-                    SLogger::debug("Throwing SendFailed exception");
-                    throw SendFailed(
-                        "No connection to target, connect flag is false");
-                }
-            } else if (
-                !this->endpoints.at(nodeId)->isConnected() &&
-                !sendOptions.connect) {
-                SLogger::debug(
-                    "Throwing SendFailed exception due to disconnected endpoint");
+            const auto it = this->endpoints.find(nodeId);
+            if (it != this->endpoints.end()) {
+                endpoint = it->second;
+            }
+        }
+        if (!endpoint) {
+            SLogger::debug("Node ID not found in endpoints");
+            if (!sendOptions.connect) {
+                SLogger::debug("Throwing SendFailed exception");
                 throw SendFailed(
                     "No connection to target, connect flag is false");
             }
-            endpoint = this->endpoints.at(nodeId);
-            SLogger::debug("Passed connection checks");
+            SLogger::debug("Creating new connection");
+            std::shared_ptr<IPendingConnection> connection =
+                this->connectorFacade->createConnection(peerDescriptor);
+            SLogger::debug("Created new connection");
+            // This connection is outgoing (locally initiated). If the
+            // tie-break rejects it — a concurrent incoming connection from
+            // the same peer already won and owns the endpoint — discard the
+            // outgoing one we just created and fall through to that
+            // endpoint. (Simultaneous connect; see acceptNewConnection.)
+            const bool accepted =
+                this->onNewConnection(connection, /*isLocalInitiated=*/true);
+            SLogger::debug("Handled new connection");
+            if (!accepted) {
+                connection->close(false);
+            }
+            {
+                std::scoped_lock lock(this->endpointsMutex);
+                const auto it = this->endpoints.find(nodeId);
+                if (it != this->endpoints.end()) {
+                    endpoint = it->second;
+                }
+            }
+            if (!endpoint) {
+                SLogger::debug(
+                    "Node ID not found in endpoints after creating new connection, this means that the connection failed");
+                throw SendFailed("No connection to target, connection failed");
+            }
+        } else if (!endpoint->isConnected() && !sendOptions.connect) {
+            SLogger::debug(
+                "Throwing SendFailed exception due to disconnected endpoint");
+            throw SendFailed("No connection to target, connect flag is false");
         }
+        SLogger::debug("Passed connection checks");
         size_t nBytes = messageWithSource.ByteSizeLong();
         SLogger::debug("Calculated message size");
         if (nBytes == 0) {
@@ -522,9 +543,17 @@ public:
     }
 
     [[nodiscard]] std::vector<PeerDescriptor> getConnections() override {
-        std::scoped_lock lock(this->endpointsMutex);
-        return this->endpoints | std::views::values |
-            std::views::filter([](const auto& endpoint) {
+        // Snapshot the endpoints under the container lock, query them
+        // after releasing it: isConnected() takes the endpoint
+        // state-machine mutex, and nesting it under endpointsMutex is
+        // against the phase-A0 locking policy.
+        std::vector<std::shared_ptr<Endpoint>> endpointsSnapshot;
+        {
+            std::scoped_lock lock(this->endpointsMutex);
+            endpointsSnapshot = this->endpoints | std::views::values |
+                std::ranges::to<std::vector>();
+        }
+        return endpointsSnapshot | std::views::filter([](const auto& endpoint) {
                    return endpoint->isConnected();
                }) |
             std::views::transform([](const auto& endpoint) {
@@ -534,14 +563,18 @@ public:
     }
 
 private:
+    // isLocalInitiated: true for a connection we created ourselves
+    // (send() -> createConnection, outgoing), false for one handed to us
+    // by the connector (incoming, initiated by the remote peer).
     bool onNewConnection(
-        const std::shared_ptr<IPendingConnection>& connection) {
+        const std::shared_ptr<IPendingConnection>& connection,
+        bool isLocalInitiated) {
         if (this->state == ConnectionManagerState::STOPPED) {
             return false;
         }
         SLogger::trace("onNewConnection()");
 
-        return this->acceptNewConnection(connection);
+        return this->acceptNewConnection(connection, isLocalInitiated);
 
         // connection.once('connected', (peerDescriptor: PeerDescriptor,
         // connection: IConnection) => this.onConnected(peerDescriptor,
@@ -552,29 +585,75 @@ private:
     }
 
     bool acceptNewConnection(
-        const std::shared_ptr<IPendingConnection>& newConnection) {
-        const auto nodeId = Identifiers::getNodeIdFromPeerDescriptor(
-            newConnection->getPeerDescriptor());
+        const std::shared_ptr<IPendingConnection>& newConnection,
+        bool isLocalInitiated) {
+        const auto peerDescriptor = newConnection->getPeerDescriptor();
+        const auto nodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor);
+        // Resolved before taking endpointsMutex: getLocalPeerDescriptor()
+        // calls out into the connector facade.
+        const auto localNodeId = Identifiers::getNodeIdFromPeerDescriptor(
+            this->getLocalPeerDescriptor());
         SLogger::debug("ConnectionManager::acceptNewConnection()");
 
+        // Simultaneous connect: both peers must converge on the SAME
+        // physical connection, otherwise one direction's traffic is
+        // delivered to a connection the other side is not listening on.
+        // The convention is to keep the connection initiated by the
+        // offerer. TS decides this with `getOfferer == remote` alone,
+        // which is only correct because its single-threaded runtime
+        // guarantees a node registers its own outgoing connection before
+        // it ever processes the peer's incoming one. Here the connector's
+        // dispatcher thread can deliver the incoming connection before the
+        // main thread's send() registers the outgoing one; deciding on
+        // getOfferer alone would then let the non-offerer replace the
+        // offerer's (incoming) connection with its own (outgoing) one, and
+        // the two nodes would settle on different connections. So the
+        // tie-break is made direction-aware and therefore order-
+        // independent: the winning connection is the offerer's — the local
+        // node's own outgoing connection when it is the offerer, the
+        // remote's incoming connection when it is not.
+        const bool localIsOfferer =
+            OffererHelper::getOfferer(localNodeId, nodeId) == Offerer::LOCAL;
+        const bool newConnectionWins = (isLocalInitiated == localIsOfferer);
+
+        // The exists-check and the insert happen under one lock hold, so
+        // two racing accepts for the same peer cannot both insert (the
+        // second one would silently orphan the first endpoint). The
+        // endpoint calls (setConnecting) run after the lock is released:
+        // they take the endpoint's state-machine mutex and lead to
+        // call-outs, and holding endpointsMutex across them was one half
+        // of the phase-A0 ABBA inversion (the other half being
+        // handleDisconnect -> removeSelfFromContainer, which now runs
+        // without the state-machine mutex held).
+        std::shared_ptr<Endpoint> existingEndpoint;
+        std::shared_ptr<Endpoint> createdEndpoint;
+        uint64_t sequenceNumber = 0;
         {
             SLogger::debug("ConnectionManager::acceptNewConnection() start");
             std::scoped_lock lock(this->endpointsMutex);
             SLogger::debug("Acquired mutex lock in acceptNewConnection");
 
-            if (this->endpoints.contains(nodeId)) {
-                if (OffererHelper::getOfferer(
-                        Identifiers::getNodeIdFromPeerDescriptor(
-                            this->getLocalPeerDescriptor()),
-                        nodeId) == Offerer::REMOTE) {
-                    this->endpoints.at(nodeId)->setConnecting(newConnection);
-                    return true;
+            const auto it = this->endpoints.find(nodeId);
+            if (it != this->endpoints.end()) {
+                if (!newConnectionWins) {
+                    return false;
                 }
-                return false;
+                existingEndpoint = it->second;
+            } else {
+                createdEndpoint = this->createEndpoint(peerDescriptor, nodeId);
+                this->endpoints.emplace(nodeId, createdEndpoint);
             }
+            // Assigned in decision order under the lock; the endpoint uses
+            // it to ignore an adoption that a thread race would otherwise
+            // apply out of order.
+            sequenceNumber = ++this->connectingSequenceCounter;
         }
-        SLogger::debug("Calling addEndpoint() in acceptNewConnection()");
-        this->addEndpoint(newConnection);
+        if (existingEndpoint) {
+            existingEndpoint->setConnecting(newConnection, sequenceNumber);
+            return true;
+        }
+        createdEndpoint->setConnecting(newConnection, sequenceNumber);
         SLogger::trace(nodeId + " added to connections at acceptNewConnection");
         return true;
     }

--- a/packages/streamr-dht/modules/connection/IPendingConnection.cppm
+++ b/packages/streamr-dht/modules/connection/IPendingConnection.cppm
@@ -46,6 +46,12 @@ public:
     virtual void destroy() = 0;
     virtual const PeerDescriptor& getPeerDescriptor() const = 0;
     virtual void onError(const std::exception_ptr& error) = 0;
+    // Silence this pending connection: after this it emits neither
+    // Connected nor Disconnected. Used when it loses a simultaneous-connect
+    // tie-break, so the eventual close of its underlying connection cannot
+    // drive (or tear down) the endpoint that has moved on to the winning
+    // connection.
+    virtual void replaceAsDuplicate() = 0;
 };
 
 } // namespace streamr::dht::connection

--- a/packages/streamr-dht/modules/connection/OutgoingHandshaker.cppm
+++ b/packages/streamr-dht/modules/connection/OutgoingHandshaker.cppm
@@ -154,11 +154,26 @@ protected:
 
     void onHandshakeResponse(
         const HandshakeResponse& handshakeResponse) override {
-        if (handshakeResponse.has_error()) {
-            this->pendingConnection->close(false);
-            stopHandshaker();
-        } else if (!isAcceptedVersion(handshakeResponse.protocolversion())) {
-            this->handleFailure(HandshakeError::UNSUPPORTED_PROTOCOL_VERSION);
+        // An errored response is routed through handleFailure(), NOT
+        // closed directly: handleFailure() closes the pending connection
+        // only for INVALID_TARGET_PEER_DESCRIPTOR /
+        // UNSUPPORTED_PROTOCOL_VERSION and otherwise waits for the other
+        // end to close the connection (matching the TS handshaker). This
+        // matters for DUPLICATE_CONNECTION — the peer won the
+        // simultaneous-connect tie-break and rejected this outgoing
+        // connection — where closing here would tear this endpoint down
+        // (and drop its buffered messages) even though it is about to be
+        // served by the peer's incoming connection. Directly closing on
+        // any error was the cause of the ~1-in-30 `received2` message loss
+        // in the SimultaneousConnections stress runs (phase A0).
+        std::optional<HandshakeError> error;
+        if (!isAcceptedVersion(handshakeResponse.protocolversion())) {
+            error = HandshakeError::UNSUPPORTED_PROTOCOL_VERSION;
+        } else if (handshakeResponse.has_error()) {
+            error = handshakeResponse.error();
+        }
+        if (error.has_value()) {
+            this->handleFailure(error);
         } else {
             this->handleSuccess(handshakeResponse.sourcepeerdescriptor());
         }
@@ -191,6 +206,17 @@ protected:
                 Identifiers::getNodeIdFromPeerDescriptor(
                     this->targetPeerDescriptor) +
                 " waiting for the other end to close the connection");
+            // The other end won the simultaneous-connect tie-break
+            // (DUPLICATE_CONNECTION). Silence this pending connection now,
+            // on receipt of the error, so that when its connection is
+            // subsequently closed by the peer the close does NOT tear down
+            // our endpoint: the endpoint is about to be handed the peer's
+            // winning connection (with its buffered messages intact). The
+            // error response is delivered before that close on the same
+            // association (per-association FIFO), so the silencing is
+            // always in place in time — this is what makes the convergence
+            // race-free rather than merely likely to win the race.
+            this->pendingConnection->replaceAsDuplicate();
         }
     }
 };

--- a/packages/streamr-dht/modules/connection/PendingConnection.cppm
+++ b/packages/streamr-dht/modules/connection/PendingConnection.cppm
@@ -60,7 +60,7 @@ public:
             this->connectingAbortController.getSignal());
     }
 
-    void replaceAsDuplicate() {
+    void replaceAsDuplicate() override {
         SLogger::trace(
             Identifiers::getNodeIdFromPeerDescriptor(
                 this->remotePeerDescriptor) +

--- a/packages/streamr-dht/modules/connection/endpoint/ConnectedEndpointState.cppm
+++ b/packages/streamr-dht/modules/connection/endpoint/ConnectedEndpointState.cppm
@@ -5,6 +5,7 @@
 module;
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -18,6 +19,7 @@ import streamr.logger.SLogger;
 import streamr.dht.Connection;
 import streamr.dht.EndpointState;
 import streamr.dht.EndpointStateInterface;
+import streamr.dht.Errors;
 
 // Hoisted from the former header (file scope, NOT exported);
 // fully qualified: relative namespace names resolve differently
@@ -27,18 +29,40 @@ using streamr::logger::SLogger;
 export namespace streamr::dht::connection::endpoint {
 
 using streamr::dht::connection::Connection;
+using streamr::dht::helpers::SendFailed;
 
+// The state's resources (connection, tokens) are guarded by the
+// Endpoint's state-machine mutex (phase A0; see ConnectingEndpointState
+// for the rationale). Methods overridden from EndpointState are called
+// with that mutex held; the event handlers registered on the connection
+// take it themselves and first validate that they still belong to the
+// current connection.
 class ConnectedEndpointState : public EndpointState {
 private:
     EndpointStateInterface& stateInterface;
     std::shared_ptr<Connection> connection;
     HandlerToken dataHandlerToken;
     HandlerToken disconnectHandlerToken;
-    std::recursive_mutex connectedEndpointStateMutex;
 
     explicit ConnectedEndpointState(EndpointStateInterface& stateInterface)
         : stateInterface(stateInterface) {
         SLogger::debug("ConnectedEndpointState constructor");
+    }
+
+    // Requires the state-machine mutex. Detaches the handlers from the
+    // current connection and forgets it; a handler already running past
+    // its off() no-ops on the identity check below.
+    void detachFromConnection() {
+        SLogger::debug("ConnectedEndpointState::detachFromConnection");
+        if (this->connection) {
+            this->connection->off<connectionevents::Data>(
+                this->dataHandlerToken);
+            this->connection->off<connectionevents::Disconnected>(
+                this->disconnectHandlerToken);
+            this->dataHandlerToken = HandlerToken{};
+            this->disconnectHandlerToken = HandlerToken{};
+            this->connection.reset();
+        }
     }
 
 public:
@@ -52,98 +76,118 @@ public:
     }
 
     ~ConnectedEndpointState() override {
-        if (this->connection) {
-            SLogger::debug(
-                "ConnectedEndpointState destructor " +
-                this->connection->getConnectionTypeString());
-        }
+        SLogger::debug("ConnectedEndpointState destructor");
     }
 
-    void enterState(const std::shared_ptr<Connection>& connection) {
+    // Requires the state-machine mutex (called by
+    // Endpoint::enterConnectedState). Unlike the pending connection, the
+    // Connection emitter is fire-and-forget (no replay), so registering
+    // the handlers here cannot invoke them synchronously — this is why
+    // registration may stay inside the transition for this state.
+    void enterState(
+        const std::shared_ptr<Connection>& connection,
+        const std::weak_ptr<void>& endpointPin) {
         SLogger::debug("ConnectedEndpointState::enterState start");
-        auto self = sharedFromThis<ConnectedEndpointState>();
-        std::scoped_lock lock(this->connectedEndpointStateMutex);
+        this->detachFromConnection();
         this->connection = connection;
+        std::weak_ptr<ConnectedEndpointState> weakSelf =
+            this->sharedFromThis<ConnectedEndpointState>();
+        auto* rawConnection = connection.get();
         this->dataHandlerToken = this->connection->on<connectionevents::Data>(
-            [this](const std::vector<std::byte>& data) {
-                SLogger::debug("ConnectedEndpointState::onData()");
-                std::scoped_lock lock(this->connectedEndpointStateMutex);
-                auto self = sharedFromThis<ConnectedEndpointState>();
+            [weakSelf, endpointPin, rawConnection](
+                const std::vector<std::byte>& data) {
+                // The pin keeps the Endpoint (and with it this state)
+                // alive for the duration of the handler.
+                const auto pin = endpointPin.lock();
+                if (!pin) {
+                    return;
+                }
+                const auto self = weakSelf.lock();
+                if (!self) {
+                    return;
+                }
+                {
+                    std::scoped_lock lock(
+                        self->stateInterface.getStateMachineMutex());
+                    if (self->connection.get() != rawConnection) {
+                        return; // stale handler of a replaced connection
+                    }
+                }
                 self->stateInterface.emitData(data);
-                SLogger::debug("ConnectedEndpointState::onData() end");
             });
         this->disconnectHandlerToken =
             this->connection->on<connectionevents::Disconnected>(
-                [this](
-                    bool gracefulLeave,
+                [weakSelf, endpointPin, rawConnection](
+                    bool /*gracefulLeave*/,
                     uint64_t /*code*/,
                     const std::string& /*reason*/) {
-                    SLogger::debug(
-                        "ConnectedEndpointState::enterState disconnected");
-                    std::scoped_lock lock(this->connectedEndpointStateMutex);
-                    auto self = sharedFromThis<ConnectedEndpointState>();
-                    self->stateInterface.handleDisconnect(gracefulLeave);
-                    SLogger::debug(
-                        "ConnectedEndpointState::enterState disconnected end");
+                    const auto pin = endpointPin.lock();
+                    if (!pin) {
+                        return;
+                    }
+                    const auto self = weakSelf.lock();
+                    if (!self) {
+                        return;
+                    }
+                    bool transitioned = false;
+                    {
+                        std::scoped_lock lock(
+                            self->stateInterface.getStateMachineMutex());
+                        if (self->connection.get() != rawConnection) {
+                            return; // stale handler of a replaced connection
+                        }
+                        self->detachFromConnection();
+                        transitioned =
+                            self->stateInterface.enterDisconnectedState();
+                    }
+                    if (transitioned) {
+                        self->stateInterface.finishDisconnect();
+                    }
                 });
         SLogger::debug("ConnectedEndpointState::enterState end");
     }
 
-    void removeEventHandlers() {
-        SLogger::debug("ConnectedEndpointState::removeEventHandlers start");
-        auto self = sharedFromThis<ConnectedEndpointState>();
-        std::scoped_lock lock(this->connectedEndpointStateMutex);
-        if (this->connection) {
-            this->connection->off<connectionevents::Data>(
-                this->dataHandlerToken);
-            this->connection->off<connectionevents::Disconnected>(
-                this->disconnectHandlerToken);
+    [[nodiscard]] DeferredCallout close(bool graceful) override {
+        SLogger::debug("ConnectedEndpointState::close");
+        auto connection = this->connection;
+        this->detachFromConnection();
+        if (!connection) {
+            return {};
         }
-        SLogger::debug("ConnectedEndpointState::removeEventHandlers end");
-    }
-
-    void close(bool graceful) override {
-        SLogger::debug(
-            "ConnectedEndpointState::close start " +
-            this->connection->getConnectionTypeString());
-        auto self = sharedFromThis<ConnectedEndpointState>();
-        std::scoped_lock lock(this->connectedEndpointStateMutex);
-        this->removeEventHandlers();
-        this->connection->close(graceful);
-        SLogger::debug(
-            "ConnectedEndpointState::close end " +
-            this->connection->getConnectionTypeString());
+        // connection->close() emits its Disconnected event, so it must
+        // run after the mutex is released.
+        return [connection, graceful]() { connection->close(graceful); };
     }
 
     void send(const std::vector<std::byte>& data) override {
-        SLogger::debug("ConnectedEndpointState::send start");
-        auto self = sharedFromThis<ConnectedEndpointState>();
-        SLogger::debug("ConnectedEndpointState::send acquiring scoped lock");
-        std::scoped_lock lock(this->connectedEndpointStateMutex);
-        SLogger::debug("ConnectedEndpointState::send lock acquired");
+        SLogger::debug("ConnectedEndpointState::send");
+        if (!this->connection) {
+            throw SendFailed("send() called on endpoint with no connection");
+        }
         this->connection->send(data);
-        SLogger::debug("ConnectedEndpointState::send end");
     }
 
-    void changeToConnectingState(
+    [[nodiscard]] DeferredCallout changeToConnectingState(
         const std::shared_ptr<IPendingConnection>& pendingConnection) override {
-        SLogger::debug("ConnectedEndpointState::changeToConnectingState start");
-        auto self = sharedFromThis<ConnectedEndpointState>();
-        std::scoped_lock lock(this->connectedEndpointStateMutex);
-        this->connection->close(true);
-        this->removeEventHandlers();
-        this->stateInterface.changeToConnectingState(pendingConnection);
-        SLogger::debug("ConnectedEndpointState::changeToConnectingState end");
+        SLogger::debug("ConnectedEndpointState::changeToConnectingState");
+        auto oldConnection = this->connection;
+        this->detachFromConnection();
+        this->stateInterface.enterConnectingState(pendingConnection);
+        if (!oldConnection) {
+            return {};
+        }
+        // Closing the replaced connection emits events; defer it.
+        return [oldConnection]() { oldConnection->close(true); };
     }
 
-    void changeToConnectedState(
+    [[nodiscard]] DeferredCallout changeToConnectedState(
         const std::shared_ptr<Connection>& connection) override {
-        SLogger::debug("ConnectedEndpointState::changeToConnectedState start");
-        auto self = sharedFromThis<ConnectedEndpointState>();
-        std::scoped_lock lock(this->connectedEndpointStateMutex);
-        this->removeEventHandlers();
-        this->enterState(connection);
-        SLogger::debug("ConnectedEndpointState::changeToConnectedState end");
+        SLogger::debug("ConnectedEndpointState::changeToConnectedState");
+        // The replaced connection is handed off, not closed (matches the
+        // pre-A0 behavior); enterConnectedState re-enters this state
+        // with the new connection.
+        this->stateInterface.enterConnectedState(connection);
+        return {};
     }
 
     [[nodiscard]] bool isConnected() const override {

--- a/packages/streamr-dht/modules/connection/endpoint/ConnectingEndpointState.cppm
+++ b/packages/streamr-dht/modules/connection/endpoint/ConnectingEndpointState.cppm
@@ -30,6 +30,17 @@ export namespace streamr::dht::connection::endpoint {
 using streamr::dht::connection::Connection;
 using streamr::dht::connection::IPendingConnection;
 
+// The state's resources (pending connection, tokens, send buffer) are
+// guarded by the Endpoint's state-machine mutex (phase A0: the former
+// per-state mutex formed an ABBA pair with the endpoint mutex between a
+// sending thread and the connection-event dispatcher thread). Methods
+// overridden from EndpointState are called with that mutex held; the
+// event handlers registered on the pending connection take it
+// themselves and first validate that they still belong to the current
+// pending connection — off() cannot stop a handler that an in-flight
+// emit has already started, and the ReplayEventEmitter can replay a
+// stored event during registration, so token bookkeeping alone is not
+// enough.
 class ConnectingEndpointState : public EndpointState {
 private:
     EndpointStateInterface& stateInterface;
@@ -37,11 +48,38 @@ private:
     std::shared_ptr<IPendingConnection> pendingConnection;
     HandlerToken connectedHandlerToken;
     HandlerToken disconnectedHandlerToken;
-    std::recursive_mutex connectingEndpointStateMutex;
 
     explicit ConnectingEndpointState(EndpointStateInterface& stateInterface)
         : stateInterface(stateInterface) {
         SLogger::debug("ConnectingEndpointState constructor");
+    }
+
+    // Requires the state-machine mutex. Detaches the handlers from the
+    // current pending connection and forgets it; a handler already
+    // running past its off() no-ops on the identity check below.
+    // Default (id 0) tokens are not off()'d: besides being no-ops, the
+    // calls would take the pending connection's handler mutex, and while
+    // the tokens are still uncommitted a registerEventHandlers() replay
+    // on another thread can be running under that same mutex while
+    // waiting for the state-machine mutex — off() here would complete
+    // the ABBA cycle.
+    void detachFromPendingConnection() {
+        SLogger::debug("ConnectingEndpointState::detachFromPendingConnection");
+        if (this->pendingConnection) {
+            if (this->connectedHandlerToken.getId() != 0) {
+                this->pendingConnection
+                    ->off<pendingconnectionevents::Connected>(
+                        this->connectedHandlerToken);
+            }
+            if (this->disconnectedHandlerToken.getId() != 0) {
+                this->pendingConnection
+                    ->off<pendingconnectionevents::Disconnected>(
+                        this->disconnectedHandlerToken);
+            }
+            this->connectedHandlerToken = HandlerToken{};
+            this->disconnectedHandlerToken = HandlerToken{};
+            this->pendingConnection.reset();
+        }
     }
 
 public:
@@ -58,107 +96,177 @@ public:
         SLogger::debug("ConnectingEndpointState destructor");
     }
 
-    void enterState(
+    // Requires the state-machine mutex (called by
+    // Endpoint::enterConnectingState). Replaces the current pending
+    // connection; the buffer is kept — data buffered while waiting for a
+    // pending connection that lost the simultaneous-connect tiebreak
+    // must still go out once its replacement connects.
+    void adoptPendingConnection(
         const std::shared_ptr<IPendingConnection>& pendingConnection) {
-        auto self = sharedFromThis<ConnectingEndpointState>();
-        std::scoped_lock lock(this->connectingEndpointStateMutex);
+        SLogger::debug("ConnectingEndpointState::adoptPendingConnection");
+        this->detachFromPendingConnection();
         this->pendingConnection = pendingConnection;
-        // The returned tokens MUST be stored: removeEventHandlers()
-        // detaches with them, and a pending connection replaced by the
-        // simultaneous-connect tiebreak (Endpoint::setConnecting) would
-        // otherwise keep driving this state — and through it a possibly
-        // already-destroyed Endpoint — when it later completes or fails
-        // (found by the ported SimultaneousConnections test, phase 0.3).
-        this->disconnectedHandlerToken =
-            this->pendingConnection->on<pendingconnectionevents::Disconnected>(
-                [this](bool gracefulLeave) {
-                    std::shared_ptr<ConnectingEndpointState> self;
-                    {
-                        std::scoped_lock lock(
-                            this->connectingEndpointStateMutex);
-                        self = sharedFromThis<ConnectingEndpointState>();
-                        self->pendingConnection
-                            ->off<pendingconnectionevents::Disconnected>(
-                                this->disconnectedHandlerToken);
-                        self->pendingConnection
-                            ->off<pendingconnectionevents::Connected>(
-                                this->connectedHandlerToken);
-                    }
-                    self->stateInterface.handleDisconnect(gracefulLeave);
-                });
-        this->connectedHandlerToken =
-            this->pendingConnection->on<pendingconnectionevents::Connected>(
-                [this](
-                    const PeerDescriptor& /*peerDescriptor*/,
-                    const std::shared_ptr<Connection>& connection) {
-                    std::shared_ptr<ConnectingEndpointState> self;
-                    {
-                        std::scoped_lock lock(
-                            this->connectingEndpointStateMutex);
-                        self = sharedFromThis<ConnectingEndpointState>();
-                    }
-                    self->changeToConnectedState(connection);
-                    self->stateInterface.handleConnected();
-                });
-        SLogger::debug("ConnectingEndpointState::enterState end");
     }
 
-    void close(bool graceful) override {
-        SLogger::debug("ConnectingEndpointState::close start");
-        auto self = sharedFromThis<ConnectingEndpointState>();
-        std::scoped_lock lock(this->connectingEndpointStateMutex);
-        this->removeEventHandlers();
-        this->pendingConnection->close(graceful);
-        SLogger::debug("ConnectingEndpointState::close end");
+    // Requires the state-machine mutex. Endpoint uses this to decide
+    // whether the pending connection it adopted is still the current one
+    // and therefore needs its handlers registered.
+    [[nodiscard]] bool isCurrentPendingConnection(
+        const std::shared_ptr<IPendingConnection>& pendingConnection) const {
+        return this->pendingConnection == pendingConnection;
+    }
+
+    // Must be called WITHOUT the state-machine mutex: the pending
+    // connection is a ReplayEventEmitter, so on() can invoke the handler
+    // synchronously (replaying an event that arrived before registration
+    // — the PR #43 race), and the handler's own call-outs must not run
+    // under the mutex. Registration is therefore a separate step after
+    // the transition instead of part of it; the replay semantics
+    // guarantee nothing is lost in between. The tokens are committed
+    // only if this pending connection is still the current one — a
+    // replayed event or a concurrent transition may have moved the
+    // machine on, in which case the handlers are taken right back off.
+    void registerEventHandlers(
+        const std::shared_ptr<IPendingConnection>& pendingConnection,
+        const std::weak_ptr<void>& endpointPin) {
+        SLogger::debug("ConnectingEndpointState::registerEventHandlers start");
+        std::weak_ptr<ConnectingEndpointState> weakSelf =
+            this->sharedFromThis<ConnectingEndpointState>();
+        auto* rawPendingConnection = pendingConnection.get();
+        // Disconnected is registered first: if the replay store holds
+        // both a Connected and a Disconnected event, the disconnect wins
+        // (the identity check makes the later Connected replay a no-op),
+        // matching the connection's real fate.
+        auto disconnectedToken =
+            pendingConnection->on<pendingconnectionevents::Disconnected>(
+                [weakSelf, endpointPin, rawPendingConnection](
+                    bool /*gracefulLeave*/) {
+                    // The pin keeps the Endpoint (and with it this
+                    // state) alive for the duration of the handler.
+                    const auto pin = endpointPin.lock();
+                    if (!pin) {
+                        return;
+                    }
+                    const auto self = weakSelf.lock();
+                    if (!self) {
+                        return;
+                    }
+                    bool transitioned = false;
+                    {
+                        std::scoped_lock lock(
+                            self->stateInterface.getStateMachineMutex());
+                        if (self->pendingConnection.get() !=
+                            rawPendingConnection) {
+                            return; // stale handler of a replaced pending
+                                    // connection
+                        }
+                        self->detachFromPendingConnection();
+                        self->buffer.clear();
+                        transitioned =
+                            self->stateInterface.enterDisconnectedState();
+                    }
+                    if (transitioned) {
+                        self->stateInterface.finishDisconnect();
+                    }
+                });
+        auto connectedToken =
+            pendingConnection->on<pendingconnectionevents::Connected>(
+                [weakSelf, endpointPin, rawPendingConnection](
+                    const PeerDescriptor& /*peerDescriptor*/,
+                    const std::shared_ptr<Connection>& connection) {
+                    const auto pin = endpointPin.lock();
+                    if (!pin) {
+                        return;
+                    }
+                    const auto self = weakSelf.lock();
+                    if (!self) {
+                        return;
+                    }
+                    bool transitioned = false;
+                    {
+                        std::scoped_lock lock(
+                            self->stateInterface.getStateMachineMutex());
+                        if (self->pendingConnection.get() !=
+                            rawPendingConnection) {
+                            return; // stale handler of a replaced pending
+                                    // connection
+                        }
+                        self->detachFromPendingConnection();
+                        // Flushing under the mutex keeps the buffered
+                        // bytes ordered before any send() that observes
+                        // the connected state (connection->send() emits
+                        // nothing, so it is safe to call here).
+                        if (!self->buffer.empty()) {
+                            connection->send(self->buffer);
+                            self->buffer.clear();
+                        }
+                        self->stateInterface.enterConnectedState(connection);
+                        transitioned = true;
+                    }
+                    if (transitioned) {
+                        self->stateInterface.emitConnected();
+                    }
+                });
+        {
+            std::scoped_lock lock(this->stateInterface.getStateMachineMutex());
+            if (this->pendingConnection == pendingConnection) {
+                this->disconnectedHandlerToken = disconnectedToken;
+                this->connectedHandlerToken = connectedToken;
+                SLogger::debug(
+                    "ConnectingEndpointState::registerEventHandlers end");
+                return;
+            }
+        }
+        pendingConnection->off<pendingconnectionevents::Disconnected>(
+            disconnectedToken);
+        pendingConnection->off<pendingconnectionevents::Connected>(
+            connectedToken);
+        SLogger::debug(
+            "ConnectingEndpointState::registerEventHandlers end (machine"
+            " moved on during registration)");
+    }
+
+    [[nodiscard]] DeferredCallout close(bool graceful) override {
+        SLogger::debug("ConnectingEndpointState::close");
+        auto pendingConnection = this->pendingConnection;
+        this->detachFromPendingConnection();
+        this->buffer.clear();
+        if (!pendingConnection) {
+            return {};
+        }
+        // pendingConnection->close() emits its Disconnected event, so it
+        // must run after the mutex is released.
+        return [pendingConnection, graceful]() {
+            pendingConnection->close(graceful);
+        };
     }
 
     void send(const std::vector<std::byte>& data) override {
-        SLogger::debug("ConnectingEndpointState::send start");
-        auto self = sharedFromThis<ConnectingEndpointState>();
-        SLogger::debug("ConnectingEndpointState::send acquiring scoped lock");
-        std::scoped_lock lock(this->connectingEndpointStateMutex);
-        SLogger::debug("ConnectingEndpointState::send lock acquired");
+        SLogger::debug("ConnectingEndpointState::send");
         this->buffer.insert(this->buffer.end(), data.begin(), data.end());
-        SLogger::debug("ConnectingEndpointState::send end");
     }
 
-    void removeEventHandlers() {
-        SLogger::debug("ConnectingEndpointState::removeEventHandlers start");
-        auto self = sharedFromThis<ConnectingEndpointState>();
-        std::scoped_lock lock(this->connectingEndpointStateMutex);
-        if (this->pendingConnection) {
-            this->pendingConnection->off<pendingconnectionevents::Connected>(
-                this->connectedHandlerToken);
-            this->pendingConnection->off<pendingconnectionevents::Disconnected>(
-                this->disconnectedHandlerToken);
-        }
-        SLogger::debug("ConnectingEndpointState::removeEventHandlers end");
-    }
-
-    void changeToConnectingState(
+    [[nodiscard]] DeferredCallout changeToConnectingState(
         const std::shared_ptr<IPendingConnection>& pendingConnection) override {
-        SLogger::debug(
-            "ConnectingEndpointState::changeToConnectingState start");
-        auto self = sharedFromThis<ConnectingEndpointState>();
-        std::scoped_lock lock(this->connectingEndpointStateMutex);
-        this->removeEventHandlers();
-        this->enterState(pendingConnection);
-        SLogger::debug("ConnectingEndpointState::changeToConnectingState end");
+        SLogger::debug("ConnectingEndpointState::changeToConnectingState");
+        // Simultaneous-connect tiebreak: the new pending connection
+        // replaces the current one.
+        this->stateInterface.enterConnectingState(pendingConnection);
+        return {};
     }
 
-    void changeToConnectedState(
+    [[nodiscard]] DeferredCallout changeToConnectedState(
         const std::shared_ptr<Connection>& connection) override {
-        SLogger::debug("ConnectingEndpointState::changeToConnectedState start");
-        auto self = sharedFromThis<ConnectingEndpointState>();
-        std::scoped_lock lock(this->connectingEndpointStateMutex);
-        this->removeEventHandlers();
-
+        SLogger::debug("ConnectingEndpointState::changeToConnectedState");
+        this->detachFromPendingConnection();
         if (!this->buffer.empty()) {
             connection->send(this->buffer);
+            this->buffer.clear();
         }
-        this->stateInterface.changeToConnectedState(connection);
-        SLogger::debug("ConnectingEndpointState::changeToConnectedState end");
+        this->stateInterface.enterConnectedState(connection);
+        return {};
     }
+
     [[nodiscard]] bool isConnected() const override {
         SLogger::debug("ConnectingEndpointState::isConnected");
         return false;

--- a/packages/streamr-dht/modules/connection/endpoint/DisconnectedEndpointState.cppm
+++ b/packages/streamr-dht/modules/connection/endpoint/DisconnectedEndpointState.cppm
@@ -27,12 +27,17 @@ using streamr::dht::connection::Connection;
 using streamr::dht::connection::IPendingConnection;
 using streamr::dht::helpers::SendFailed;
 
+// Terminal state: a disconnected endpoint ignores further transitions
+// (a connection accepted for it by the simultaneous-connect tiebreak
+// while the disconnect was completing is deliberately dropped). All
+// methods are called with the state-machine mutex held; see
+// EndpointState for the contract.
 class DisconnectedEndpointState : public EndpointState {
 private:
-    EndpointStateInterface& stateInterface;
-
-    explicit DisconnectedEndpointState(EndpointStateInterface& stateInterface)
-        : stateInterface(stateInterface) {
+    // The terminal state drives no further transitions, so unlike its
+    // siblings it does not keep the EndpointStateInterface reference.
+    explicit DisconnectedEndpointState(
+        EndpointStateInterface& /*stateInterface*/) {
         SLogger::debug("DisconnectedEndpointState constructor");
     }
 
@@ -50,31 +55,27 @@ public:
         SLogger::debug("DisconnectedEndpointState destructor");
     }
 
-    void close(bool /*graceful*/) override {
-        SLogger::debug("DisconnectedEndpointState::close start");
-        SLogger::debug("DisconnectedEndpointState::close end");
+    [[nodiscard]] DeferredCallout close(bool /*graceful*/) override {
+        SLogger::debug("DisconnectedEndpointState::close");
+        return {};
     }
 
     void send(const std::vector<std::byte>& /* data */) override {
-        SLogger::debug("DisconnectedEndpointState::send start");
-        SLogger::debug("DisconnectedEndpointState::send end");
+        SLogger::debug("DisconnectedEndpointState::send");
         throw SendFailed("send() called on disconnected endpoint");
     }
 
-    void changeToConnectingState(
+    [[nodiscard]] DeferredCallout changeToConnectingState(
         const std::shared_ptr<IPendingConnection>& /*pendingConnection*/)
         override {
-        SLogger::debug(
-            "DisconnectedEndpointState::changeToConnectingState start");
-        SLogger::debug(
-            "DisconnectedEndpointState::changeToConnectingState end");
+        SLogger::debug("DisconnectedEndpointState::changeToConnectingState");
+        return {};
     }
 
-    void changeToConnectedState(
+    [[nodiscard]] DeferredCallout changeToConnectedState(
         const std::shared_ptr<Connection>& /*connection*/) override {
-        SLogger::debug(
-            "DisconnectedEndpointState::changeToConnectedState start");
-        SLogger::debug("DisconnectedEndpointState::changeToConnectedState end");
+        SLogger::debug("DisconnectedEndpointState::changeToConnectedState");
+        return {};
     }
 
     [[nodiscard]] bool isConnected() const override {

--- a/packages/streamr-dht/modules/connection/endpoint/Endpoint.cppm
+++ b/packages/streamr-dht/modules/connection/endpoint/Endpoint.cppm
@@ -5,6 +5,7 @@
 module;
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -50,51 +51,87 @@ using EndpointEvents = std::tuple<
 
 // Endpoint implements EndpointStateInterface (privately) so the state
 // classes can drive the machine through the abstract interface — see
-// EndpointStateInterface.hpp for why this replaces the former concrete
-// forwarder member.
+// EndpointStateInterface.cppm for why this replaces the former concrete
+// forwarder member, and for the locking contract this class implements
+// (phase A0): one mutex guards the whole state machine, transitions
+// happen under it, and every call-out that can emit an event runs after
+// it is released. Each public method is therefore two-phase: a locked
+// section that asks the current state to transition (collecting any
+// deferred call-out it returns), then the call-outs.
 class Endpoint : public EventEmitter<EndpointEvents>,
                  public EnableSharedFromThis,
                  private EndpointStateInterface {
 private:
     std::function<void()> removeSelfFromContainer;
     EndpointState* state;
+    // The single state-machine mutex; guards the current-state pointer
+    // and all state-owned resources. Recursive because the states drive
+    // nested transitions through EndpointStateInterface while the public
+    // entry point already holds it.
     std::recursive_mutex mutex;
+    // Highest pending-connection sequence number adopted so far; guarded
+    // by mutex. See setConnecting().
+    uint64_t lastConnectingSequence = 0;
+
+    // --- EndpointStateInterface (called by the state classes) ---
+
+    std::recursive_mutex& getStateMachineMutex() override {
+        return this->mutex;
+    }
+
+    void enterConnectingState(
+        const std::shared_ptr<IPendingConnection>& pendingConnection) override {
+        SLogger::debug("Endpoint::enterConnectingState");
+        this->state = this->connectingState.get();
+        this->connectingState->adoptPendingConnection(pendingConnection);
+    }
+
+    void enterConnectedState(
+        const std::shared_ptr<Connection>& connection) override {
+        SLogger::debug("Endpoint::enterConnectedState");
+        this->state = this->connectedState.get();
+        this->connectedState->enterState(connection, this->weakPin());
+    }
+
+    bool enterDisconnectedState() override {
+        SLogger::debug("Endpoint::enterDisconnectedState");
+        if (this->state == this->disconnectedState.get()) {
+            return false;
+        }
+        this->state = this->disconnectedState.get();
+        return true;
+    }
 
     void emitData(const std::vector<std::byte>& data) override {
-        SLogger::debug("Endpoint::emitData start");
-        auto self = sharedFromThis<Endpoint>();
-        std::scoped_lock lock(this->mutex);
+        SLogger::debug("Endpoint::emitData");
         this->emit<endpointevents::Data>(data);
-        SLogger::debug("Endpoint::emitData end");
     }
 
-    void handleDisconnect(bool /*gracefulLeave*/) override {
-        SLogger::debug("Endpoint::handleDisconnect start");
-        auto self = sharedFromThis<Endpoint>();
-        std::scoped_lock lock(this->mutex);
-        this->state = this->disconnectedState.get();
+    void emitConnected() override {
+        SLogger::debug("Endpoint::emitConnected");
+        this->emit<endpointevents::Connected>();
+    }
+
+    void finishDisconnect() override {
+        SLogger::debug("Endpoint::finishDisconnect start");
+        // Container removal (and the container's own Disconnected
+        // notification) must complete before the endpoint-level emit:
+        // ConnectionManager::gracefullyDisconnect() resumes on the
+        // endpoint-level event and stop() then removes all transport
+        // listeners — the reverse order loses the transport-level
+        // Disconnected on the stopping side (seen as the disconnected3
+        // timeout in the ConnectionManagerIntegrationTest stress runs).
+        this->removeSelfFromContainer();
         this->emit<endpointevents::Disconnected>();
         this->removeAllListeners();
-        this->removeSelfFromContainer();
-        SLogger::debug("Endpoint::handleDisconnect end");
+        SLogger::debug("Endpoint::finishDisconnect end");
     }
 
-    void changeToConnectedState(
-        const std::shared_ptr<Connection>& connection) override {
-        SLogger::debug("Endpoint::changeToConnectedState start");
-        auto self = sharedFromThis<Endpoint>();
-        std::scoped_lock lock(this->mutex);
-        this->state = this->connectedState.get();
-        this->connectedState->enterState(connection);
-        SLogger::debug("Endpoint::changeToConnectedState end");
-    }
-
-    void handleConnected() override {
-        SLogger::debug("Endpoint::handleConnected start");
-        auto self = sharedFromThis<Endpoint>();
-        std::scoped_lock lock(this->mutex);
-        this->emit<endpointevents::Connected>();
-        SLogger::debug("Endpoint::handleConnected end");
+    // Type-erased weak reference the state handlers pin before touching
+    // the machine, so a late connection event cannot race the Endpoint's
+    // destruction (the states only hold a plain reference back here).
+    [[nodiscard]] std::weak_ptr<void> weakPin() {
+        return this->sharedFromThis<Endpoint>();
     }
 
     std::shared_ptr<InitialEndpointState> initialState;
@@ -135,14 +172,62 @@ public:
 
     ~Endpoint() override { SLogger::debug("Endpoint destructor"); }
 
-    void changeToConnectingState(
-        const std::shared_ptr<IPendingConnection>& pendingConnection) override {
-        SLogger::debug("Endpoint::changeToConnectingState start");
-        auto self = sharedFromThis<Endpoint>();
-        std::scoped_lock lock(this->mutex);
-        this->state = this->connectingState.get();
-        this->connectingState->enterState(pendingConnection);
-        SLogger::debug("Endpoint::changeToConnectingState end");
+    // sequenceNumber orders the pending connections handed to this
+    // endpoint. ConnectionManager assigns it under endpointsMutex, so it
+    // reflects the order in which the tie-break DECIDED, which can differ
+    // from the order in which these setConnecting() calls actually run
+    // (the initial adoption from send() on the main thread races the
+    // replacing adoption from an incoming connection on the connector's
+    // dispatcher thread). Adopting only strictly-newer sequence numbers
+    // makes the outcome independent of that thread race, so both peers
+    // still converge on the connection the tie-break chose.
+    void setConnecting(
+        const std::shared_ptr<IPendingConnection>& pendingConnection,
+        uint64_t sequenceNumber) {
+        SLogger::debug("Endpoint::setConnecting start");
+        auto self = this->sharedFromThis<Endpoint>();
+        std::function<void()> callout;
+        bool adopted = false;
+        {
+            std::scoped_lock lock(this->mutex);
+            if (sequenceNumber <= this->lastConnectingSequence) {
+                SLogger::debug(
+                    "Endpoint::setConnecting ignoring superseded pending"
+                    " connection");
+                return;
+            }
+            this->lastConnectingSequence = sequenceNumber;
+            callout = this->state->changeToConnectingState(pendingConnection);
+            adopted = this->state == this->connectingState.get() &&
+                this->connectingState->isCurrentPendingConnection(
+                    pendingConnection);
+        }
+        if (callout) {
+            callout();
+        }
+        if (adopted) {
+            // Registering on the (replaying) pending connection may
+            // complete the connection synchronously, so it must happen
+            // outside the mutex — see
+            // ConnectingEndpointState::registerEventHandlers.
+            this->connectingState->registerEventHandlers(
+                pendingConnection, self);
+        }
+        SLogger::debug("Endpoint::setConnecting end");
+    }
+
+    void setConnected(const std::shared_ptr<Connection>& connection) {
+        SLogger::debug("Endpoint::setConnected start");
+        auto self = this->sharedFromThis<Endpoint>();
+        std::function<void()> callout;
+        {
+            std::scoped_lock lock(this->mutex);
+            callout = this->state->changeToConnectedState(connection);
+        }
+        if (callout) {
+            callout();
+        }
+        SLogger::debug("Endpoint::setConnected end");
     }
 
     [[nodiscard]] bool isConnected() {
@@ -151,50 +236,42 @@ public:
         return this->state->isConnected();
     }
 
-    [[nodiscard]] PeerDescriptor getPeerDescriptor() {
+    [[nodiscard]] PeerDescriptor getPeerDescriptor() const {
         SLogger::debug("Endpoint::getPeerDescriptor");
-        SLogger::debug("Endpoint::getPeerDescriptor acquiring scoped lock");
-        std::scoped_lock lock(this->mutex);
-        SLogger::debug("Endpoint::getPeerDescriptor got scoped lock");
+        // Immutable after construction, so no lock is needed — callers
+        // may hold container locks.
         return this->peerDescriptor;
     }
 
     void close(bool graceful) {
         SLogger::debug("Endpoint::close start");
-        auto self = sharedFromThis<Endpoint>();
-        std::scoped_lock lock(this->mutex);
-        this->state->close(graceful);
-        this->removeAllListeners();
-        this->removeSelfFromContainer();
+        auto self = this->sharedFromThis<Endpoint>();
+        std::function<void()> callout;
+        bool transitioned = false;
+        {
+            std::scoped_lock lock(this->mutex);
+            callout = this->state->close(graceful);
+            transitioned = this->enterDisconnectedState();
+        }
+        if (callout) {
+            callout();
+        }
+        if (transitioned) {
+            this->finishDisconnect();
+        }
         SLogger::debug("Endpoint::close end");
     }
 
     void send(const std::vector<std::byte>& data) {
-        SLogger::debug("Endpoint::send() start");
-        SLogger::debug("Endpoint::send() acquiring scoped lock");
-        auto self = sharedFromThis<Endpoint>();
+        SLogger::debug("Endpoint::send start");
+        auto self = this->sharedFromThis<Endpoint>();
         std::scoped_lock lock(this->mutex);
-        SLogger::debug(
-            "Endpoint::send() acquired scoped lock and calling state->send()");
+        // ConnectedEndpointState forwards to connection->send() under
+        // the mutex: a deliberate exception to the no-call-outs rule —
+        // it emits nothing, and holding the mutex keeps direct sends
+        // ordered with the connecting-state buffer flush.
         this->state->send(data);
-        SLogger::debug("Endpoint::send() state->send() returned");
-    }
-
-    void setConnecting(
-        const std::shared_ptr<IPendingConnection>& pendingConnection) {
-        auto self = sharedFromThis<Endpoint>();
-        std::scoped_lock lock(this->mutex);
-        SLogger::debug("Endpoint::setConnecting start");
-        this->state->changeToConnectingState(pendingConnection);
-        SLogger::debug("Endpoint::setConnecting end");
-    }
-
-    void setConnected(const std::shared_ptr<Connection>& connection) {
-        SLogger::debug("Endpoint::setConnected start");
-        auto self = sharedFromThis<Endpoint>();
-        std::scoped_lock lock(this->mutex);
-        this->state->changeToConnectedState(connection);
-        SLogger::debug("Endpoint::setConnected end");
+        SLogger::debug("Endpoint::send end");
     }
 };
 

--- a/packages/streamr-dht/modules/connection/endpoint/EndpointState.cppm
+++ b/packages/streamr-dht/modules/connection/endpoint/EndpointState.cppm
@@ -5,6 +5,7 @@
 module;
 
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -25,26 +26,33 @@ export namespace streamr::dht::connection::endpoint {
 using streamr::dht::connection::Connection;
 using streamr::dht::connection::IPendingConnection;
 
+// LOCKING CONTRACT (phase A0, see EndpointStateInterface): every method
+// here is called by Endpoint with the state-machine mutex held. Methods
+// that need to perform a call-out (closing a connection or a pending
+// connection — both can emit events synchronously) must not do it
+// inline; they return it as a DeferredCallout, which Endpoint runs after
+// releasing the mutex.
 class EndpointState : public EnableSharedFromThis {
 protected:
     EndpointState() { SLogger::debug("EndpointState constructor"); }
 
 public:
+    using DeferredCallout = std::function<void()>;
+
     ~EndpointState() override { SLogger::debug("EndpointState destructor"); }
 
-    virtual void close(bool /*graceful*/) {
-        SLogger::debug("EndpointState::close start");
-        SLogger::debug("EndpointState::close end");
+    [[nodiscard]] virtual DeferredCallout close(bool /*graceful*/) {
+        SLogger::debug("EndpointState::close");
+        return {};
     };
     virtual void send(const std::vector<std::byte>& /* data */) {
-        SLogger::debug("EndpointState::send start");
-        SLogger::debug("EndpointState::send end");
+        SLogger::debug("EndpointState::send");
     };
 
-    virtual void changeToConnectingState(
+    [[nodiscard]] virtual DeferredCallout changeToConnectingState(
         const std::shared_ptr<IPendingConnection>& pendingConnection) = 0;
 
-    virtual void changeToConnectedState(
+    [[nodiscard]] virtual DeferredCallout changeToConnectedState(
         const std::shared_ptr<Connection>& connection) = 0;
 
     [[nodiscard]] virtual bool isConnected() const = 0;

--- a/packages/streamr-dht/modules/connection/endpoint/EndpointStateInterface.cppm
+++ b/packages/streamr-dht/modules/connection/endpoint/EndpointStateInterface.cppm
@@ -6,6 +6,7 @@ module;
 
 #include <cstddef>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 export module streamr.dht.EndpointStateInterface;
@@ -25,16 +26,46 @@ using streamr::dht::connection::IPendingConnection;
 // depends on the states and the states depend only on this interface.
 // (This was the only header cycle in the monorepo; the planned module
 // consolidation needs the header graph to be a DAG.)
+//
+// LOCKING CONTRACT (phase A0 of trackerless-network-completion-plan.md):
+// the whole state machine — the current-state pointer and every
+// state-owned resource (pending connection, connection, handler tokens,
+// send buffer) — is guarded by ONE mutex, owned by Endpoint and reached
+// through getStateMachineMutex(). The former per-state mutexes are gone:
+// they formed an ABBA pair with the endpoint mutex between a sending
+// thread and the connection-event dispatcher thread. The methods below
+// are split by that contract:
+//  - the enter*State() transitions REQUIRE the state-machine mutex to be
+//    held by the caller and perform no call-outs;
+//  - emitData(), emitConnected() and finishDisconnect() perform the
+//    call-outs (event emits, container removal) and must be called with
+//    the state-machine mutex NOT held: a handler of those events may
+//    call back into the state machine from another thread, so emitting
+//    under the mutex deadlocks against the emitter's per-event emit-loop
+//    mutex.
 class EndpointStateInterface {
 public:
     virtual ~EndpointStateInterface() = default;
-    virtual void changeToConnectingState(
+
+    // The single state-machine mutex. State event handlers lock it
+    // before validating that they are still relevant and transitioning.
+    virtual std::recursive_mutex& getStateMachineMutex() = 0;
+
+    // Transitions: caller must hold the state-machine mutex.
+    virtual void enterConnectingState(
         const std::shared_ptr<IPendingConnection>& pendingConnection) = 0;
-    virtual void changeToConnectedState(
+    virtual void enterConnectedState(
         const std::shared_ptr<Connection>& connection) = 0;
+    // Returns false if the machine already was in the disconnected state,
+    // so the disconnect call-outs run exactly once.
+    virtual bool enterDisconnectedState() = 0;
+
+    // Call-outs: caller must NOT hold the state-machine mutex.
     virtual void emitData(const std::vector<std::byte>& data) = 0;
-    virtual void handleDisconnect(bool gracefulLeave) = 0;
-    virtual void handleConnected() = 0;
+    virtual void emitConnected() = 0;
+    // Emits the Disconnected event and removes the endpoint from its
+    // container; the final step of every disconnect/close path.
+    virtual void finishDisconnect() = 0;
 };
 
 } // namespace streamr::dht::connection::endpoint

--- a/packages/streamr-dht/modules/connection/endpoint/InitialEndpointState.cppm
+++ b/packages/streamr-dht/modules/connection/endpoint/InitialEndpointState.cppm
@@ -27,6 +27,8 @@ using streamr::dht::connection::Connection;
 using streamr::dht::connection::IPendingConnection;
 using streamr::dht::helpers::SendFailed;
 
+// All methods are called with the state-machine mutex held; see
+// EndpointState for the contract.
 class InitialEndpointState : public EndpointState {
 private:
     EndpointStateInterface& stateInterface;
@@ -50,31 +52,27 @@ public:
         SLogger::debug("InitialEndpointState destructor");
     }
 
-    void close(bool /*graceful*/) override {
-        SLogger::debug("InitialEndpointState::close start");
-        SLogger::debug("InitialEndpointState::close end");
+    [[nodiscard]] DeferredCallout close(bool /*graceful*/) override {
+        SLogger::debug("InitialEndpointState::close");
+        return {};
     }
 
     void send(const std::vector<std::byte>& /* data */) override {
-        SLogger::debug("InitialEndpointState::send start");
-        SLogger::debug("InitialEndpointState::send end");
+        SLogger::debug("InitialEndpointState::send");
         throw SendFailed("send() called on endpoint in initial state");
     }
 
-    void changeToConnectingState(
+    [[nodiscard]] DeferredCallout changeToConnectingState(
         const std::shared_ptr<IPendingConnection>& pendingConnection) override {
-        SLogger::debug("InitialEndpointState::changeToConnectingState start");
-
-        auto self = sharedFromThis<InitialEndpointState>();
-        this->stateInterface.changeToConnectingState(pendingConnection);
-
-        SLogger::debug("InitialEndpointState::changeToConnectingState end");
+        SLogger::debug("InitialEndpointState::changeToConnectingState");
+        this->stateInterface.enterConnectingState(pendingConnection);
+        return {};
     }
 
-    void changeToConnectedState(
+    [[nodiscard]] DeferredCallout changeToConnectedState(
         const std::shared_ptr<Connection>& /*connection*/) override {
-        SLogger::debug("InitialEndpointState::changeToConnectedState start");
-        SLogger::debug("InitialEndpointState::changeToConnectedState end");
+        SLogger::debug("InitialEndpointState::changeToConnectedState");
+        return {};
     }
 
     [[nodiscard]] bool isConnected() const override {

--- a/packages/streamr-dht/test/integration/ConnectionManagerIntegrationTest.cpp
+++ b/packages/streamr-dht/test/integration/ConnectionManagerIntegrationTest.cpp
@@ -39,7 +39,8 @@ namespace {
 
 constexpr auto serviceId = "demo";
 
-void expectCondition(std::function<bool()>&& condition) {
+void expectCondition(const char* label, std::function<bool()>&& condition) {
+    SCOPED_TRACE(label);
     auto task = waitForCondition(std::move(condition));
     EXPECT_NO_THROW(streamr::utils::blockingWait(std::move(task)));
 }
@@ -98,15 +99,20 @@ TEST(
     msg.mutable_targetdescriptor()->CopyFrom(peerDescriptor4);
     connectionManager3->send(msg, SendOptions{});
 
-    expectCondition([&dataReceived]() { return dataReceived.load(); });
-    expectCondition([&connected3]() { return connected3.load(); });
-    expectCondition([&connected4]() { return connected4.load(); });
+    expectCondition(
+        "dataReceived", [&dataReceived]() { return dataReceived.load(); });
+    expectCondition(
+        "connected3", [&connected3]() { return connected3.load(); });
+    expectCondition(
+        "connected4", [&connected4]() { return connected4.load(); });
 
     // disconnect through the public API (see the header comment)
     connectionManager3->stop();
 
-    expectCondition([&disconnected3]() { return disconnected3.load(); });
-    expectCondition([&disconnected4]() { return disconnected4.load(); });
+    expectCondition(
+        "disconnected3", [&disconnected3]() { return disconnected3.load(); });
+    expectCondition(
+        "disconnected4", [&disconnected4]() { return disconnected4.load(); });
 
     connectionManager4->stop();
     simulator2.stop();

--- a/packages/streamr-dht/test/integration/SimultaneousConnectionsTest.cpp
+++ b/packages/streamr-dht/test/integration/SimultaneousConnectionsTest.cpp
@@ -54,7 +54,8 @@ PeerDescriptor createPeerDescriptorWithRandomRegion() {
     return descriptor;
 }
 
-void expectCondition(std::function<bool()>&& condition) {
+void expectCondition(const char* label, std::function<bool()>&& condition) {
+    SCOPED_TRACE(label);
     auto task = waitForCondition(std::move(condition));
     EXPECT_NO_THROW(streamr::utils::blockingWait(std::move(task)));
 }
@@ -90,16 +91,18 @@ TEST(SimultaneousConnectionsTest, SimultaneousSimulatedConnection) {
     transport1->send(createBaseMessage(peerDescriptor2), SendOptions{});
     transport2->send(createBaseMessage(peerDescriptor1), SendOptions{});
 
-    expectCondition([&received1]() { return received1.load(); });
-    expectCondition([&received2]() { return received2.load(); });
-    expectCondition([&transport2, &peerDescriptor1]() {
-        return transport2->hasConnection(
-            Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor1));
-    });
-    expectCondition([&transport1, &peerDescriptor2]() {
-        return transport1->hasConnection(
-            Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor2));
-    });
+    expectCondition("received1", [&received1]() { return received1.load(); });
+    expectCondition("received2", [&received2]() { return received2.load(); });
+    expectCondition(
+        "transport2 has connection", [&transport2, &peerDescriptor1]() {
+            return transport2->hasConnection(
+                Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor1));
+        });
+    expectCondition(
+        "transport1 has connection", [&transport1, &peerDescriptor2]() {
+            return transport1->hasConnection(
+                Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor2));
+        });
 
     transport1->stop();
     transport2->stop();

--- a/packages/streamr-dht/test/unit/HandshakerTest.cpp
+++ b/packages/streamr-dht/test/unit/HandshakerTest.cpp
@@ -39,6 +39,7 @@ public:
         (const, override)); // NOLINT
     MOCK_METHOD(
         void, onError, (const std::exception_ptr&), (override)); // NOLINT
+    MOCK_METHOD(void, replaceAsDuplicate, (), (override)); // NOLINT
 };
 
 class MockConnection : public Connection {

--- a/packages/streamr-eventemitter/modules/EventEmitter.cppm
+++ b/packages/streamr-eventemitter/modules/EventEmitter.cppm
@@ -192,7 +192,6 @@ public:
         MatchingEventType<EmitterEventType> EventType,
         MatchingCallbackType<EmitterEventType> CallbackType>
     HandlerToken on(const CallbackType& callback, bool once = false) {
-        std::lock_guard guard{mEventHandlersMutex};
         typename EmitterEventType::Handler::HandlerFunction handlerFunction =
             callback;
         // silently ignore null callbacks
@@ -205,15 +204,55 @@ public:
             handlerFunction, handlerReference.getId(), once);
 
         if constexpr (ReplayLatestEventToNewListeners) {
-            std::lock_guard guard{mLatestEventMutex};
-            if (mLatestEvent.has_value()) {
-                invokeLatestEvent(handler, mLatestEvent.value().getArguments());
+            // The replay-check and the registration are one atomic step
+            // under mEventHandlersMutex, matching emit()'s latest-store +
+            // snapshot (also under mEventHandlersMutex): a listener that
+            // registers concurrently with an emit either lands in that
+            // emit's snapshot (live dispatch, and it observed no stored
+            // event here) or observes the stored event and replays it
+            // (and is absent from that snapshot) — never neither, never
+            // both.
+            //
+            // The replayed handler is invoked AFTER the mutex is
+            // released. It is user code that may take its own locks and
+            // call back into on()/off(); invoking it under
+            // mEventHandlersMutex is an ABBA deadlock against a thread
+            // that holds such a user lock and calls off() (which needs
+            // mEventHandlersMutex). This is deliberately NOT serialized
+            // with emit() through mEmitLoopMutex: taking mEmitLoopMutex
+            // here would self-deadlock when a handler runs on()/once()
+            // during an emit on the same thread. The cost is that, under
+            // a concurrent emit, a brand-new listener could observe a
+            // newer live event before its replay of the older stored one;
+            // the ReplayEventEmitter is only used for terminal one-shot
+            // events (a pending connection's single Connected xor
+            // Disconnected), where no such ordering arises.
+            std::optional<typename EmitterEventType::ArgumentTypes>
+                replayArguments;
+            {
+                std::lock_guard guard{mEventHandlersMutex};
+                {
+                    std::lock_guard latestGuard{mLatestEventMutex};
+                    if (mLatestEvent.has_value()) {
+                        replayArguments = mLatestEvent.value().getArguments();
+                    }
+                }
+                // a once-listener satisfied by the replay is never
+                // registered at all
+                if (!(once && replayArguments.has_value())) {
+                    mEventHandlers.push_back(handler);
+                }
+            }
+            if (replayArguments.has_value()) {
+                invokeLatestEvent(handler, std::move(replayArguments.value()));
                 if (once) {
                     return HandlerToken{};
                 }
             }
+            return handlerReference;
         }
 
+        std::lock_guard guard{mEventHandlersMutex};
         mEventHandlers.push_back(handler);
         return handlerReference;
     }
@@ -315,7 +354,15 @@ public:
 
         while (auto ret = popHandlerFromExecutingEmitLoopHandlersMap()) {
             auto handler = ret.value();
-            std::invoke(handler, std::forward<EventArgs>(args)...);
+            // Pass the arguments as lvalues, NOT std::forward: every
+            // handler must receive its own copy. Forwarding here moved
+            // the arguments into the first handler's by-value parameters,
+            // leaving the second and later handlers with moved-from
+            // values (an empty vector for a Data<std::vector<std::byte>>
+            // event, for instance). The per-handler copy is the intended
+            // fan-out semantics; Handler::operator() then moves the copy
+            // on into the stored std::function.
+            std::invoke(handler, args...);
             if (handler.isOnce()) {
                 std::lock_guard guard{mEventHandlersMutex};
                 mEventHandlers.remove(handler);

--- a/packages/streamr-eventemitter/test/unit/EventEmitterTest.cpp
+++ b/packages/streamr-eventemitter/test/unit/EventEmitterTest.cpp
@@ -3,9 +3,12 @@
 #include <future>
 #include <iostream>
 #include <list>
+#include <mutex>
+#include <string>
 #include <string_view>
 #include <thread>
 #include <tuple>
+#include <vector>
 #include <gtest/gtest.h>
 
 import streamr.eventemitter.EventEmitter;
@@ -13,6 +16,7 @@ import streamr.eventemitter.EventEmitter;
 using streamr::eventemitter::Event;
 using streamr::eventemitter::EventEmitter;
 using streamr::eventemitter::HandlerToken;
+using streamr::eventemitter::ReplayEventEmitter;
 
 class EventEmitterTest : public ::testing::Test {
 protected:
@@ -56,6 +60,95 @@ TEST_F(EventEmitterTest, TestEmitMultipleListeners) {
 
     ASSERT_EQ(promise1.get_future().get(), "Hello, world!");
     ASSERT_EQ(promise2.get_future().get(), "Hello, world!");
+}
+
+TEST_F(EventEmitterTest, EachListenerReceivesItsOwnCopyOfMoveSensitiveArgs) {
+    // Regression test: the emit loop must hand each listener its own copy
+    // of the arguments. It used to std::forward the arguments into every
+    // invocation, so the first listener move-constructed its by-value
+    // parameter from the emit arguments and every later listener saw a
+    // moved-from (empty) value.
+    struct Payload : Event<std::vector<std::byte>> {};
+    using Events = std::tuple<Payload>;
+
+    EventEmitter<Events> eventEmitter;
+
+    std::vector<size_t> receivedSizes;
+    std::mutex receivedSizesMutex;
+    auto record = [&receivedSizes,
+                   &receivedSizesMutex](const std::vector<std::byte>& data) {
+        std::lock_guard lock(receivedSizesMutex);
+        receivedSizes.push_back(data.size());
+    };
+    eventEmitter.on<Payload>(record);
+    eventEmitter.on<Payload>(record);
+    eventEmitter.on<Payload>(record);
+
+    constexpr size_t payloadSize = 4;
+    constexpr std::byte fillByte{0x07};
+    std::vector<std::byte> data(payloadSize, fillByte);
+    eventEmitter.emit<Payload>(data);
+
+    ASSERT_EQ(receivedSizes.size(), 3U);
+    for (const auto size : receivedSizes) {
+        EXPECT_EQ(size, payloadSize);
+    }
+}
+
+TEST_F(
+    EventEmitterTest,
+    ReplayEmitterReplaysLatestEventExactlyOnceToLateListener) {
+    struct Greeting : Event<std::string> {};
+    using Events = std::tuple<Greeting>;
+
+    ReplayEventEmitter<Events> eventEmitter;
+    eventEmitter.emit<Greeting>("stored");
+
+    int callCount = 0;
+    std::string lastMessage;
+    eventEmitter.on<Greeting>([&callCount, &lastMessage](std::string message) {
+        ++callCount;
+        lastMessage = std::move(message);
+    });
+
+    EXPECT_EQ(callCount, 1);
+    EXPECT_EQ(lastMessage, "stored");
+}
+
+TEST_F(
+    EventEmitterTest,
+    ReplayEmitterHoldsNoHandlerMutexWhileInvokingReplayHandler) {
+    // The replayed handler must be invoked with NO internal EventEmitter
+    // mutex held, otherwise a handler that takes a user lock deadlocks
+    // ABBA against another thread that holds that user lock and calls
+    // off() (which needs the handler mutex). A same-thread re-entrancy
+    // test cannot detect this — the handler mutex is recursive — so this
+    // uses a second thread: from inside the replay it calls
+    // listenerCount(), which needs the handler mutex. If the replay held
+    // that mutex, the second thread would block until the replay
+    // returned, but the replay waits on the second thread — a deadlock,
+    // caught here as the 2 s timeout rather than a genuine hang.
+    struct Ping : Event<> {};
+    using Events = std::tuple<Ping>;
+
+    ReplayEventEmitter<Events> eventEmitter;
+    eventEmitter.emit<Ping>();
+
+    bool replayInvoked = false;
+    std::future_status otherThreadStatus = std::future_status::timeout;
+    eventEmitter.on<Ping>([&]() {
+        replayInvoked = true;
+        auto future = std::async(std::launch::async, [&eventEmitter]() {
+            return eventEmitter.listenerCount<Ping>();
+        });
+        otherThreadStatus = future.wait_for(std::chrono::seconds(2));
+        if (otherThreadStatus == std::future_status::ready) {
+            [[maybe_unused]] auto count = future.get();
+        }
+    });
+
+    EXPECT_TRUE(replayInvoked);
+    EXPECT_EQ(otherThreadStatus, std::future_status::ready);
 }
 
 TEST_F(EventEmitterTest, TestEmitFromMultipleThreads) {

--- a/packages/streamr-utils/modules/waitForEvent.cppm
+++ b/packages/streamr-utils/modules/waitForEvent.cppm
@@ -10,6 +10,7 @@ module;
 
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <tuple>
 #include <utility>
 
@@ -17,8 +18,11 @@ export module streamr.utils.waitForEvent;
 
 import streamr.utils.CoroutineHelper;
 import streamr.utils.AbortController;
+import streamr.eventemitter.EventEmitter;
 
 export namespace streamr::utils {
+
+using streamr::eventemitter::HandlerToken;
 
 template <typename T>
 struct remove_pointer { // NOLINT
@@ -60,17 +64,40 @@ waitForEvent(
     EmitterType* emitter,
     std::chrono::milliseconds timeout = defaultTimeout,
     AbortSignal* abortSignal = nullptr) {
-    Waiter<typename remove_pointer<EventType>::type::ArgumentTypes> waiter;
-    emitter->template once<typename remove_pointer<EventType>::type>(
-        waiter.function);
+    using RealEvent = typename remove_pointer<EventType>::type;
+    // The waiter is heap-owned and CO-OWNED by the registered listener,
+    // so a delivery that races the timeout or cancellation operates on a
+    // live promise. The old code registered a listener capturing a stack
+    // waiter and never removed it on the timeout path: once the coroutine
+    // frame unwound, a later emit invoked the dangling listener and
+    // called setValue on the destroyed promise (folly Promise.h
+    // "Check failed: state_" abort, hit in the connection-teardown stress
+    // runs, phase A0).
+    auto waiter = std::make_shared<Waiter<typename RealEvent::ArgumentTypes>>();
+    auto token = emitter->template once<RealEvent>([waiter](auto&&... args) {
+        waiter->function(std::forward<decltype(args)>(args)...);
+    });
+    // Remove the listener on every exit path. When the event fired, once()
+    // already removed it and this off() is a no-op; on the timeout and
+    // cancellation paths this is what unregisters it. A listener
+    // invocation already in flight on another thread keeps the waiter
+    // alive through its own copy of the callable, so this never races the
+    // waiter's destruction. The remover is declared after the waiter so
+    // it is destroyed (and unregisters) before the waiter shared_ptr in
+    // this frame drops.
+    struct Remover {
+        EmitterType* emitter;
+        HandlerToken token;
+        ~Remover() { emitter->template off<RealEvent>(token); }
+    } remover{emitter, token};
     if (abortSignal) {
         co_return co_await streamr::utils::co_withCancellation(
             abortSignal->getCancellationToken(),
             folly::coro::timeout(
-                std::move(waiter.promiseContract.second), timeout));
+                std::move(waiter->promiseContract.second), timeout));
     }
     co_return co_await folly::coro::timeout(
-        std::move(waiter.promiseContract.second), timeout);
+        std::move(waiter->promiseContract.second), timeout);
 }
 
 } // namespace streamr::utils

--- a/packages/streamr-utils/test/unit/waitForEventTest.cpp
+++ b/packages/streamr-utils/test/unit/waitForEventTest.cpp
@@ -65,6 +65,43 @@ TEST(WaitForEventTest, WaitForTimeout) {
         folly::FutureTimeout);
 }
 
+TEST(WaitForEventTest, RemovesListenerAfterTimeout) {
+    // Regression test for the dangling-listener use-after-free: after a
+    // timeout, waitForEvent must have removed its once-listener, so a
+    // later emit reaches no handler backed by the destroyed coroutine
+    // frame. Asserted directly via the listener count (deterministic),
+    // then a late emit that must be a harmless no-op.
+    EventEmitter<TestEvents> emitter;
+
+    EXPECT_THROW(
+        streamr::utils::blockingWait(
+            waitForEvent<Disconnected>(&emitter, 10ms)), // NOLINT
+        folly::FutureTimeout);
+
+    EXPECT_EQ(emitter.listenerCount<Disconnected>(), 0U);
+    emitter.emit<Disconnected>("late"); // must not crash
+}
+
+TEST(WaitForEventTest, RemovesListenerAfterDelivery) {
+    // The mirror case: after the event fires, once() removed the listener
+    // and waitForEvent's own cleanup is a harmless no-op — the count is
+    // back to zero and a second emit reaches nothing.
+    EventEmitter<TestEvents> emitter;
+
+    streamr::utils::blockingWait(
+        folly::coro::co_invoke([&emitter]() -> folly::coro::Task<void> {
+            co_await folly::coro::collectAll(
+                waitForEvent<Disconnected>(&emitter), // NOLINT
+                folly::coro::co_invoke([&emitter]() -> folly::coro::Task<void> {
+                    emitter.emit<Disconnected>("test");
+                    co_return;
+                }));
+        }));
+
+    EXPECT_EQ(emitter.listenerCount<Disconnected>(), 0U);
+    emitter.emit<Disconnected>("again"); // must not crash
+}
+
 TEST(WaitForEventTest, WaitForStringEventWithAbortSignal) {
     EventEmitter<TestEvents> emitter;
     AbortController abortController;

--- a/trackerless-network-completion-plan.md
+++ b/trackerless-network-completion-plan.md
@@ -294,6 +294,55 @@ Endpoint/EndpointStates/ConnectionManager — one mutex per endpoint state machi
 call-outs (emits, container callbacks) while holding any of these locks — plus a TSAN CI leg
 and `--gtest_repeat` stress runs as the acceptance test. Prerequisite for scaling the
 simulator-based integration tests in the rest of milestone A.
+*Implemented (phase-A0 PR):* the state machine now runs under one recursive mutex owned by
+`Endpoint` (reached by the states through `EndpointStateInterface::getStateMachineMutex()`;
+the per-state mutexes are gone), every public `Endpoint` operation is two-phase — transition
+under the mutex, call-outs (event emits, connection/pending-connection close, container
+removal, replay-emitter handler registration) after releasing it, with the states returning
+their call-outs as deferred closures — and connection-event handlers pin the endpoint through
+a weak reference and re-validate under the mutex that they still belong to the current
+pending connection/connection before acting (an in-flight emit can outlive `off()`, and a
+`ReplayEventEmitter` can replay during `on()`). `ConnectionManager` holds `endpointsMutex`
+only for container lookups/inserts; `createConnection`/`onNewConnection`, `setConnecting`
+and the endpoint queries in `send()`/`getConnections()` run outside it, and the
+exists-check/insert race in `acceptNewConnection` is closed by deciding and inserting under
+a single lock hold. The TSAN CI leg is still open (tracked as follow-up; the vcpkg-built
+dependencies would need instrumented builds for a clean run).
+Two further defects surfaced by the same stress loop were fixed alongside the locking pass:
+(a) `EventEmitter::emit` `std::forward`-ed the arguments into every listener in its dispatch
+loop, so with more than one listener the second and later handlers received moved-from
+(empty) values — it now passes each listener its own copy; and (b) `waitForEvent` registered
+a `once` listener that captured a stack waiter and never removed it on the timeout/cancel
+path, so a later emit invoked the dangling listener and called `setValue` on the destroyed
+promise (a folly `Promise.h` abort seen in the teardown of a timed-out connection) — the
+waiter is now heap-owned and co-owned by the listener, which is removed on every exit path.
+Both are covered by new unit tests in `streamr-eventemitter` and `streamr-utils`.
+The remaining defects were in the simultaneous-connect convergence, which the threaded
+runtime exposes but TS's single-threaded model hides (both surfaced as a `received2` timeout,
+initially ~1 in 30 simultaneous-connect stress iterations). Three changes, all matching the
+TS behavior once the threading is accounted for:
+- *Direction-aware tie-break.* `acceptNewConnection` replaced on `getOfferer == remote`
+  alone, correct only when a node always registers its own outgoing connection before it
+  processes the peer's incoming one. The connector's dispatcher thread can deliver the
+  incoming before the main-thread `send()` registers the outgoing, inverting the tie-break so
+  the two nodes settle on different connections. `onNewConnection` now carries an
+  `isLocalInitiated` flag and the winning connection is the offerer's regardless of which
+  thread registered it first.
+- *Adoption sequence number.* Even with the right decision, the initial `setConnecting` from
+  `send()` and the replacing `setConnecting` from the incoming connection race on the endpoint
+  mutex outside `endpointsMutex`, so the initial one could run last and re-adopt the losing
+  connection. `ConnectionManager` assigns a monotonic sequence under `endpointsMutex` and the
+  endpoint adopts only strictly-newer sequences, making the outcome independent of that race.
+- *No teardown of the losing endpoint.* `OutgoingHandshaker::onHandshakeResponse` closed the
+  pending connection on ANY error response instead of routing through `handleFailure`, so a
+  `DUPLICATE_CONNECTION` rejection (the peer won the tie-break) tore the endpoint down and
+  dropped its buffered messages. It now routes through `handleFailure`, which for
+  `DUPLICATE_CONNECTION` marks the pending connection `replaceAsDuplicate()` — silencing it so
+  the peer's subsequent connection close cannot drive or tear down the endpoint that is about
+  to be handed the winning connection. The error response precedes that close on the same
+  association (per-association FIFO), so the silencing is always in place in time, making the
+  convergence race-free. Acceptance stress loop: 500 `--gtest_repeat` rounds of
+  `Simultaneous*:ConnectionManagerIntegration*` with zero failures.
 
 **Phase A1 — Identifiers, distance, contact lists.**
 New classes: `Contact`, `ContactList`, `SortedContactList`, `RandomContactList`,


### PR DESCRIPTION
## Summary

Phase A0 of the trackerless-network completion plan: the connection-layer locking-discipline pass promised at the end of phase 0.3. It fixes the two diagnosed **ABBA lock-order inversions** that deadlock `streamr-dht`'s connection layer under `--gtest_repeat` stress, plus four further concurrency defects the same stress loop surfaced. Every one of these is a race TypeScript's single-threaded runtime never hits.

Reproduction before this PR (deadlock/timeout within a few rounds):
```
./streamr-dht-test-integration \
  --gtest_filter='Simultaneous*:ConnectionManagerIntegration*' --gtest_repeat=50
```

## The two ABBA inversions

**1. `Endpoint::mutex` vs. the per-state mutexes.** A `send()` on the main thread locked `Endpoint::mutex` then waited on a state mutex, while the simulator dispatcher thread ran a `ConnectingEndpointState` connected-handler that locked the state mutex then drove the endpoint back through `Endpoint::mutex`.

The endpoint state machine now runs under **one recursive mutex owned by `Endpoint`**, reached by the state classes through `EndpointStateInterface::getStateMachineMutex()` — the per-state mutexes are gone. Every public `Endpoint` operation is **two-phase**: transition under the mutex, then run the call-outs (event emits, connection/pending-connection close, container removal, replay-emitter handler registration) *after* releasing it. The states return their call-outs to `Endpoint` as deferred closures. Connection and pending-connection event handlers pin the endpoint through a weak reference and re-validate under the mutex that they still own the current connection before acting (an in-flight emit can outlive `off()`, and a `ReplayEventEmitter` can replay during `on()`).

**2. `ConnectionManager::endpointsMutex` vs. `Endpoint::mutex`.** `acceptNewConnection` held `endpointsMutex` and called into an endpoint (`setConnecting`), while `Endpoint::handleDisconnect` held the endpoint mutex and called `removeSelfFromContainer()` (which takes `endpointsMutex`).

`ConnectionManager` now holds `endpointsMutex` only for the container lookups/inserts; `createConnection`, `onNewConnection`, `setConnecting` and the endpoint queries in `send()`/`getConnections()` run outside it, and `handleDisconnect → removeSelfFromContainer` no longer runs under the endpoint mutex. The exists-check/insert in `acceptNewConnection` is done under a single lock hold so two racing accepts can't both insert.

## Four more defects found by the same stress loop

- **`EventEmitter::emit` moved args into every listener.** The dispatch loop `std::forward`-ed the arguments into each handler, so with more than one listener the second and later ones received moved-from (empty) values — silent data loss for any multi-listener event carrying `std::vector<std::byte>`. Each listener now gets its own copy.
- **`EventEmitter` replay `on()` invoked the listener under the handler mutex** — an ABBA deadlock against a thread holding a user lock and calling `off()`. The replay now runs after the internal mutexes are released; the replay/live-dispatch decision stays atomic under the handler mutex, so a late listener still sees the stored event exactly once.
- **`waitForEvent` leaked a `once`-listener capturing a stack waiter** on the timeout/cancel path, so a later emit invoked the dangling listener and called `setValue` on a destroyed promise (a folly `Promise.h` "Check failed: state_" abort, seen in the teardown of a timed-out connection). The waiter is now heap-owned and co-owned by the listener, which is removed on every exit path.
- **Simultaneous-connect convergence race** (the `received2` message loss, initially ~1 in 30 stress iterations). The `acceptNewConnection` tie-break replaced on `getOfferer == remote` alone — correct only under TS's single-threaded ordering. The connector's dispatcher thread can deliver the incoming connection before the main-thread `send()` registers the outgoing one, and the two nodes then settle on different physical connections. Fixed with three order-independent changes:
  - **direction-aware tie-break** — `onNewConnection` carries an `isLocalInitiated` flag; the winning connection is the offerer's regardless of which thread registered it first;
  - **adoption sequence number** — `ConnectionManager` assigns a monotonic sequence under `endpointsMutex` and the endpoint adopts only strictly-newer sequences, so a race between the initial and the replacing `setConnecting` can't re-adopt the loser;
  - **no teardown of the losing endpoint** — `OutgoingHandshaker::onHandshakeResponse` routed *any* error response straight to `pendingConnection->close()`, tearing the endpoint (and its buffered messages) down on a `DUPLICATE_CONNECTION` rejection. It now routes through `handleFailure`, which marks the pending connection `replaceAsDuplicate()` — silencing it so the peer's subsequent connection close cannot drive or tear down the endpoint that is about to receive the winning connection. Per-association FIFO guarantees the error precedes that close, so the silencing is always in place in time.

## Tests

- New unit tests lock in the two library fixes: `streamr-eventemitter` (per-listener copy; replay exactly-once; replay holds no handler mutex — a two-thread test) and `streamr-utils` (`waitForEvent` removes its listener after both timeout and delivery).
- Opt-in `STREAMR_DHT_TSAN` CMake option for the connection-layer concurrency work. The vcpkg dependencies are not TSAN-instrumented, so a clean CI leg remains a follow-up (noted in the plan).

## Test plan

- [x] Acceptance stress loop `--gtest_filter='Simultaneous*:ConnectionManagerIntegration*' --gtest_repeat=500` — **zero failures** (was deadlocking/timing out within a few rounds)
- [x] `./test.sh` — **348/348 pass**
- [x] `./lint.sh` — clean (clangd 22)

Stacked on the merged #55 (phase 0.3); branched from updated `main`. Refs `trackerless-network-completion-plan.md` phase A0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)