### PR TITLE
Phase A1: identifiers, distance and contact lists

### DIFF
--- a/packages/streamr-dht/CMakeLists.txt
+++ b/packages/streamr-dht/CMakeLists.txt
@@ -206,6 +206,10 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         test/unit/ListeningRpcCommunicatorTest.cpp
         test/unit/CustomMatchersTest.cpp
         test/unit/SimulatorTest.cpp
+        test/unit/SortedContactListTest.cpp
+        test/unit/RandomContactListTest.cpp
+        test/unit/getClosestNodesTest.cpp
+        test/unit/RingContactListTest.cpp
     )
 
     target_include_directories(streamr-dht-test-unit

--- a/packages/streamr-dht/modules/dht/contact/Contact.cppm
+++ b/packages/streamr-dht/modules/dht/contact/Contact.cppm
@@ -1,0 +1,37 @@
+// Module streamr.dht.Contact
+// Ported from packages/dht/src/dht/contact/Contact.ts (v103.8.0-rc.3).
+module;
+
+#include <utility>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.Contact;
+
+import streamr.dht.Identifiers;
+
+export namespace streamr::dht::contact {
+
+using ::dht::PeerDescriptor;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+
+// A thin wrapper that gives a PeerDescriptor the getNodeId()/
+// getPeerDescriptor() shape the contact-list templates expect.
+class Contact {
+private:
+    PeerDescriptor peerDescriptor;
+
+public:
+    explicit Contact(PeerDescriptor peerDescriptor)
+        : peerDescriptor(std::move(peerDescriptor)) {}
+
+    [[nodiscard]] PeerDescriptor getPeerDescriptor() const {
+        return this->peerDescriptor;
+    }
+
+    [[nodiscard]] DhtAddress getNodeId() const {
+        return Identifiers::getNodeIdFromPeerDescriptor(this->peerDescriptor);
+    }
+};
+
+} // namespace streamr::dht::contact

--- a/packages/streamr-dht/modules/dht/contact/ContactList.cppm
+++ b/packages/streamr-dht/modules/dht/contact/ContactList.cppm
@@ -1,0 +1,89 @@
+// Module streamr.dht.ContactList
+// Ported from packages/dht/src/dht/contact/ContactList.ts (v103.8.0-rc.3).
+module;
+
+#include <concepts>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+export module streamr.dht.ContactList;
+
+import streamr.eventemitter.EventEmitter;
+import streamr.dht.Identifiers;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::eventemitter::Event;
+using streamr::eventemitter::EventEmitter;
+
+export namespace streamr::dht::contact {
+
+using streamr::dht::DhtAddress;
+
+// The element type the sorted/random contact lists hold: anything that can
+// report its node id. Replaces TS's `C extends { getNodeId: () => DhtAddress
+// }`.
+template <typename C>
+concept HasGetNodeId = requires(const C& contact) {
+    { contact.getNodeId() } -> std::convertible_to<DhtAddress>;
+};
+
+// The events every contact list emits. The TS `Events<C>` interface is
+// shared by ContactList and SortedContactList; here it is the event tuple
+// both extend. Contacts are passed by shared_ptr (C is a class type with
+// getNodeId()).
+namespace contactlistevents {
+
+template <typename C>
+struct ContactRemoved : Event<std::shared_ptr<C>> {};
+
+template <typename C>
+struct ContactAdded : Event<std::shared_ptr<C>> {};
+
+} // namespace contactlistevents
+
+template <typename C>
+using ContactListEvents = std::tuple<
+    contactlistevents::ContactRemoved<C>,
+    contactlistevents::ContactAdded<C>>;
+
+template <HasGetNodeId C>
+class ContactList : public EventEmitter<ContactListEvents<C>> {
+protected:
+    std::map<DhtAddress, std::shared_ptr<C>> contactsById;
+    // TODO (from TS) move this to SortedContactList
+    std::vector<DhtAddress> contactIds;
+    DhtAddress localNodeId;
+    size_t maxSize;
+
+public:
+    ContactList(DhtAddress localNodeId, size_t maxSize)
+        : localNodeId(std::move(localNodeId)), maxSize(maxSize) {}
+
+    ~ContactList() override = default;
+
+    [[nodiscard]] std::shared_ptr<C> getContact(const DhtAddress& id) const {
+        const auto it = this->contactsById.find(id);
+        if (it == this->contactsById.end()) {
+            return nullptr;
+        }
+        return it->second;
+    }
+
+    [[nodiscard]] size_t getSize() const { return this->contactIds.size(); }
+
+    void clear() {
+        this->contactsById.clear();
+        this->contactIds.clear();
+    }
+
+    void stop() {
+        this->removeAllListeners();
+        this->clear();
+    }
+};
+
+} // namespace streamr::dht::contact

--- a/packages/streamr-dht/modules/dht/contact/RandomContactList.cppm
+++ b/packages/streamr-dht/modules/dht/contact/RandomContactList.cppm
@@ -1,0 +1,89 @@
+// Module streamr.dht.RandomContactList
+// Ported from packages/dht/src/dht/contact/RandomContactList.ts
+// (v103.8.0-rc.3).
+module;
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <random>
+#include <utility>
+#include <vector>
+
+export module streamr.dht.RandomContactList;
+
+import streamr.dht.ContactList;
+import streamr.dht.Identifiers;
+
+export namespace streamr::dht::contact {
+
+using streamr::dht::DhtAddress;
+
+// Keeps a random sample of the contacts offered to it: each new contact is
+// admitted with probability `randomness`, evicting the oldest once full.
+template <HasGetNodeId C>
+class RandomContactList : public ContactList<C> {
+private:
+    double randomness;
+    std::mt19937 randomGenerator{std::random_device{}()};
+    std::uniform_real_distribution<double> distribution{0.0, 1.0};
+
+public:
+    RandomContactList(
+        DhtAddress localNodeId,
+        size_t maxSize,
+        double randomness = 0.20) // NOLINT(readability-magic-numbers)
+        : ContactList<C>(std::move(localNodeId), maxSize),
+          randomness(randomness) {}
+
+    void addContact(const std::shared_ptr<C>& contact) {
+        if (this->localNodeId == contact->getNodeId()) {
+            return;
+        }
+        if (this->contactsById.contains(contact->getNodeId())) {
+            return;
+        }
+        const double roll = this->distribution(this->randomGenerator);
+        if (roll < this->randomness) {
+            if (this->getSize() == this->maxSize && this->getSize() > 0) {
+                this->removeContact(this->contactIds.front());
+            }
+            this->contactIds.push_back(contact->getNodeId());
+            this->contactsById.emplace(contact->getNodeId(), contact);
+            this->template emit<contactlistevents::ContactAdded<C>>(contact);
+        }
+    }
+
+    bool removeContact(const DhtAddress& id) {
+        const auto it = this->contactsById.find(id);
+        if (it == this->contactsById.end()) {
+            return false;
+        }
+        const std::shared_ptr<C> removed = it->second;
+        const auto idIt = std::ranges::find(this->contactIds, id);
+        if (idIt != this->contactIds.end()) {
+            this->contactIds.erase(idIt);
+        }
+        this->contactsById.erase(it);
+        this->template emit<contactlistevents::ContactRemoved<C>>(removed);
+        return true;
+    }
+
+    [[nodiscard]] std::vector<std::shared_ptr<C>> getContacts(
+        std::optional<int> limit = std::nullopt) const {
+        const size_t count = limit.has_value()
+            ? std::min(
+                  this->contactIds.size(),
+                  static_cast<size_t>(std::max(limit.value(), 0)))
+            : this->contactIds.size();
+        std::vector<std::shared_ptr<C>> result;
+        result.reserve(count);
+        for (size_t i = 0; i < count; ++i) {
+            result.push_back(this->contactsById.at(this->contactIds[i]));
+        }
+        return result;
+    }
+};
+
+} // namespace streamr::dht::contact

--- a/packages/streamr-dht/modules/dht/contact/RingContactList.cppm
+++ b/packages/streamr-dht/modules/dht/contact/RingContactList.cppm
@@ -1,0 +1,188 @@
+// Module streamr.dht.RingContactList
+// Ported from packages/dht/src/dht/contact/RingContactList.ts
+// (v103.8.0-rc.3). The TS OrderedMap<RingDistance, C> is a std::map here
+// (ascending key order, same neighbour semantics).
+module;
+
+#include <concepts>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <utility>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.RingContactList;
+
+import streamr.eventemitter.EventEmitter;
+import streamr.dht.ContactList;
+import streamr.dht.Identifiers;
+import streamr.dht.ringIdentifiers;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::eventemitter::EventEmitter;
+
+export namespace streamr::dht::contact {
+
+using ::dht::PeerDescriptor;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+
+// The element type the ring contact list holds: anything that can report
+// its PeerDescriptor. Replaces TS's `C extends { getPeerDescriptor():
+// PeerDescriptor }`.
+template <typename C>
+concept HasGetPeerDescriptor = requires(const C& contact) {
+    { contact.getPeerDescriptor() } -> std::convertible_to<PeerDescriptor>;
+};
+
+template <HasGetPeerDescriptor C>
+struct RingContacts {
+    std::vector<std::shared_ptr<C>> left;
+    std::vector<std::shared_ptr<C>> right;
+};
+
+template <HasGetPeerDescriptor C>
+class RingContactList : public EventEmitter<ContactListEvents<C>> {
+private:
+    static constexpr size_t numNeighborsPerSide = 5;
+    RingId referenceId;
+    std::set<DhtAddress> excludedIds;
+    // Ascending by distance; the closest neighbours are at the front.
+    std::map<RingDistance, std::shared_ptr<C>> leftNeighbors;
+    std::map<RingDistance, std::shared_ptr<C>> rightNeighbors;
+
+    // Keeps the closest numNeighborsPerSide by distance; returns whether it
+    // added and/or evicted, so the caller can emit the right events.
+    static void insertBounded(
+        std::map<RingDistance, std::shared_ptr<C>>& neighbors,
+        RingDistance distance,
+        const std::shared_ptr<C>& contact,
+        bool& elementAdded,
+        bool& elementRemoved) {
+        const bool empty = neighbors.empty();
+        // std::prev(end()) is the largest (furthest) key.
+        if (empty || distance < std::prev(neighbors.end())->first) {
+            neighbors.insert_or_assign(distance, contact);
+            elementAdded = true;
+            if (neighbors.size() > numNeighborsPerSide) {
+                neighbors.erase(std::prev(neighbors.end()));
+                elementRemoved = true;
+            }
+        }
+    }
+
+public:
+    explicit RingContactList(
+        const RingIdRaw& rawReferenceId,
+        std::optional<std::set<DhtAddress>> excludedIds = std::nullopt)
+        : referenceId(getRingIdFromRaw(rawReferenceId)),
+          excludedIds(excludedIds.value_or(std::set<DhtAddress>{})) {}
+
+    void addContact(const std::shared_ptr<C>& contact) {
+        const RingId id =
+            getRingIdFromPeerDescriptor(contact->getPeerDescriptor());
+        if (id == this->referenceId ||
+            this->excludedIds.contains(
+                Identifiers::getNodeIdFromPeerDescriptor(
+                    contact->getPeerDescriptor()))) {
+            return;
+        }
+        bool elementAdded = false;
+        bool elementRemoved = false;
+
+        insertBounded(
+            this->leftNeighbors,
+            getLeftDistance(this->referenceId, id),
+            contact,
+            elementAdded,
+            elementRemoved);
+        insertBounded(
+            this->rightNeighbors,
+            getRightDistance(this->referenceId, id),
+            contact,
+            elementAdded,
+            elementRemoved);
+
+        if (elementAdded) {
+            this->template emit<contactlistevents::ContactAdded<C>>(contact);
+        }
+        if (elementRemoved) {
+            this->template emit<contactlistevents::ContactRemoved<C>>(contact);
+        }
+    }
+
+    void removeContact(const std::shared_ptr<C>& contact) {
+        if (!contact) {
+            return;
+        }
+        const RingId id =
+            getRingIdFromPeerDescriptor(contact->getPeerDescriptor());
+        const RingDistance leftDistance =
+            getLeftDistance(this->referenceId, id);
+        const RingDistance rightDistance =
+            getRightDistance(this->referenceId, id);
+
+        bool elementRemoved = false;
+        if (this->leftNeighbors.erase(leftDistance) > 0) {
+            elementRemoved = true;
+        }
+        if (this->rightNeighbors.erase(rightDistance) > 0) {
+            elementRemoved = true;
+        }
+        if (elementRemoved) {
+            this->template emit<contactlistevents::ContactRemoved<C>>(contact);
+        }
+    }
+
+    [[nodiscard]] std::shared_ptr<C> getContact(
+        const PeerDescriptor& peerDescriptor) const {
+        const RingId id = getRingIdFromPeerDescriptor(peerDescriptor);
+        const auto leftIt =
+            this->leftNeighbors.find(getLeftDistance(this->referenceId, id));
+        if (leftIt != this->leftNeighbors.end()) {
+            return leftIt->second;
+        }
+        const auto rightIt =
+            this->rightNeighbors.find(getRightDistance(this->referenceId, id));
+        if (rightIt != this->rightNeighbors.end()) {
+            return rightIt->second;
+        }
+        return nullptr;
+    }
+
+    [[nodiscard]] RingContacts<C> getClosestContacts(
+        std::optional<size_t> limitPerSide = std::nullopt) const {
+        RingContacts<C> result;
+        for (const auto& [distance, contact] : this->leftNeighbors) {
+            if (limitPerSide.has_value() &&
+                result.left.size() >= limitPerSide.value()) {
+                break;
+            }
+            result.left.push_back(contact);
+        }
+        for (const auto& [distance, contact] : this->rightNeighbors) {
+            if (limitPerSide.has_value() &&
+                result.right.size() >= limitPerSide.value()) {
+                break;
+            }
+            result.right.push_back(contact);
+        }
+        return result;
+    }
+
+    [[nodiscard]] std::vector<std::shared_ptr<C>> getAllContacts() const {
+        std::vector<std::shared_ptr<C>> result;
+        for (const auto& [distance, contact] : this->leftNeighbors) {
+            result.push_back(contact);
+        }
+        for (const auto& [distance, contact] : this->rightNeighbors) {
+            result.push_back(contact);
+        }
+        return result;
+    }
+};
+
+} // namespace streamr::dht::contact

--- a/packages/streamr-dht/modules/dht/contact/SortedContactList.cppm
+++ b/packages/streamr-dht/modules/dht/contact/SortedContactList.cppm
@@ -1,0 +1,237 @@
+// Module streamr.dht.SortedContactList
+// Ported from packages/dht/src/dht/contact/SortedContactList.ts
+// (v103.8.0-rc.3). Unlike RandomContactList it does NOT extend
+// ContactList — it keeps its own contactsById/contactIds and only reuses
+// ContactList's event tuple (matching TS).
+module;
+
+#include <algorithm>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <utility>
+#include <vector>
+
+export module streamr.dht.SortedContactList;
+
+import streamr.eventemitter.EventEmitter;
+import streamr.dht.ContactList;
+import streamr.dht.Identifiers;
+import streamr.dht.getPeerDistance;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::eventemitter::EventEmitter;
+
+export namespace streamr::dht::contact {
+
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtAddressRaw;
+using streamr::dht::Identifiers;
+using streamr::dht::helpers::getPeerDistance;
+
+struct SortedContactListOptions {
+    // all contacts in this list are sorted by the distance to this id
+    DhtAddress referenceId;
+    bool allowToContainReferenceId;
+    std::optional<size_t> maxSize;
+    // if set, the list can't contain contacts further away than this limit
+    std::optional<DhtAddress> nodeIdDistanceLimit;
+    // if set, the list can't contain contacts with these ids
+    std::optional<std::set<DhtAddress>> excludedNodeIds;
+};
+
+template <HasGetNodeId C>
+class SortedContactList : public EventEmitter<ContactListEvents<C>> {
+private:
+    SortedContactListOptions options;
+    DhtAddressRaw referenceIdRaw;
+    std::map<DhtAddress, std::shared_ptr<C>> contactsById;
+    std::vector<DhtAddress> contactIds; // sorted ascending by distance
+
+    [[nodiscard]] double distanceToReferenceId(const DhtAddress& id) const {
+        return getPeerDistance(
+            this->referenceIdRaw, Identifiers::getRawFromDhtAddress(id));
+    }
+
+    // Lowest index at which contactId keeps contactIds sorted ascending by
+    // distance (lodash sortedIndexBy: leftmost position for equal keys).
+    [[nodiscard]] size_t sortedInsertionIndex(
+        const DhtAddress& contactId) const {
+        const double distance = this->distanceToReferenceId(contactId);
+        const auto it = std::lower_bound(
+            this->contactIds.begin(),
+            this->contactIds.end(),
+            distance,
+            [this](const DhtAddress& existing, double value) {
+                return this->distanceToReferenceId(existing) < value;
+            });
+        return static_cast<size_t>(it - this->contactIds.begin());
+    }
+
+public:
+    explicit SortedContactList(SortedContactListOptions options)
+        : options(std::move(options)),
+          referenceIdRaw(
+              Identifiers::getRawFromDhtAddress(this->options.referenceId)) {}
+
+    [[nodiscard]] DhtAddress getClosestContactId() const {
+        return this->contactIds.front();
+    }
+
+    [[nodiscard]] std::vector<DhtAddress> getContactIds() const {
+        return this->contactIds;
+    }
+
+    void addContact(const std::shared_ptr<C>& contact) {
+        const DhtAddress contactId = contact->getNodeId();
+        if (this->options.excludedNodeIds.has_value() &&
+            this->options.excludedNodeIds->contains(contactId)) {
+            return;
+        }
+        if ((!this->options.allowToContainReferenceId &&
+             this->options.referenceId == contactId) ||
+            (this->options.nodeIdDistanceLimit.has_value() &&
+             this->compareIds(
+                 this->options.nodeIdDistanceLimit.value(), contactId) < 0)) {
+            return;
+        }
+        if (this->contactsById.contains(contactId)) {
+            return;
+        }
+        if (!this->options.maxSize.has_value() ||
+            this->contactIds.size() < this->options.maxSize.value()) {
+            this->contactsById.emplace(contactId, contact);
+            this->contactIds.insert(
+                this->contactIds.begin() +
+                    static_cast<std::ptrdiff_t>(
+                        this->sortedInsertionIndex(contactId)),
+                contactId);
+            this->template emit<contactlistevents::ContactAdded<C>>(contact);
+        } else if (
+            this->compareIds(
+                this->contactIds[this->options.maxSize.value() - 1],
+                contactId) > 0) {
+            const DhtAddress removedId = this->contactIds.back();
+            this->contactIds.pop_back();
+            const std::shared_ptr<C> removedContact =
+                this->contactsById.at(removedId);
+            this->contactsById.erase(removedId);
+            this->contactsById.emplace(contactId, contact);
+            this->contactIds.insert(
+                this->contactIds.begin() +
+                    static_cast<std::ptrdiff_t>(
+                        this->sortedInsertionIndex(contactId)),
+                contactId);
+            this->template emit<contactlistevents::ContactRemoved<C>>(
+                removedContact);
+            this->template emit<contactlistevents::ContactAdded<C>>(contact);
+        }
+    }
+
+    void addContacts(const std::vector<std::shared_ptr<C>>& contacts) {
+        for (const auto& contact : contacts) {
+            this->addContact(contact);
+        }
+    }
+
+    [[nodiscard]] std::shared_ptr<C> getContact(const DhtAddress& id) const {
+        const auto it = this->contactsById.find(id);
+        if (it == this->contactsById.end()) {
+            return nullptr;
+        }
+        return it->second;
+    }
+
+    [[nodiscard]] bool has(const DhtAddress& id) const {
+        return this->contactsById.contains(id);
+    }
+
+    // Closest first, then others in ascending distance order.
+    [[nodiscard]] std::vector<std::shared_ptr<C>> getClosestContacts(
+        std::optional<int> limit = std::nullopt) const {
+        const size_t count = limit.has_value()
+            ? std::min(
+                  this->contactIds.size(),
+                  static_cast<size_t>(std::max(limit.value(), 0)))
+            : this->contactIds.size();
+        std::vector<std::shared_ptr<C>> result;
+        result.reserve(count);
+        for (size_t i = 0; i < count; ++i) {
+            result.push_back(this->contactsById.at(this->contactIds[i]));
+        }
+        return result;
+    }
+
+    // Furthest first, then others in descending distance order.
+    [[nodiscard]] std::vector<std::shared_ptr<C>> getFurthestContacts(
+        std::optional<int> limit = std::nullopt) const {
+        std::vector<std::shared_ptr<C>> reversed = this->getClosestContacts();
+        std::ranges::reverse(reversed);
+        if (!limit.has_value()) {
+            return reversed;
+        }
+        const size_t count = std::min(
+            reversed.size(), static_cast<size_t>(std::max(limit.value(), 0)));
+        reversed.resize(count);
+        return reversed;
+    }
+
+    [[nodiscard]] double compareIds(
+        const DhtAddress& id1, const DhtAddress& id2) const {
+        return this->distanceToReferenceId(id1) -
+            this->distanceToReferenceId(id2);
+    }
+
+    bool removeContact(const DhtAddress& id) {
+        const auto it = this->contactsById.find(id);
+        if (it == this->contactsById.end()) {
+            return false;
+        }
+        const std::shared_ptr<C> removed = it->second;
+        const auto idIt = std::ranges::find(this->contactIds, id);
+        if (idIt != this->contactIds.end()) {
+            this->contactIds.erase(idIt);
+        }
+        this->contactsById.erase(it);
+        this->template emit<contactlistevents::ContactRemoved<C>>(removed);
+        return true;
+    }
+
+    [[nodiscard]] std::vector<std::shared_ptr<C>>
+    getAllContactsInUndefinedOrder() const {
+        std::vector<std::shared_ptr<C>> result;
+        result.reserve(this->contactsById.size());
+        for (const auto& [id, contact] : this->contactsById) {
+            result.push_back(contact);
+        }
+        return result;
+    }
+
+    [[nodiscard]] size_t getSize(
+        const std::optional<std::set<DhtAddress>>& excludedNodeIds =
+            std::nullopt) const {
+        size_t excludedCount = 0;
+        if (excludedNodeIds.has_value()) {
+            for (const auto& nodeId : excludedNodeIds.value()) {
+                if (this->has(nodeId)) {
+                    ++excludedCount;
+                }
+            }
+        }
+        return this->contactIds.size() - excludedCount;
+    }
+
+    void clear() {
+        this->contactsById.clear();
+        this->contactIds.clear();
+    }
+
+    void stop() {
+        this->removeAllListeners();
+        this->clear();
+    }
+};
+
+} // namespace streamr::dht::contact

--- a/packages/streamr-dht/modules/dht/contact/getClosestNodes.cppm
+++ b/packages/streamr-dht/modules/dht/contact/getClosestNodes.cppm
@@ -1,0 +1,50 @@
+// Module streamr.dht.getClosestNodes
+// Ported from packages/dht/src/dht/contact/getClosestNodes.ts
+// (v103.8.0-rc.3).
+module;
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <set>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.getClosestNodes;
+
+import streamr.dht.Contact;
+import streamr.dht.Identifiers;
+import streamr.dht.SortedContactList;
+
+export namespace streamr::dht::contact {
+
+using ::dht::PeerDescriptor;
+using streamr::dht::DhtAddress;
+
+struct GetClosestNodesOptions {
+    std::optional<size_t> maxCount;
+    std::optional<std::set<DhtAddress>> excludedNodeIds;
+};
+
+inline std::vector<PeerDescriptor> getClosestNodes(
+    const DhtAddress& referenceId,
+    const std::vector<PeerDescriptor>& contacts,
+    const GetClosestNodesOptions& opts = {}) {
+    SortedContactList<Contact> list(
+        SortedContactListOptions{
+            .referenceId = referenceId,
+            .allowToContainReferenceId = true,
+            .maxSize = opts.maxCount,
+            .nodeIdDistanceLimit = std::nullopt,
+            .excludedNodeIds = opts.excludedNodeIds});
+    for (const auto& contact : contacts) {
+        list.addContact(std::make_shared<Contact>(contact));
+    }
+    std::vector<PeerDescriptor> result;
+    for (const auto& contact : list.getClosestContacts()) {
+        result.push_back(contact->getPeerDescriptor());
+    }
+    return result;
+}
+
+} // namespace streamr::dht::contact

--- a/packages/streamr-dht/modules/dht/contact/ringIdentifiers.cppm
+++ b/packages/streamr-dht/modules/dht/contact/ringIdentifiers.cppm
@@ -1,0 +1,102 @@
+// Module streamr.dht.ringIdentifiers
+// Ported from packages/dht/src/dht/contact/ringIdentifiers.ts
+// (v103.8.0-rc.3).
+module;
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.ringIdentifiers;
+
+import streamr.utils.Branded;
+
+export namespace streamr::dht::contact {
+
+using ::dht::PeerDescriptor;
+
+// The raw ring id: region (4 bytes, big-endian) + ipAddress (4 bytes,
+// big-endian) + the last 7 bytes of the node id = 15 bytes = 120 bits.
+// Notice (from TS): you cannot convert a RingId back to RingIdRaw, because
+// RingId is only an approximation of the actual value — that is why the raw
+// form is what is stored and compared throughout the codebase.
+using RingIdRaw = streamr::utils::Branded<std::string, struct RingIdRawBrand>;
+// RingId / RingDistance are JavaScript Numbers in TS, i.e. doubles. The raw
+// 120-bit value exceeds a double's 53-bit mantissa, so the low bits are
+// lost — deliberately, and identically to TS, so orderings match.
+using RingId = double;
+using RingDistance = double;
+
+namespace ringidentifiers {
+inline constexpr size_t wordBytes = 4;
+inline constexpr size_t uniquePartBytes = 7;
+inline constexpr int byteBits = 8;
+inline constexpr unsigned int byteMask = 0xFF;
+} // namespace ringidentifiers
+
+// 2^120 - 1, evaluated as a double exactly as TS's `2 ** 120 - 1` (the -1
+// is lost to rounding, giving 2^120).
+inline const RingDistance RING_SIZE = // NOLINT(cert-err58-cpp)
+    std::ldexp(1.0, 120) - 1.0; // NOLINT(readability-magic-numbers)
+
+// The exact 120-bit big-endian integer, converted to a double once (as
+// TS's Number(binaryToBigInt(...)) does) — NOT accumulated byte-by-byte in
+// double, which would round differently. 128-bit is wide enough for 120
+// bits.
+inline double ringIdRawToDouble(const RingIdRaw& raw) {
+    unsigned __int128 acc = 0;
+    for (const char byte : raw) {
+        acc = (acc << ringidentifiers::byteBits) |
+            static_cast<unsigned char>(byte);
+    }
+    return static_cast<double>(acc);
+}
+
+inline RingId getRingIdFromRaw(const RingIdRaw& raw) {
+    return ringIdRawToDouble(raw);
+}
+
+inline RingIdRaw getRingIdRawFromPeerDescriptor(
+    const PeerDescriptor& peerDescriptor) {
+    std::string raw;
+    raw.reserve(
+        2 * ringidentifiers::wordBytes + ringidentifiers::uniquePartBytes);
+    const auto appendBigEndian = [&raw](uint32_t value) {
+        for (size_t i = ringidentifiers::wordBytes; i-- > 0;) {
+            raw.push_back(
+                static_cast<char>(
+                    (value >> (ringidentifiers::byteBits * i)) &
+                    ringidentifiers::byteMask));
+        }
+    };
+    // region()/ipaddress() return 0 when unset (proto3), matching TS's `?? 0`.
+    appendBigEndian(peerDescriptor.region());
+    appendBigEndian(peerDescriptor.ipaddress());
+    const std::string& nodeId = peerDescriptor.nodeid();
+    const size_t start = nodeId.size() >= ringidentifiers::uniquePartBytes
+        ? nodeId.size() - ringidentifiers::uniquePartBytes
+        : 0;
+    raw.append(nodeId, start, ringidentifiers::uniquePartBytes);
+    return RingIdRaw{raw};
+}
+
+inline RingId getRingIdFromPeerDescriptor(
+    const PeerDescriptor& peerDescriptor) {
+    return ringIdRawToDouble(getRingIdRawFromPeerDescriptor(peerDescriptor));
+}
+
+inline RingDistance getLeftDistance(RingId referenceId, RingId id) {
+    const double diff = std::fabs(referenceId - id);
+    // id smaller than referenceId → distance is the difference;
+    // otherwise it wraps around the ring.
+    return (referenceId > id) ? diff : RING_SIZE - diff;
+}
+
+inline RingDistance getRightDistance(RingId referenceId, RingId id) {
+    const double diff = std::fabs(referenceId - id);
+    return (referenceId > id) ? RING_SIZE - diff : diff;
+}
+
+} // namespace streamr::dht::contact

--- a/packages/streamr-dht/modules/helpers/getPeerDistance.cppm
+++ b/packages/streamr-dht/modules/helpers/getPeerDistance.cppm
@@ -1,0 +1,45 @@
+// Module streamr.dht.getPeerDistance
+// Ported from packages/dht/src/dht/helpers/getPeerDistance.ts
+// (v103.8.0-rc.3).
+module;
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+
+export module streamr.dht.getPeerDistance;
+
+import streamr.dht.Identifiers;
+
+export namespace streamr::dht::helpers {
+
+using streamr::dht::DhtAddressRaw;
+
+// XOR distance between two raw ids, computed exactly as the npm `k-bucket`
+// library's KBucket.distance (which the TS getPeerDistance wraps): the
+// bytes are folded into a single number, most-significant byte first. The
+// accumulator is a double, matching JavaScript's Number, so for the full
+// 20-byte kademlia ids the low bits are lost the same way they are in TS
+// — the value is only used as a sort key, and both this port and the TS
+// tests fold with the identical IEEE-754 operations, so the ordering
+// matches. (KBucket itself arrives in phase A2; only this distance
+// function is needed here.)
+inline double getPeerDistance(
+    const DhtAddressRaw& first, const DhtAddressRaw& second) {
+    double distance = 0;
+    const size_t min = std::min(first.size(), second.size());
+    const size_t max = std::max(first.size(), second.size());
+    size_t i = 0;
+    for (; i < min; ++i) {
+        const auto a = static_cast<unsigned char>(first[i]);
+        const auto b = static_cast<unsigned char>(second[i]);
+        distance =
+            distance * 256 + (a ^ b); // NOLINT(readability-magic-numbers)
+    }
+    for (; i < max; ++i) {
+        distance = distance * 256 + 255; // NOLINT(readability-magic-numbers)
+    }
+    return distance;
+}
+
+} // namespace streamr::dht::helpers

--- a/packages/streamr-dht/test/unit/RandomContactListTest.cpp
+++ b/packages/streamr-dht/test/unit/RandomContactListTest.cpp
@@ -1,0 +1,94 @@
+// Ported from packages/dht/test/unit/RandomContactList.test.ts
+// (v103.8.0-rc.3). randomness is 1 so every distinct contact is admitted,
+// making the tests deterministic.
+#include <memory>
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+
+import streamr.dht.Identifiers;
+import streamr.dht.RandomContactList;
+
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtAddressRaw;
+using streamr::dht::Identifiers;
+using streamr::dht::contact::RandomContactList;
+
+namespace {
+
+constexpr size_t listMaxSize = 5;
+constexpr double alwaysAdmit = 1.0;
+
+struct TestItem {
+    DhtAddress nodeId;
+    explicit TestItem(const DhtAddressRaw& raw)
+        : nodeId(Identifiers::getDhtAddressFromRaw(raw)) {}
+    [[nodiscard]] DhtAddress getNodeId() const { return this->nodeId; }
+};
+
+std::shared_ptr<TestItem> createItem(const std::vector<unsigned char>& bytes) {
+    return std::make_shared<TestItem>(
+        DhtAddressRaw{std::string(bytes.begin(), bytes.end())});
+}
+
+std::vector<DhtAddress> nodeIdsOf(
+    const std::vector<std::shared_ptr<TestItem>>& items) {
+    std::vector<DhtAddress> ids;
+    ids.reserve(items.size());
+    for (const auto& item : items) {
+        ids.push_back(item->getNodeId());
+    }
+    return ids;
+}
+
+} // namespace
+
+class RandomContactListTest : public ::testing::Test {
+protected:
+    std::shared_ptr<TestItem> item0 = createItem({0, 0, 0, 0});
+    std::shared_ptr<TestItem> item1 = createItem({0, 0, 0, 1});
+    std::shared_ptr<TestItem> item2 = createItem({0, 0, 0, 2});
+    std::shared_ptr<TestItem> item3 = createItem({0, 0, 0, 3});
+    std::shared_ptr<TestItem> item4 = createItem({0, 0, 0, 4});
+};
+
+TEST_F(RandomContactListTest, AddsContactsCorrectly) {
+    RandomContactList<TestItem> list(
+        item0->getNodeId(), listMaxSize, alwaysAdmit);
+    list.addContact(item1);
+    list.addContact(item2);
+    list.addContact(item3);
+    list.addContact(item3);
+    list.addContact(item4);
+    list.addContact(item4);
+    EXPECT_EQ(list.getSize(), 4U);
+    EXPECT_EQ(
+        nodeIdsOf(list.getContacts()), nodeIdsOf({item1, item2, item3, item4}));
+}
+
+TEST_F(RandomContactListTest, RemovesContactsCorrectly) {
+    RandomContactList<TestItem> list(
+        item0->getNodeId(), listMaxSize, alwaysAdmit);
+    list.addContact(item1);
+    list.addContact(item2);
+    list.addContact(item3);
+    list.addContact(item4);
+    list.removeContact(item2->getNodeId());
+    EXPECT_TRUE(list.getContact(item1->getNodeId()));
+    EXPECT_TRUE(list.getContact(item3->getNodeId()));
+    EXPECT_TRUE(list.getContact(item4->getNodeId()));
+    EXPECT_EQ(nodeIdsOf(list.getContacts()), nodeIdsOf({item1, item3, item4}));
+    EXPECT_EQ(list.getSize(), 3U);
+}
+
+TEST_F(RandomContactListTest, GetContacts) {
+    RandomContactList<TestItem> list(
+        item0->getNodeId(), listMaxSize, alwaysAdmit);
+    list.addContact(item1);
+    list.addContact(item2);
+    list.addContact(item3);
+    list.addContact(item4);
+    EXPECT_EQ(list.getContacts().size(), 4U);
+    EXPECT_EQ(list.getContacts(3).size(), 3U);
+    EXPECT_EQ(list.getContacts(-2).size(), 0U);
+}

--- a/packages/streamr-dht/test/unit/RingContactListTest.cpp
+++ b/packages/streamr-dht/test/unit/RingContactListTest.cpp
@@ -1,0 +1,193 @@
+// Unit coverage for RingContactList (module streamr.dht.RingContactList).
+//
+// The TS ring coverage lives in test/benchmark/RingCorrectness.test.ts,
+// which drives 900 real DhtNodes joining a ring and compares against
+// pre-generated ground-truth data — none of which exists in the C++ port
+// yet (DhtNode/joinRing are much later phases). Per the plan (phase A1),
+// the ring behaviour is instead covered by this plain unit test exercising
+// RingContactList directly: neighbour selection to each side, the
+// per-side cap, reference-id / excluded-id filtering, removal and lookup.
+//
+// A contact's ring id is region(4 bytes) + ipAddress(4 bytes) + the last 7
+// bytes of the node id, most-significant first. The region therefore
+// dominates the ordering (weight 2^88), so setting distinct regions places
+// contacts at controlled, ordered positions on the ring; distinct node ids
+// keep their identities (and exclusion) separate.
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+
+import streamr.dht.Contact;
+import streamr.dht.Identifiers;
+import streamr.dht.protos;
+import streamr.dht.RingContactList;
+import streamr.dht.ringIdentifiers;
+
+using ::dht::NodeType;
+using ::dht::PeerDescriptor;
+using streamr::dht::Identifiers;
+using streamr::dht::contact::Contact;
+using streamr::dht::contact::getRingIdRawFromPeerDescriptor;
+using streamr::dht::contact::RingContactList;
+using streamr::dht::contact::RingIdRaw;
+
+namespace {
+
+constexpr size_t kademliaIdLength = 20;
+constexpr uint32_t referenceRegion = 100;
+constexpr unsigned int byteMask = 0xFF;
+constexpr unsigned int byteShift = 8;
+
+PeerDescriptor makePeerDescriptor(uint32_t region) {
+    PeerDescriptor peerDescriptor;
+    // 20-byte node id, unique per region (encoded in the low bytes, which
+    // also form the ring id's low bits — dwarfed by the region).
+    std::string nodeId(kademliaIdLength, '\0');
+    nodeId[kademliaIdLength - 1] = static_cast<char>(region & byteMask);
+    nodeId[kademliaIdLength - 2] =
+        static_cast<char>((region >> byteShift) & byteMask);
+    peerDescriptor.set_nodeid(nodeId);
+    peerDescriptor.set_region(region);
+    peerDescriptor.set_type(NodeType::NODEJS);
+    return peerDescriptor;
+}
+
+static_assert(
+    streamr::dht::contact::HasGetPeerDescriptor<Contact>,
+    "Contact provides getPeerDescriptor()");
+static_assert(
+    !streamr::dht::contact::HasGetPeerDescriptor<int>,
+    "the HasGetPeerDescriptor constraint is not vacuous");
+
+std::shared_ptr<Contact> makeContact(uint32_t region) {
+    return std::make_shared<Contact>(makePeerDescriptor(region));
+}
+
+RingIdRaw referenceIdRaw() {
+    return getRingIdRawFromPeerDescriptor(makePeerDescriptor(referenceRegion));
+}
+
+std::vector<uint32_t> regionsOf(
+    const std::vector<std::shared_ptr<Contact>>& contacts) {
+    std::vector<uint32_t> regions;
+    regions.reserve(contacts.size());
+    for (const auto& contact : contacts) {
+        regions.push_back(contact->getPeerDescriptor().region());
+    }
+    return regions;
+}
+
+// The distinct regions present, sorted. A contact may legitimately sit on
+// BOTH sides when the ring is sparse (an empty side accepts any contact),
+// so getAllContacts() can list it twice; the distinct set is what the
+// membership assertions care about.
+std::vector<uint32_t> sortedUniqueRegions(
+    const std::vector<std::shared_ptr<Contact>>& contacts) {
+    std::set<uint32_t> regions;
+    for (const auto& contact : contacts) {
+        regions.insert(contact->getPeerDescriptor().region());
+    }
+    return {regions.begin(), regions.end()};
+}
+
+} // namespace
+
+// The region values below are arbitrary ring positions (test data), so the
+// magic-number check is suppressed for the test bodies.
+// NOLINTBEGIN(readability-magic-numbers)
+
+TEST(RingContactListTest, KeepsClosestNeighboursPerSide) {
+    RingContactList<Contact> list(referenceIdRaw());
+    // 10 below and 10 above the reference region (100).
+    for (uint32_t region = 90; region < 100; ++region) {
+        list.addContact(makeContact(region));
+    }
+    for (uint32_t region = 101; region <= 110; ++region) {
+        list.addContact(makeContact(region));
+    }
+    const auto closest = list.getClosestContacts();
+    // Left = the 5 nearest below, closest first (descending region).
+    EXPECT_EQ(
+        regionsOf(closest.left), (std::vector<uint32_t>{99, 98, 97, 96, 95}));
+    // Right = the 5 nearest above, closest first (ascending region).
+    EXPECT_EQ(
+        regionsOf(closest.right),
+        (std::vector<uint32_t>{101, 102, 103, 104, 105}));
+}
+
+TEST(RingContactListTest, LimitPerSide) {
+    RingContactList<Contact> list(referenceIdRaw());
+    for (uint32_t region = 95; region < 100; ++region) {
+        list.addContact(makeContact(region));
+    }
+    for (uint32_t region = 101; region <= 105; ++region) {
+        list.addContact(makeContact(region));
+    }
+    const auto closest = list.getClosestContacts(2);
+    EXPECT_EQ(regionsOf(closest.left), (std::vector<uint32_t>{99, 98}));
+    EXPECT_EQ(regionsOf(closest.right), (std::vector<uint32_t>{101, 102}));
+}
+
+TEST(RingContactListTest, ExcludesReferenceIdAndExcludedIds) {
+    const auto excludedContact = makeContact(101);
+    const std::set<streamr::dht::DhtAddress> excludedIds = {
+        Identifiers::getNodeIdFromPeerDescriptor(
+            excludedContact->getPeerDescriptor())};
+    RingContactList<Contact> list(referenceIdRaw(), excludedIds);
+
+    list.addContact(makeContact(referenceRegion)); // same ring id as reference
+    list.addContact(excludedContact); // excluded by node id
+    list.addContact(makeContact(99));
+    list.addContact(makeContact(102));
+
+    // The reference-region and excluded contacts are dropped; only 99 and
+    // 102 remain (each may appear on both sides — see sortedUniqueRegions).
+    EXPECT_EQ(
+        sortedUniqueRegions(list.getAllContacts()),
+        (std::vector<uint32_t>{99, 102}));
+}
+
+TEST(RingContactListTest, GetContactAndRemoveContact) {
+    RingContactList<Contact> list(referenceIdRaw());
+    const auto below = makeContact(99);
+    const auto above = makeContact(101);
+    list.addContact(below);
+    list.addContact(above);
+
+    EXPECT_TRUE(list.getContact(below->getPeerDescriptor()));
+    EXPECT_TRUE(list.getContact(above->getPeerDescriptor()));
+    EXPECT_FALSE(list.getContact(makePeerDescriptor(50)));
+
+    list.removeContact(below);
+    EXPECT_FALSE(list.getContact(below->getPeerDescriptor()));
+    EXPECT_EQ(regionsOf(list.getAllContacts()), (std::vector<uint32_t>{101}));
+}
+
+TEST(RingContactListTest, GetAllContactsReturnsBothSides) {
+    RingContactList<Contact> list(referenceIdRaw());
+    // Enough on each side that the closest neighbours are distinct per side
+    // (no sparse both-sides overlap): 5 below and 5 above.
+    for (uint32_t region = 95; region < 100; ++region) {
+        list.addContact(makeContact(region));
+    }
+    for (uint32_t region = 101; region <= 105; ++region) {
+        list.addContact(makeContact(region));
+    }
+    const auto closest = list.getClosestContacts();
+    EXPECT_EQ(
+        regionsOf(closest.left), (std::vector<uint32_t>{99, 98, 97, 96, 95}));
+    EXPECT_EQ(
+        regionsOf(closest.right),
+        (std::vector<uint32_t>{101, 102, 103, 104, 105}));
+    // getAllContacts is left ++ right.
+    std::vector<uint32_t> both = regionsOf(closest.left);
+    const auto rightRegions = regionsOf(closest.right);
+    both.insert(both.end(), rightRegions.begin(), rightRegions.end());
+    EXPECT_EQ(regionsOf(list.getAllContacts()), both);
+}
+
+// NOLINTEND(readability-magic-numbers)

--- a/packages/streamr-dht/test/unit/SortedContactListTest.cpp
+++ b/packages/streamr-dht/test/unit/SortedContactListTest.cpp
@@ -1,0 +1,214 @@
+// Ported from packages/dht/test/unit/SortedContactList.test.ts
+// (v103.8.0-rc.3).
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+
+import streamr.dht.ContactList;
+import streamr.dht.Identifiers;
+import streamr.dht.SortedContactList;
+
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtAddressRaw;
+using streamr::dht::Identifiers;
+using streamr::dht::contact::SortedContactList;
+using streamr::dht::contact::SortedContactListOptions;
+namespace contactlistevents = streamr::dht::contact::contactlistevents;
+
+namespace {
+
+constexpr size_t defaultMaxSize = 8;
+constexpr size_t largeMaxSize = 10;
+constexpr size_t maxSizeThree = 3;
+constexpr size_t maxSizeTwo = 2;
+constexpr int limitTwo = 2;
+constexpr int limitTen = 10;
+constexpr int negativeLimit = -2;
+
+struct TestItem {
+    DhtAddress nodeId;
+    explicit TestItem(const DhtAddressRaw& raw)
+        : nodeId(Identifiers::getDhtAddressFromRaw(raw)) {}
+    [[nodiscard]] DhtAddress getNodeId() const { return this->nodeId; }
+};
+
+static_assert(
+    streamr::dht::contact::HasGetNodeId<TestItem>,
+    "TestItem provides getNodeId()");
+static_assert(
+    !streamr::dht::contact::HasGetNodeId<int>,
+    "the HasGetNodeId constraint is not vacuous");
+
+DhtAddressRaw rawFromBytes(const std::vector<unsigned char>& bytes) {
+    return DhtAddressRaw{std::string(bytes.begin(), bytes.end())};
+}
+
+std::shared_ptr<TestItem> createItem(const std::vector<unsigned char>& bytes) {
+    return std::make_shared<TestItem>(rawFromBytes(bytes));
+}
+
+std::vector<DhtAddress> nodeIdsOf(
+    const std::vector<std::shared_ptr<TestItem>>& items) {
+    std::vector<DhtAddress> ids;
+    ids.reserve(items.size());
+    for (const auto& item : items) {
+        ids.push_back(item->getNodeId());
+    }
+    return ids;
+}
+
+} // namespace
+
+class SortedContactListTest : public ::testing::Test {
+protected:
+    std::shared_ptr<TestItem> item0 = createItem({0, 0, 0, 0});
+    std::shared_ptr<TestItem> item1 = createItem({0, 0, 0, 1});
+    std::shared_ptr<TestItem> item2 = createItem({0, 0, 0, 2});
+    std::shared_ptr<TestItem> item3 = createItem({0, 0, 0, 3});
+    std::shared_ptr<TestItem> item4 = createItem({0, 0, 0, 4});
+};
+
+TEST_F(SortedContactListTest, ComparesIdsCorrectly) {
+    SortedContactList<TestItem> list(
+        SortedContactListOptions{
+            .referenceId = item0->getNodeId(),
+            .allowToContainReferenceId = true,
+            .maxSize = largeMaxSize});
+    EXPECT_EQ(list.compareIds(item0->getNodeId(), item0->getNodeId()), 0);
+    EXPECT_EQ(list.compareIds(item1->getNodeId(), item1->getNodeId()), 0);
+    EXPECT_EQ(list.compareIds(item0->getNodeId(), item1->getNodeId()), -1);
+    EXPECT_EQ(list.compareIds(item0->getNodeId(), item2->getNodeId()), -2);
+    EXPECT_EQ(list.compareIds(item1->getNodeId(), item0->getNodeId()), 1);
+    EXPECT_EQ(list.compareIds(item2->getNodeId(), item0->getNodeId()), 2);
+    EXPECT_EQ(list.compareIds(item2->getNodeId(), item3->getNodeId()), -1);
+    EXPECT_EQ(list.compareIds(item1->getNodeId(), item4->getNodeId()), -3);
+}
+
+TEST_F(SortedContactListTest, CannotExceedMaxSize) {
+    SortedContactList<TestItem> list(
+        SortedContactListOptions{
+            .referenceId = item0->getNodeId(),
+            .allowToContainReferenceId = false,
+            .maxSize = maxSizeThree});
+    std::vector<std::shared_ptr<TestItem>> removed;
+    list.on<contactlistevents::ContactRemoved<TestItem>>(
+        [&removed](const std::shared_ptr<TestItem>& contact) {
+            removed.push_back(contact);
+        });
+    list.addContact(item1);
+    list.addContact(item4);
+    list.addContact(item3);
+    list.addContact(item2);
+    EXPECT_EQ(list.getSize(), 3U);
+    EXPECT_EQ(
+        nodeIdsOf(list.getClosestContacts()), nodeIdsOf({item1, item2, item3}));
+    EXPECT_EQ(list.getContactIds(), nodeIdsOf({item1, item2, item3}));
+    ASSERT_EQ(removed.size(), 1U);
+    EXPECT_EQ(removed[0]->getNodeId(), item4->getNodeId());
+    EXPECT_FALSE(list.getContact(item4->getNodeId()));
+}
+
+TEST_F(SortedContactListTest, RemovingContacts) {
+    SortedContactList<TestItem> list(
+        SortedContactListOptions{
+            .referenceId = item0->getNodeId(),
+            .allowToContainReferenceId = false,
+            .maxSize = defaultMaxSize});
+    std::vector<std::shared_ptr<TestItem>> removed;
+    list.on<contactlistevents::ContactRemoved<TestItem>>(
+        [&removed](const std::shared_ptr<TestItem>& contact) {
+            removed.push_back(contact);
+        });
+    list.removeContact(Identifiers::createRandomDhtAddress());
+    list.addContact(item3);
+    list.removeContact(item3->getNodeId());
+    list.addContact(item4);
+    list.addContact(item3);
+    list.addContact(item2);
+    list.addContact(item1);
+    list.removeContact(item2->getNodeId());
+    EXPECT_EQ(list.getSize(), 3U);
+    EXPECT_FALSE(list.getContact(item2->getNodeId()));
+    auto sorted = list.getContactIds();
+    std::ranges::sort(
+        sorted, [&list](const DhtAddress& a, const DhtAddress& b) {
+            return list.compareIds(a, b) < 0;
+        });
+    EXPECT_EQ(list.getContactIds(), sorted);
+    EXPECT_EQ(
+        nodeIdsOf(list.getClosestContacts()), nodeIdsOf({item1, item3, item4}));
+    const bool ret = list.removeContact(
+        Identifiers::getDhtAddressFromRaw(rawFromBytes({0, 0, 0, 6})));
+    EXPECT_FALSE(ret);
+    list.removeContact(item3->getNodeId());
+    list.removeContact(Identifiers::createRandomDhtAddress());
+    EXPECT_EQ(nodeIdsOf(list.getClosestContacts()), nodeIdsOf({item1, item4}));
+    ASSERT_EQ(removed.size(), 3U);
+    EXPECT_EQ(removed[0]->getNodeId(), item3->getNodeId());
+    EXPECT_EQ(removed[1]->getNodeId(), item2->getNodeId());
+    EXPECT_EQ(removed[2]->getNodeId(), item3->getNodeId());
+}
+
+TEST_F(SortedContactListTest, GetClosestContacts) {
+    SortedContactList<TestItem> list(
+        SortedContactListOptions{
+            .referenceId = item0->getNodeId(),
+            .allowToContainReferenceId = false,
+            .maxSize = defaultMaxSize});
+    list.addContact(item1);
+    list.addContact(item3);
+    list.addContact(item4);
+    list.addContact(item2);
+    EXPECT_EQ(
+        nodeIdsOf(list.getClosestContacts(limitTwo)),
+        nodeIdsOf({item1, item2}));
+    EXPECT_EQ(
+        nodeIdsOf(list.getClosestContacts(limitTen)),
+        nodeIdsOf({item1, item2, item3, item4}));
+    EXPECT_EQ(
+        nodeIdsOf(list.getClosestContacts()),
+        nodeIdsOf({item1, item2, item3, item4}));
+    EXPECT_TRUE(list.getClosestContacts(negativeLimit).empty());
+}
+
+TEST_F(SortedContactListTest, GetFurthestContacts) {
+    SortedContactList<TestItem> list(
+        SortedContactListOptions{
+            .referenceId = item0->getNodeId(),
+            .allowToContainReferenceId = false,
+            .maxSize = defaultMaxSize});
+    list.addContact(item1);
+    list.addContact(item3);
+    list.addContact(item4);
+    list.addContact(item2);
+    EXPECT_EQ(
+        nodeIdsOf(list.getFurthestContacts(limitTwo)),
+        nodeIdsOf({item4, item3}));
+    EXPECT_EQ(
+        nodeIdsOf(list.getFurthestContacts(limitTen)),
+        nodeIdsOf({item4, item3, item2, item1}));
+    EXPECT_EQ(
+        nodeIdsOf(list.getFurthestContacts()),
+        nodeIdsOf({item4, item3, item2, item1}));
+    EXPECT_TRUE(list.getFurthestContacts(negativeLimit).empty());
+}
+
+TEST_F(SortedContactListTest, DoesNotEmitContactAddedIfContactDidNotFit) {
+    SortedContactList<TestItem> list(
+        SortedContactListOptions{
+            .referenceId = item0->getNodeId(),
+            .allowToContainReferenceId = false,
+            .maxSize = maxSizeTwo});
+    int added = 0;
+    list.on<contactlistevents::ContactAdded<TestItem>>(
+        [&added](const std::shared_ptr<TestItem>& /*contact*/) { ++added; });
+    list.addContact(item1);
+    list.addContact(item2);
+    EXPECT_EQ(added, 2);
+    list.addContact(item3);
+    EXPECT_EQ(added, 2);
+    EXPECT_EQ(list.getClosestContacts().size(), 2U);
+}

--- a/packages/streamr-dht/test/unit/getClosestNodesTest.cpp
+++ b/packages/streamr-dht/test/unit/getClosestNodesTest.cpp
@@ -1,0 +1,79 @@
+// Ported from packages/dht/test/unit/getClosestNodes.test.ts
+// (v103.8.0-rc.3). The TS test excludes a random sample of 2 node ids;
+// here it excludes the first two, which exercises the same filtering.
+#include <algorithm>
+#include <cstddef>
+#include <set>
+#include <vector>
+#include <gtest/gtest.h>
+
+import streamr.dht.getClosestNodes;
+import streamr.dht.getPeerDistance;
+import streamr.dht.Identifiers;
+import streamr.dht.protos;
+import streamr.dht.TestUtils;
+
+using ::dht::PeerDescriptor;
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtAddressRaw;
+using streamr::dht::Identifiers;
+using streamr::dht::contact::getClosestNodes;
+using streamr::dht::contact::GetClosestNodesOptions;
+using streamr::dht::helpers::getPeerDistance;
+using streamr::dht::testutils::createMockPeerDescriptor;
+
+namespace {
+
+constexpr size_t descriptorCount = 10;
+constexpr size_t maxCount = 5;
+
+std::vector<DhtAddress> nodeIdsOf(
+    const std::vector<PeerDescriptor>& peerDescriptors) {
+    std::vector<DhtAddress> ids;
+    ids.reserve(peerDescriptors.size());
+    for (const auto& peerDescriptor : peerDescriptors) {
+        ids.push_back(Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor));
+    }
+    return ids;
+}
+
+} // namespace
+
+TEST(getClosestNodes, HappyPath) {
+    std::vector<PeerDescriptor> peerDescriptors;
+    peerDescriptors.reserve(descriptorCount);
+    for (size_t i = 0; i < descriptorCount; ++i) {
+        peerDescriptors.push_back(createMockPeerDescriptor());
+    }
+    const DhtAddress referenceId = Identifiers::createRandomDhtAddress();
+    const std::set<DhtAddress> excluded = {
+        Identifiers::getNodeIdFromPeerDescriptor(peerDescriptors[0]),
+        Identifiers::getNodeIdFromPeerDescriptor(peerDescriptors[1])};
+
+    const std::vector<PeerDescriptor> actual = getClosestNodes(
+        referenceId,
+        peerDescriptors,
+        GetClosestNodesOptions{
+            .maxCount = maxCount, .excludedNodeIds = excluded});
+
+    const DhtAddressRaw referenceIdRaw =
+        Identifiers::getRawFromDhtAddress(referenceId);
+    std::vector<PeerDescriptor> expected;
+    for (const auto& peerDescriptor : peerDescriptors) {
+        if (!excluded.contains(
+                Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor))) {
+            expected.push_back(peerDescriptor);
+        }
+    }
+    std::ranges::stable_sort(
+        expected,
+        [&referenceIdRaw](const PeerDescriptor& a, const PeerDescriptor& b) {
+            return getPeerDistance(DhtAddressRaw{a.nodeid()}, referenceIdRaw) <
+                getPeerDistance(DhtAddressRaw{b.nodeid()}, referenceIdRaw);
+        });
+    if (expected.size() > maxCount) {
+        expected.resize(maxCount);
+    }
+
+    EXPECT_EQ(nodeIdsOf(actual), nodeIdsOf(expected));
+}

--- a/trackerless-network-completion-plan.md
+++ b/trackerless-network-completion-plan.md
@@ -351,6 +351,25 @@ New classes: `Contact`, `ContactList`, `SortedContactList`, `RandomContactList`,
 *Tests to port:* `unit/SortedContactList.test.ts`, `unit/RandomContactList.test.ts`,
 `unit/getClosestNodes.test.ts`, ring-contact coverage from `benchmark/RingCorrectness.test.ts`
 (port as a plain unit test, dropping the benchmark harness).
+*Implemented (phase-A1 PR):* all classes ported to `modules/dht/contact/` (namespace
+`streamr::dht::contact`) plus `getPeerDistance` in `modules/helpers/`. `getPeerDistance`
+replicates npm `k-bucket`'s `KBucket.distance` as a double accumulation so the sort key
+matches TS bit-for-bit (KBucket itself is phase A2). The contact lists are class templates
+over `C`, constrained with concepts (`HasGetNodeId` for the sorted/random lists,
+`HasGetPeerDescriptor` for the ring list) that enforce the required member at compile time
+instead of by comment,
+storing `shared_ptr<C>` and emitting the shared `ContactListEvents<C>`
+(contactAdded/contactRemoved); the TS `hasEventListeners()` emit guard is dropped as a no-op
+(emitting to zero listeners is already a no-op).
+`SortedContactList` uses `std::lower_bound` for the lodash `sortedIndexBy` insertion.
+`ringIdentifiers` computes the 120-bit ring id via `unsigned __int128` before the single
+narrowing to double, matching TS's `Number(binaryToBigInt(...))` (a byte-by-byte double
+accumulation would round differently); `RingContactList` uses `std::map<RingDistance, C>` for
+the TS `OrderedMap`. The three unit tests port directly; the ring coverage is a from-scratch
+`RingContactListTest` (the `RingCorrectness` benchmark needs `DhtNode`/`joinRing` and
+ground-truth data files, all later phases) exercising per-side neighbour selection, the
+per-side cap, reference/excluded-id filtering, removal and lookup. All 15 new tests green;
+full `./test.sh` and `./lint.sh` green.
 
 **Phase A2 — KBucket.**
 New class: `KBucket` (port of npm `k-bucket`), with contact arbitration and events wired to


### PR DESCRIPTION
## Summary

Phase A1 of the trackerless-network completion plan: the DHT contact-list layer, ported from TS 103.8.0-rc.3 into `packages/streamr-dht/modules/dht/contact/` (namespace `streamr::dht::contact`), plus `getPeerDistance` in `modules/helpers/`. This is the first of the milestone-A phases that build the DHT core logic on top of the phase-0.3 simulator.

## New modules

- **`getPeerDistance`** — the raw 20-byte XOR distance. Replicates npm `k-bucket`'s `KBucket.distance` as a `double` accumulation so the sort key matches TS bit-for-bit (KBucket itself arrives in phase A2; only the distance function is needed here).
- **`Contact`** — wraps a `PeerDescriptor` with the `getNodeId()` / `getPeerDescriptor()` shape the lists expect.
- **`ContactList<C>`** — the common base (`contactsById` / `contactIds`, the shared `contactAdded` / `contactRemoved` events) that `RandomContactList` extends.
- **`SortedContactList<C>`** — distance-sorted list with `maxSize` eviction; `std::lower_bound` implements the lodash `sortedIndexBy` insertion.
- **`RandomContactList<C>`** — random-sample list.
- **`ringIdentifiers`** — ring id and left/right ring distance. The 120-bit ring id is built in `unsigned __int128` and narrowed to `double` once, matching TS's `Number(binaryToBigInt(...))` — a byte-by-byte double accumulation would round differently.
- **`RingContactList<C>`** — the left/right ring-neighbour structure, using `std::map<RingDistance, C>` for the TS `OrderedMap`.

The lists are class templates over `C` (with `getNodeId()` / `getPeerDescriptor()`), storing `shared_ptr<C>` and emitting `ContactListEvents<C>`. The TS `hasEventListeners()` emit guard is dropped as a behaviour-preserving no-op (emitting to zero listeners is already a no-op).

## Tests

- **`SortedContactListTest`**, **`RandomContactListTest`**, **`getClosestNodesTest`** port the corresponding TS unit tests directly.
- **`RingContactListTest`** is a from-scratch unit test. The TS ring coverage is `benchmark/RingCorrectness.test.ts`, which drives 900 real `DhtNode`s joining a ring and compares against pre-generated ground-truth data — all of which is much later phases (`DhtNode`/`joinRing`). Per the plan, that benchmark is replaced by a plain unit test exercising per-side neighbour selection, the per-side cap, reference/excluded-id filtering, removal and lookup. (Note: when the ring is sparse a contact can legitimately sit on both sides — an empty side accepts any contact — which the test accounts for.)

## Test plan

- [x] 15 new unit tests green (`*ContactList*` + `getClosestNodes`)
- [x] `getClosestNodes` random test stress `--gtest_repeat=100` — stable
- [x] `./test.sh` — **363/363 pass** (was 348)
- [x] `./lint.sh` — clean (clangd 22)

Branched from `main` after #56 (phase A0) merged. Refs `trackerless-network-completion-plan.md` phase A1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)