### PR TITLE
Phase A2: KBucket

### DIFF
--- a/packages/streamr-dht/CMakeLists.txt
+++ b/packages/streamr-dht/CMakeLists.txt
@@ -210,6 +210,7 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         test/unit/RandomContactListTest.cpp
         test/unit/getClosestNodesTest.cpp
         test/unit/RingContactListTest.cpp
+        test/unit/KBucketTest.cpp
     )
 
     target_include_directories(streamr-dht-test-unit

--- a/packages/streamr-dht/modules/dht/contact/KBucket.cppm
+++ b/packages/streamr-dht/modules/dht/contact/KBucket.cppm
@@ -1,0 +1,319 @@
+// Module streamr.dht.KBucket
+// Ported from the npm `k-bucket` library (v5.1.0, MIT, Tristan Slominski),
+// which the TS DHT uses via `import KBucket from 'k-bucket'`. A Kademlia
+// k-bucket stored as a binary tree of nodes.
+//
+// Sized to what the DHT actually uses (PeerManager / DhtNode): the default
+// XOR distance and the default vectorClock arbiter are built in rather
+// than exposed as constructor options, and the `metadata` option and the
+// `toIterable` generator are omitted. The events are wired to
+// streamr-eventemitter instead of Node's EventEmitter.
+module;
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+export module streamr.dht.KBucket;
+
+import streamr.eventemitter.EventEmitter;
+import streamr.dht.Identifiers;
+import streamr.dht.getPeerDistance;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::eventemitter::Event;
+using streamr::eventemitter::EventEmitter;
+
+export namespace streamr::dht::contact {
+
+using streamr::dht::DhtAddressRaw;
+using streamr::dht::helpers::getPeerDistance;
+
+// The element type a KBucket holds: it reports its id (for the XOR metric
+// and identity) and a vector clock (for the default arbiter — the larger
+// vector clock wins when two contacts share an id). Replaces TS's
+// `interface KBucketContact { id: DhtAddressRaw; vectorClock: number }`.
+template <typename C>
+concept KBucketContact = requires(const C& contact) {
+    { contact.getId() } -> std::convertible_to<DhtAddressRaw>;
+    { contact.getVectorClock() } -> std::integral;
+};
+
+namespace kbucketevents {
+
+template <typename C>
+struct Added : Event<std::shared_ptr<C>> {};
+
+template <typename C>
+struct Removed : Event<std::shared_ptr<C>> {};
+
+// (incumbent, selection)
+template <typename C>
+struct Updated : Event<std::shared_ptr<C>, std::shared_ptr<C>> {};
+
+// (contacts to ping, replacement candidate)
+template <typename C>
+struct Ping : Event<std::vector<std::shared_ptr<C>>, std::shared_ptr<C>> {};
+
+} // namespace kbucketevents
+
+template <typename C>
+using KBucketEvents = std::tuple<
+    kbucketevents::Added<C>,
+    kbucketevents::Removed<C>,
+    kbucketevents::Updated<C>,
+    kbucketevents::Ping<C>>;
+
+struct KBucketOptions {
+    DhtAddressRaw localNodeId;
+    // The number of nodes a k-bucket holds before it must split or ping.
+    std::optional<size_t> numberOfNodesPerKBucket;
+    // The number of longest-uncontacted nodes offered in a `ping` event
+    // when a non-splittable bucket is full.
+    std::optional<size_t> numberOfNodesToPing;
+};
+
+template <KBucketContact C>
+class KBucket : public EventEmitter<KBucketEvents<C>> {
+private:
+    // A tree node: a leaf holds `contacts`; an inner node has `contacts`
+    // empty-of-value (nullopt) and two children.
+    struct Node {
+        std::optional<std::vector<std::shared_ptr<C>>> contacts =
+            std::vector<std::shared_ptr<C>>{};
+        bool dontSplit = false;
+        std::unique_ptr<Node> left;
+        std::unique_ptr<Node> right;
+
+        [[nodiscard]] bool isInner() const {
+            return !this->contacts.has_value();
+        }
+    };
+
+    static constexpr size_t defaultNodesPerKBucket = 20;
+    static constexpr size_t defaultNodesToPing = 3;
+
+    DhtAddressRaw localNodeId;
+    size_t numberOfNodesPerKBucket;
+    size_t numberOfNodesToPing;
+    Node root;
+
+    // The default vectorClock arbiter: the contact with the larger vector
+    // clock wins; ties go to the candidate (the more recent contact).
+    static std::shared_ptr<C> arbiter(
+        const std::shared_ptr<C>& incumbent,
+        const std::shared_ptr<C>& candidate) {
+        return incumbent->getVectorClock() > candidate->getVectorClock()
+            ? incumbent
+            : candidate;
+    }
+
+    // Returns the child to descend into for `id` at `bitIndex`. An id too
+    // short to have the bit is treated as having a 0 bit (goes left),
+    // matching the library's out-of-range/undefined byte handling.
+    Node* determineNode(Node* node, const DhtAddressRaw& id, size_t bitIndex) {
+        const size_t bytesDescribedByBitIndex = bitIndex >> 3U;
+        const size_t bitIndexWithinByte = bitIndex % 8U;
+        if (bytesDescribedByBitIndex >= id.size()) {
+            return node->left.get();
+        }
+        const auto byteUnderConsideration =
+            static_cast<unsigned char>(id[bytesDescribedByBitIndex]);
+        if ((byteUnderConsideration & (1U << (7U - bitIndexWithinByte))) != 0) {
+            return node->right.get();
+        }
+        return node->left.get();
+    }
+
+    // Index of the contact with `id` in a leaf node, or -1.
+    static int indexOf(const Node* node, const DhtAddressRaw& id) {
+        for (size_t i = 0; i < node->contacts->size(); ++i) {
+            if ((*node->contacts)[i]->getId() == id) {
+                return static_cast<int>(i);
+            }
+        }
+        return -1;
+    }
+
+    // Splits a full leaf into two children, redistributes its contacts, and
+    // marks the child NOT containing the local node id as dontSplit (the
+    // "far away" bucket does not split further).
+    void split(Node* node, size_t bitIndex) {
+        node->left = std::make_unique<Node>();
+        node->right = std::make_unique<Node>();
+        for (const auto& contact : *node->contacts) {
+            this->determineNode(node, contact->getId(), bitIndex)
+                ->contacts->push_back(contact);
+        }
+        node->contacts = std::nullopt; // mark as inner node
+        Node* detNode = this->determineNode(node, this->localNodeId, bitIndex);
+        Node* otherNode = (node->left.get() == detNode) ? node->right.get()
+                                                        : node->left.get();
+        otherNode->dontSplit = true;
+    }
+
+    // Updates the contact at `index` using the arbiter. If the incumbent is
+    // kept and the candidate is a different object, nothing changes;
+    // otherwise the selection replaces it at the most-recently-contacted
+    // (end) position and an `updated` event is emitted.
+    void update(Node* node, size_t index, const std::shared_ptr<C>& contact) {
+        const std::shared_ptr<C> incumbent = (*node->contacts)[index];
+        const std::shared_ptr<C> selection = arbiter(incumbent, contact);
+        if (selection == incumbent && incumbent != contact) {
+            return;
+        }
+        node->contacts->erase(
+            node->contacts->begin() + static_cast<std::ptrdiff_t>(index));
+        node->contacts->push_back(selection);
+        this->template emit<kbucketevents::Updated<C>>(incumbent, selection);
+    }
+
+public:
+    explicit KBucket(KBucketOptions options)
+        : localNodeId(std::move(options.localNodeId)),
+          numberOfNodesPerKBucket(
+              options.numberOfNodesPerKBucket.value_or(defaultNodesPerKBucket)),
+          numberOfNodesToPing(
+              options.numberOfNodesToPing.value_or(defaultNodesToPing)) {}
+
+    // Adds a contact. Descends to the owning leaf; updates it in place if
+    // already present; otherwise appends it if there is room; otherwise
+    // either pings (if the leaf cannot split) or splits and retries.
+    void add(const std::shared_ptr<C>& contact) {
+        size_t bitIndex = 0;
+        Node* node = &this->root;
+        while (node->isInner()) {
+            node = this->determineNode(node, contact->getId(), bitIndex++);
+        }
+        const int index = indexOf(node, contact->getId());
+        if (index >= 0) {
+            this->update(node, static_cast<size_t>(index), contact);
+            return;
+        }
+        if (node->contacts->size() < this->numberOfNodesPerKBucket) {
+            node->contacts->push_back(contact);
+            this->template emit<kbucketevents::Added<C>>(contact);
+            return;
+        }
+        if (node->dontSplit) {
+            const size_t pingCount =
+                std::min(this->numberOfNodesToPing, node->contacts->size());
+            std::vector<std::shared_ptr<C>> toPing(
+                node->contacts->begin(),
+                node->contacts->begin() +
+                    static_cast<std::ptrdiff_t>(pingCount));
+            this->template emit<kbucketevents::Ping<C>>(toPing, contact);
+            return;
+        }
+        this->split(node, bitIndex);
+        this->add(contact);
+    }
+
+    // The contact with the exact id, or nullptr.
+    [[nodiscard]] std::shared_ptr<C> get(const DhtAddressRaw& id) {
+        size_t bitIndex = 0;
+        Node* node = &this->root;
+        while (node->isInner()) {
+            node = this->determineNode(node, id, bitIndex++);
+        }
+        const int index = indexOf(node, id);
+        return index >= 0 ? (*node->contacts)[static_cast<size_t>(index)]
+                          : nullptr;
+    }
+
+    // Removes the contact with the id (emitting `removed` if it was present).
+    void remove(const DhtAddressRaw& id) {
+        size_t bitIndex = 0;
+        Node* node = &this->root;
+        while (node->isInner()) {
+            node = this->determineNode(node, id, bitIndex++);
+        }
+        const int index = indexOf(node, id);
+        if (index >= 0) {
+            const std::shared_ptr<C> contact =
+                (*node->contacts)[static_cast<size_t>(index)];
+            node->contacts->erase(node->contacts->begin() + index);
+            this->template emit<kbucketevents::Removed<C>>(contact);
+        }
+    }
+
+    // The up-to-`n` closest contacts to `id` by the XOR metric, nearest
+    // first. Without a limit, all contacts are returned in that order.
+    [[nodiscard]] std::vector<std::shared_ptr<C>> closest(
+        const DhtAddressRaw& id, std::optional<size_t> n = std::nullopt) {
+        const size_t limit = n.value_or(SIZE_MAX);
+        std::vector<std::shared_ptr<C>> contacts;
+        std::vector<Node*> nodes{&this->root};
+        size_t bitIndex = 0;
+        while (!nodes.empty() && contacts.size() < limit) {
+            Node* node = nodes.back();
+            nodes.pop_back();
+            if (node->isInner()) {
+                Node* detNode = this->determineNode(node, id, bitIndex++);
+                nodes.push_back(
+                    node->left.get() == detNode ? node->right.get()
+                                                : node->left.get());
+                nodes.push_back(detNode);
+            } else {
+                contacts.insert(
+                    contacts.end(),
+                    node->contacts->begin(),
+                    node->contacts->end());
+            }
+        }
+        std::ranges::stable_sort(
+            contacts,
+            [&id](const std::shared_ptr<C>& a, const std::shared_ptr<C>& b) {
+                return getPeerDistance(a->getId(), id) <
+                    getPeerDistance(b->getId(), id);
+            });
+        if (contacts.size() > limit) {
+            contacts.resize(limit);
+        }
+        return contacts;
+    }
+
+    // The total number of contacts held in the tree.
+    [[nodiscard]] size_t count() {
+        size_t count = 0;
+        std::vector<Node*> nodes{&this->root};
+        while (!nodes.empty()) {
+            Node* node = nodes.back();
+            nodes.pop_back();
+            if (node->isInner()) {
+                nodes.push_back(node->right.get());
+                nodes.push_back(node->left.get());
+            } else {
+                count += node->contacts->size();
+            }
+        }
+        return count;
+    }
+
+    // All contacts in the tree.
+    [[nodiscard]] std::vector<std::shared_ptr<C>> toArray() {
+        std::vector<std::shared_ptr<C>> result;
+        std::vector<Node*> nodes{&this->root};
+        while (!nodes.empty()) {
+            Node* node = nodes.back();
+            nodes.pop_back();
+            if (node->isInner()) {
+                nodes.push_back(node->right.get());
+                nodes.push_back(node->left.get());
+            } else {
+                result.insert(
+                    result.end(),
+                    node->contacts->begin(),
+                    node->contacts->end());
+            }
+        }
+        return result;
+    }
+};
+
+} // namespace streamr::dht::contact

--- a/packages/streamr-dht/test/unit/KBucketTest.cpp
+++ b/packages/streamr-dht/test/unit/KBucketTest.cpp
@@ -1,0 +1,273 @@
+// Unit coverage for KBucket (module streamr.dht.KBucket), derived from the
+// behaviour contract of the npm k-bucket library's own test suite
+// (add / split / ping / closest / remove / update / count / toArray),
+// exercised through the public API (the internal tree is private).
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+
+import streamr.dht.getPeerDistance;
+import streamr.dht.Identifiers;
+import streamr.dht.KBucket;
+
+using streamr::dht::DhtAddressRaw;
+using streamr::dht::contact::KBucket;
+using streamr::dht::contact::KBucketOptions;
+using streamr::dht::helpers::getPeerDistance;
+namespace kbucketevents = streamr::dht::contact::kbucketevents;
+
+namespace {
+
+constexpr size_t defaultBucketSize = 20;
+constexpr size_t defaultNodesToPing = 3;
+
+struct MockContact {
+    DhtAddressRaw id;
+    int64_t vectorClock;
+    MockContact(DhtAddressRaw id, int64_t vectorClock)
+        : id(std::move(id)), vectorClock(vectorClock) {}
+    [[nodiscard]] DhtAddressRaw getId() const { return this->id; }
+    [[nodiscard]] int64_t getVectorClock() const { return this->vectorClock; }
+};
+
+static_assert(
+    streamr::dht::contact::KBucketContact<MockContact>,
+    "MockContact provides getId()/getVectorClock()");
+static_assert(
+    !streamr::dht::contact::KBucketContact<int>,
+    "the KBucketContact constraint is not vacuous");
+
+DhtAddressRaw rawFromBytes(const std::vector<unsigned char>& bytes) {
+    return DhtAddressRaw{std::string(bytes.begin(), bytes.end())};
+}
+
+std::shared_ptr<MockContact> makeContact(
+    const std::vector<unsigned char>& bytes, int64_t vectorClock = 0) {
+    return std::make_shared<MockContact>(rawFromBytes(bytes), vectorClock);
+}
+
+KBucket<MockContact> makeBucket(const std::vector<unsigned char>& localId) {
+    return KBucket<MockContact>(
+        KBucketOptions{.localNodeId = rawFromBytes(localId)});
+}
+
+} // namespace
+
+// NOLINTBEGIN(readability-magic-numbers) — byte-array ids and vector clocks
+// are arbitrary test data.
+
+TEST(KBucketTest, AddingContactPlacesItInBucket) {
+    auto bucket = makeBucket({0x00});
+    const auto contact = makeContact({'a'});
+    bucket.add(contact);
+    EXPECT_EQ(bucket.count(), 1U);
+    EXPECT_EQ(bucket.get(rawFromBytes({'a'})), contact);
+    ASSERT_EQ(bucket.toArray().size(), 1U);
+    EXPECT_EQ(bucket.toArray()[0], contact);
+}
+
+TEST(KBucketTest, AddingExistingContactDoesNotIncreaseCount) {
+    auto bucket = makeBucket({0x00});
+    bucket.add(makeContact({'a'}));
+    bucket.add(makeContact({'a'}));
+    EXPECT_EQ(bucket.count(), 1U);
+}
+
+TEST(KBucketTest, AddingSameContactMovesItToTheEnd) {
+    auto bucket = makeBucket({0x00});
+    const auto contactA = makeContact({'a'});
+    const auto contactB = makeContact({'b'});
+    bucket.add(contactA);
+    bucket.add(contactB);
+    EXPECT_EQ(
+        bucket.toArray(),
+        (std::vector<std::shared_ptr<MockContact>>{contactA, contactB}));
+
+    bool updated = false;
+    bucket.on<kbucketevents::Updated<MockContact>>(
+        [&updated](
+            const std::shared_ptr<MockContact>& /*incumbent*/,
+            const std::shared_ptr<MockContact>& /*selection*/) {
+            updated = true;
+        });
+    const auto contactANewer = makeContact({'a'});
+    bucket.add(contactANewer);
+    EXPECT_EQ(
+        bucket.toArray(),
+        (std::vector<std::shared_ptr<MockContact>>{contactB, contactANewer}));
+    EXPECT_TRUE(updated);
+}
+
+TEST(KBucketTest, AddingNewContactEmitsAdded) {
+    auto bucket = makeBucket({0x00});
+    std::shared_ptr<MockContact> added;
+    bucket.on<kbucketevents::Added<MockContact>>(
+        [&added](const std::shared_ptr<MockContact>& contact) {
+            added = contact;
+        });
+    const auto contact = makeContact({'a'});
+    bucket.add(contact);
+    EXPECT_EQ(added, contact);
+}
+
+TEST(KBucketTest, SplittingRetainsAllContactsBeyondBucketSize) {
+    // With localNodeId near the added ids, a full bucket splits instead of
+    // pinging, so all numberOfNodesPerKBucket + 1 contacts are kept.
+    auto bucket = makeBucket({0x00});
+    for (unsigned char i = 0; i <= defaultBucketSize; ++i) {
+        bucket.add(makeContact({i}));
+    }
+    EXPECT_EQ(bucket.count(), defaultBucketSize + 1);
+    for (unsigned char i = 0; i <= defaultBucketSize; ++i) {
+        EXPECT_TRUE(bucket.get(rawFromBytes({i}))) << "missing contact " << i;
+    }
+}
+
+TEST(KBucketTest, NonSplittableFullBucketEmitsPingAndRejectsContact) {
+    // All ids are in the half "far" from localNodeId (high bit set), so the
+    // split marks their bucket dontSplit; the next contact overflows it and
+    // triggers a ping of the longest-uncontacted nodes instead of an add.
+    auto bucket = makeBucket({0x00});
+    for (unsigned char i = 0; i < defaultBucketSize; ++i) {
+        bucket.add(makeContact({static_cast<unsigned char>(0x80 + i)}));
+    }
+    std::vector<std::shared_ptr<MockContact>> pinged;
+    std::shared_ptr<MockContact> replacement;
+    bucket.on<kbucketevents::Ping<MockContact>>(
+        [&pinged, &replacement](
+            const std::vector<std::shared_ptr<MockContact>>& contacts,
+            const std::shared_ptr<MockContact>& candidate) {
+            pinged = contacts;
+            replacement = candidate;
+        });
+    const auto extra =
+        makeContact({static_cast<unsigned char>(0x80 + defaultBucketSize)});
+    bucket.add(extra);
+
+    EXPECT_EQ(pinged.size(), defaultNodesToPing);
+    EXPECT_EQ(replacement, extra);
+    // the least-recently-contacted contacts are offered for pinging
+    EXPECT_EQ(pinged[0]->getId(), rawFromBytes({0x80}));
+    EXPECT_EQ(pinged[1]->getId(), rawFromBytes({0x81}));
+    EXPECT_EQ(pinged[2]->getId(), rawFromBytes({0x82}));
+    EXPECT_EQ(bucket.count(), defaultBucketSize);
+    EXPECT_FALSE(bucket.get(extra->getId()));
+}
+
+TEST(KBucketTest, ClosestReturnsNClosestByXorDistance) {
+    auto bucket = makeBucket({0x00});
+    std::vector<std::shared_ptr<MockContact>> contacts = {
+        makeContact({0x00, 0x01}),
+        makeContact({0x00, 0x05}),
+        makeContact({0x10, 0x00}),
+        makeContact({0x20, 0x03}),
+        makeContact({0x40, 0x0a}),
+        makeContact({0x80, 0x00})};
+    for (const auto& contact : contacts) {
+        bucket.add(contact);
+    }
+    const DhtAddressRaw target = rawFromBytes({0x00, 0x02});
+    const auto actual = bucket.closest(target, defaultNodesToPing);
+
+    auto expected = contacts;
+    std::ranges::stable_sort(
+        expected,
+        [&target](
+            const std::shared_ptr<MockContact>& a,
+            const std::shared_ptr<MockContact>& b) {
+            return getPeerDistance(a->getId(), target) <
+                getPeerDistance(b->getId(), target);
+        });
+    expected.resize(defaultNodesToPing);
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(KBucketTest, ClosestWithoutLimitReturnsAllSortedByDistance) {
+    auto bucket = makeBucket({0x00});
+    const auto near = makeContact({0x00, 0x01});
+    const auto mid = makeContact({0x10, 0x00});
+    const auto far = makeContact({0x80, 0x00});
+    bucket.add(far);
+    bucket.add(near);
+    bucket.add(mid);
+    const auto actual = bucket.closest(rawFromBytes({0x00, 0x00}));
+    EXPECT_EQ(
+        actual, (std::vector<std::shared_ptr<MockContact>>{near, mid, far}));
+}
+
+TEST(KBucketTest, RemoveEmitsRemovedAndDropsContact) {
+    auto bucket = makeBucket({0x00});
+    const auto contact = makeContact({'a'});
+    bucket.add(contact);
+    std::shared_ptr<MockContact> removed;
+    bucket.on<kbucketevents::Removed<MockContact>>(
+        [&removed](const std::shared_ptr<MockContact>& c) { removed = c; });
+    bucket.remove(rawFromBytes({'a'}));
+    EXPECT_EQ(removed, contact);
+    EXPECT_FALSE(bucket.get(rawFromBytes({'a'})));
+    EXPECT_EQ(bucket.count(), 0U);
+}
+
+TEST(KBucketTest, RemovingUnknownIdIsANoOp) {
+    auto bucket = makeBucket({0x00});
+    bucket.add(makeContact({'a'}));
+    bool removed = false;
+    bucket.on<kbucketevents::Removed<MockContact>>(
+        [&removed](const std::shared_ptr<MockContact>& /*c*/) {
+            removed = true;
+        });
+    bucket.remove(rawFromBytes({'b'}));
+    EXPECT_FALSE(removed);
+    EXPECT_EQ(bucket.count(), 1U);
+}
+
+TEST(KBucketTest, LowerVectorClockIsDropped) {
+    auto bucket = makeBucket({0x00});
+    bucket.add(makeContact({'a'}, 3));
+    bool updated = false;
+    bucket.on<kbucketevents::Updated<MockContact>>(
+        [&updated](
+            const std::shared_ptr<MockContact>& /*incumbent*/,
+            const std::shared_ptr<MockContact>& /*selection*/) {
+            updated = true;
+        });
+    bucket.add(makeContact({'a'}, 2));
+    EXPECT_EQ(bucket.get(rawFromBytes({'a'}))->getVectorClock(), 3);
+    EXPECT_FALSE(updated);
+}
+
+TEST(KBucketTest, HigherVectorClockWinsAndEmitsUpdated) {
+    auto bucket = makeBucket({0x00});
+    bucket.add(makeContact({'a'}, 3));
+    std::shared_ptr<MockContact> updatedIncumbent;
+    std::shared_ptr<MockContact> updatedSelection;
+    bucket.on<kbucketevents::Updated<MockContact>>(
+        [&updatedIncumbent, &updatedSelection](
+            const std::shared_ptr<MockContact>& incumbent,
+            const std::shared_ptr<MockContact>& selection) {
+            updatedIncumbent = incumbent;
+            updatedSelection = selection;
+        });
+    const auto newer = makeContact({'a'}, 4);
+    bucket.add(newer);
+    EXPECT_EQ(bucket.get(rawFromBytes({'a'}))->getVectorClock(), 4);
+    EXPECT_EQ(updatedSelection, newer);
+    EXPECT_EQ(updatedIncumbent->getVectorClock(), 3);
+}
+
+TEST(KBucketTest, CountAndToArrayReflectContents) {
+    auto bucket = makeBucket({0x00});
+    EXPECT_EQ(bucket.count(), 0U);
+    EXPECT_TRUE(bucket.toArray().empty());
+    bucket.add(makeContact({'a'}));
+    bucket.add(makeContact({'b'}));
+    bucket.add(makeContact({'c'}));
+    EXPECT_EQ(bucket.count(), 3U);
+    EXPECT_EQ(bucket.toArray().size(), 3U);
+}
+
+// NOLINTEND(readability-magic-numbers)

--- a/trackerless-network-completion-plan.md
+++ b/trackerless-network-completion-plan.md
@@ -376,6 +376,21 @@ New class: `KBucket` (port of npm `k-bucket`), with contact arbitration and even
 `streamr-eventemitter`.
 *Tests:* new unit tests derived from the library's behavior contract (add/split/ping-eviction/
 closest iteration), sized by what `PeerManager` actually uses.
+*Implemented (phase-A2 PR):* `KBucket<C>` in `modules/dht/contact/` (namespace
+`streamr::dht::contact`), a faithful port of the npm `k-bucket` binary-tree implementation —
+`add` (descend / update / append / split / ping), `get`, `remove`, `closest`, `count`,
+`toArray`, with the tree nodes held as `std::optional<vector>` contacts (nullopt = inner
+node) and `unique_ptr` children. Sized to the DHT's usage: the default XOR distance
+(`getPeerDistance`) and the default vector-clock arbiter are built in rather than exposed as
+constructor options, and the `metadata` option and `toIterable` generator are dropped. The
+contact type is constrained by a `KBucketContact` concept (`getId()` → `DhtAddressRaw`,
+`getVectorClock()` → integral), replacing TS's `KBucketContact` interface; events
+(added/removed/updated/ping) go through `streamr-eventemitter`. 13 unit tests cover the
+behaviour contract through the public API (the tree is private): add/dedupe/move-to-end,
+`added`; splitting retaining all 21 contacts; a non-splittable full bucket emitting `ping`
+of the 3 longest-uncontacted and rejecting the overflow; `closest` by XOR distance (limited
+and unlimited); remove/`removed`; the vector-clock arbiter (lower dropped, higher wins +
+`updated`); count/toArray. Full `./test.sh` and `./lint.sh` green.
 
 **Phase A3 — DhtNodeRpc and PeerManager.**
 New classes: `DhtNodeRpcLocal`, `DhtNodeRpcRemote` (extends the existing `RpcRemote` base),


### PR DESCRIPTION
## Summary

Phase A2 of the trackerless-network completion plan: `KBucket` — a port of the npm [`k-bucket`](https://github.com/tristanls/k-bucket) library (the Kademlia k-bucket the TS DHT uses via `import KBucket from 'k-bucket'`), into `packages/streamr-dht/modules/dht/contact/` (namespace `streamr::dht::contact`).

## The port

A faithful port of k-bucket's binary-tree implementation as a class template `KBucket<C>`:
- `add` (descend to the owning leaf → update in place / append / split / ping), `get`, `remove`, `closest`, `count`, `toArray`.
- The tree nodes are held with `std::optional<std::vector<...>>` contacts (`nullopt` marks an inner node) and `std::unique_ptr` children.
- Splitting marks the child not containing the local node id as `dontSplit` (the "far away" bucket doesn't split further); a full non-splittable bucket emits `ping` instead of adding.

**Sized to what the DHT actually uses** (`PeerManager` / `DhtNode`): the default XOR distance (`getPeerDistance`, ported in A1) and the default vector-clock arbiter are built in rather than exposed as constructor options, and the `metadata` option and the `toIterable` generator are dropped.

- The contact type is constrained by a **`KBucketContact` concept** (`getId() -> DhtAddressRaw`, `getVectorClock() -> std::integral`), replacing TS's `KBucketContact` interface.
- The events (`added` / `removed` / `updated` / `ping`) are wired to **`streamr-eventemitter`** instead of Node's `EventEmitter`.

## Tests

`KBucketTest` (13 cases) covers the library's behaviour contract through the public API (the tree is private):
- add / dedupe / move-to-end, and the `added` event;
- splitting retaining all `numberOfNodesPerKBucket + 1` contacts;
- a non-splittable full bucket emitting `ping` of the three longest-uncontacted contacts and rejecting the overflow;
- `closest` by XOR distance (limited and unlimited);
- remove and the `removed` event;
- the vector-clock arbiter (lower vector clock dropped; higher wins with an `updated` event);
- count and toArray.

## Test plan

- [x] 13 new `KBucketTest` cases green
- [x] `./test.sh` — **376/376 pass** (was 363)
- [x] `./lint.sh` — clean (clangd 22)

Branched from `main` after #57 (phase A1) merged. Refs `trackerless-network-completion-plan.md` phase A2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)