### PR TITLE
Phase A3: DhtNodeRpc client/server and PeerManager

### DIFF
--- a/packages/streamr-dht/CMakeLists.txt
+++ b/packages/streamr-dht/CMakeLists.txt
@@ -211,6 +211,8 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         test/unit/getClosestNodesTest.cpp
         test/unit/RingContactListTest.cpp
         test/unit/KBucketTest.cpp
+        test/unit/DhtNodeRpcLocalTest.cpp
+        test/unit/PeerManagerTest.cpp
     )
 
     target_include_directories(streamr-dht-test-unit
@@ -242,6 +244,7 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         test/integration/ConnectionLockingTest.cpp
         test/integration/SimultaneousConnectionsTest.cpp
         test/integration/ConnectionManagerIntegrationTest.cpp
+        test/integration/DhtNodeRpcRemoteTest.cpp
     )
 
     target_include_directories(streamr-dht-test-integration

--- a/packages/streamr-dht/lint.sh
+++ b/packages/streamr-dht/lint.sh
@@ -29,7 +29,15 @@ echo "Running clangd-tidy on $FILES"
 # simulator + ported TS integration tests) trip the same false positive
 # through their simulator-module imports. The compiler accepts and runs
 # all three on every platform; clang-format still checks them.
-TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/integration/ConnectionLockingTest.cpp' | grep -v 'test/unit/PendingConnectionTest.cpp' | grep -v 'test/unit/SimulatorTest.cpp' | grep -v 'test/integration/SimultaneousConnectionsTest.cpp' | grep -v 'test/integration/ConnectionManagerIntegrationTest.cpp' | tr '\n' ' ')
+# DhtNodeRpcLocalTest.cpp and DhtNodeRpcRemoteTest.cpp (phase A3, the
+# DhtNodeRpc client/server port) trip the same std-type unification false
+# positive through the DhtNodeRpc module cluster (DhtNodeRpcRemote /
+# DhtRpcClient imports): clangd reports gtest's own CodeLocation /
+# MakeAndRegisterTestInfo calls as ambiguous (spurious two-std::string
+# mismatch). The compiler accepts and runs both on every platform;
+# clang-format still checks them. (PeerManagerTest.cpp imports the same
+# cluster but does NOT trip it, so it stays in the clangd-tidy set.)
+TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/integration/ConnectionLockingTest.cpp' | grep -v 'test/unit/PendingConnectionTest.cpp' | grep -v 'test/unit/SimulatorTest.cpp' | grep -v 'test/integration/SimultaneousConnectionsTest.cpp' | grep -v 'test/integration/ConnectionManagerIntegrationTest.cpp' | grep -v 'test/unit/DhtNodeRpcLocalTest.cpp' | grep -v 'test/integration/DhtNodeRpcRemoteTest.cpp' | tr '\n' ' ')
 clangd-tidy -p "$COMPILE_DB" $TIDY_FILES
 
 echo "Running clang-format --dry-run on $FILES"

--- a/packages/streamr-dht/modules/dht/DhtNodeRpcLocal.cppm
+++ b/packages/streamr-dht/modules/dht/DhtNodeRpcLocal.cppm
@@ -1,0 +1,121 @@
+// Module streamr.dht.DhtNodeRpcLocal
+// Ported from packages/dht/src/dht/DhtNodeRpcLocal.ts (v103.8.0-rc.3).
+// The server-side handlers for the DhtNodeRpc service (peer discovery and
+// liveness): getClosestPeers, getClosestRingPeers, ping, leaveNotice.
+module;
+
+#include <cstddef>
+#include <functional>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.DhtNodeRpcLocal;
+
+import streamr.logger.SLogger;
+import streamr.dht.DhtRpcServer;
+import streamr.dht.DhtCallContext;
+import streamr.dht.DhtNodeRpcRemote;
+import streamr.dht.getClosestNodes;
+import streamr.dht.Identifiers;
+import streamr.dht.ringIdentifiers;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+
+export namespace streamr::dht {
+
+using ::dht::ClosestPeersRequest;
+using ::dht::ClosestPeersResponse;
+using ::dht::ClosestRingPeersRequest;
+using ::dht::ClosestRingPeersResponse;
+using ::dht::LeaveNotice;
+using ::dht::PeerDescriptor;
+using ::dht::PingRequest;
+using ::dht::PingResponse;
+using streamr::dht::contact::getClosestNodes;
+using streamr::dht::contact::GetClosestNodesOptions;
+using streamr::dht::contact::RingIdRaw;
+using streamr::dht::rpcprotocol::DhtCallContext;
+
+using DhtNodeRpc = ::dht::DhtNodeRpc<DhtCallContext>;
+
+struct DhtNodeRpcLocalOptions {
+    size_t peerDiscoveryQueryBatchSize;
+    std::function<std::vector<PeerDescriptor>()> getNeighbors;
+    std::function<ClosestRingPeerDescriptors(const RingIdRaw&, size_t)>
+        getClosestRingContactsTo;
+    std::function<void(const PeerDescriptor&)> addContact;
+    std::function<void(const DhtAddress&)> removeContact;
+};
+
+class DhtNodeRpcLocal : public DhtNodeRpc {
+private:
+    DhtNodeRpcLocalOptions options;
+
+public:
+    explicit DhtNodeRpcLocal(DhtNodeRpcLocalOptions options)
+        : options(std::move(options)) {}
+
+    ~DhtNodeRpcLocal() override = default;
+
+    ClosestPeersResponse getClosestPeers(
+        const ClosestPeersRequest& request,
+        const DhtCallContext& callContext) override {
+        this->options.addContact(callContext.incomingSourceDescriptor.value());
+        const auto peers = getClosestNodes(
+            Identifiers::getDhtAddressFromRaw(DhtAddressRaw{request.nodeid()}),
+            this->options.getNeighbors(),
+            GetClosestNodesOptions{
+                .maxCount = this->options.peerDiscoveryQueryBatchSize});
+        ClosestPeersResponse response;
+        for (const auto& peer : peers) {
+            *response.add_peers() = peer;
+        }
+        response.set_requestid(request.requestid());
+        return response;
+    }
+
+    ClosestRingPeersResponse getClosestRingPeers(
+        const ClosestRingPeersRequest& request,
+        const DhtCallContext& callContext) override {
+        this->options.addContact(callContext.incomingSourceDescriptor.value());
+        const auto closest = this->options.getClosestRingContactsTo(
+            RingIdRaw{request.ringid()},
+            this->options.peerDiscoveryQueryBatchSize);
+        ClosestRingPeersResponse response;
+        for (const auto& peer : closest.left) {
+            *response.add_leftpeers() = peer;
+        }
+        for (const auto& peer : closest.right) {
+            *response.add_rightpeers() = peer;
+        }
+        response.set_requestid(request.requestid());
+        return response;
+    }
+
+    PingResponse ping(
+        const PingRequest& request,
+        const DhtCallContext& callContext) override {
+        SLogger::trace(
+            "received ping request from " +
+            Identifiers::getNodeIdFromPeerDescriptor(
+                callContext.incomingSourceDescriptor.value()));
+        this->options.addContact(callContext.incomingSourceDescriptor.value());
+        PingResponse response;
+        response.set_requestid(request.requestid());
+        return response;
+    }
+
+    void leaveNotice(
+        const LeaveNotice& /*request*/,
+        const DhtCallContext& callContext) override {
+        const auto sender = callContext.incomingSourceDescriptor.value();
+        SLogger::trace(
+            "received leave notice from " +
+            Identifiers::getNodeIdFromPeerDescriptor(sender));
+        this->options.removeContact(
+            Identifiers::getNodeIdFromPeerDescriptor(sender));
+    }
+};
+
+} // namespace streamr::dht

--- a/packages/streamr-dht/modules/dht/DhtNodeRpcRemote.cppm
+++ b/packages/streamr-dht/modules/dht/DhtNodeRpcRemote.cppm
@@ -1,0 +1,171 @@
+// Module streamr.dht.DhtNodeRpcRemote
+// Ported from packages/dht/src/dht/DhtNodeRpcRemote.ts (v103.8.0-rc.3).
+// The client-side wrapper for a peer's DhtNodeRpc service. Also serves as
+// the k-bucket contact for that peer (getId()/getVectorClock()).
+module;
+
+// Coroutine definitions need std::coroutine_traits declared in THIS
+// translation unit; it cannot arrive through an imported BMI.
+#include <coroutine> // IWYU pragma: keep
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+#include <string>
+
+export module streamr.dht.DhtNodeRpcRemote;
+
+import streamr.utils.CoroutineHelper;
+import streamr.utils.Uuid;
+import streamr.logger.SLogger;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.DhtCallContext;
+import streamr.dht.Identifiers;
+import streamr.dht.ringIdentifiers;
+import streamr.dht.RpcRemote;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+using streamr::utils::Uuid;
+
+export namespace streamr::dht {
+
+using ::dht::ClosestPeersRequest;
+using ::dht::ClosestRingPeersRequest;
+using ::dht::LeaveNotice;
+using ::dht::PeerDescriptor;
+using ::dht::PingRequest;
+using streamr::dht::contact::RingIdRaw;
+using streamr::dht::contact::RpcRemote;
+using streamr::dht::rpcprotocol::DhtCallContext;
+
+using DhtNodeRpcClient = ::dht::DhtNodeRpcClient<DhtCallContext>;
+
+// The PeerDescriptor form of a ring query result (the wire response's
+// left/right peer lists), distinct from RingContactList's contact-typed
+// RingContacts.
+struct ClosestRingPeerDescriptors {
+    std::vector<PeerDescriptor> left;
+    std::vector<PeerDescriptor> right;
+};
+
+class DhtNodeRpcRemote : public RpcRemote<DhtNodeRpcClient> {
+private:
+    inline static int64_t counter =
+        0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+    DhtAddressRaw id;
+    int64_t vectorClock;
+    ServiceID serviceId;
+
+public:
+    DhtNodeRpcRemote(
+        PeerDescriptor localPeerDescriptor, // NOLINT
+        PeerDescriptor remotePeerDescriptor,
+        ServiceID serviceId,
+        DhtNodeRpcClient client,
+        std::optional<std::chrono::milliseconds> timeout = std::nullopt)
+        : RpcRemote<DhtNodeRpcClient>(
+              std::move(localPeerDescriptor),
+              std::move(remotePeerDescriptor),
+              std::move(client),
+              timeout),
+          id(DhtAddressRaw{this->getPeerDescriptor().nodeid()}),
+          vectorClock(counter++),
+          serviceId(std::move(serviceId)) {}
+
+    // Virtual (like ping() below) so tests can substitute a subclass; the
+    // RpcRemote base is not polymorphic, so this introduces the vtable.
+    virtual ~DhtNodeRpcRemote() = default;
+
+    DhtNodeRpcRemote(const DhtNodeRpcRemote&) = default;
+    DhtNodeRpcRemote& operator=(const DhtNodeRpcRemote&) = delete;
+    DhtNodeRpcRemote(DhtNodeRpcRemote&&) = delete;
+    DhtNodeRpcRemote& operator=(DhtNodeRpcRemote&&) = delete;
+
+    // KBucketContact interface (see streamr.dht.KBucket).
+    [[nodiscard]] DhtAddressRaw getId() const { return this->id; }
+    [[nodiscard]] int64_t getVectorClock() const { return this->vectorClock; }
+
+    [[nodiscard]] DhtAddress getNodeId() const {
+        return Identifiers::getNodeIdFromPeerDescriptor(
+            this->getPeerDescriptor());
+    }
+
+    folly::coro::Task<std::vector<PeerDescriptor>> getClosestPeers(
+        const DhtAddress& nodeId) {
+        ClosestPeersRequest request;
+        request.set_nodeid(Identifiers::getRawFromDhtAddress(nodeId));
+        request.set_requestid(Uuid::v4());
+        auto options = this->formDhtRpcOptions();
+        auto timeout = this->getTimeout();
+        const auto response = co_await this->getClient().getClosestPeers(
+            std::move(request), std::move(options), timeout);
+        std::vector<PeerDescriptor> peers;
+        peers.reserve(static_cast<size_t>(response.peers_size()));
+        for (const auto& peer : response.peers()) {
+            peers.push_back(peer);
+        }
+        co_return peers;
+    }
+
+    folly::coro::Task<ClosestRingPeerDescriptors> getClosestRingPeers(
+        const RingIdRaw& ringIdRaw) {
+        ClosestRingPeersRequest request;
+        request.set_ringid(ringIdRaw);
+        request.set_requestid(Uuid::v4());
+        auto options = this->formDhtRpcOptions();
+        auto timeout = this->getTimeout();
+        const auto response = co_await this->getClient().getClosestRingPeers(
+            std::move(request), std::move(options), timeout);
+        ClosestRingPeerDescriptors result;
+        result.left.reserve(static_cast<size_t>(response.leftpeers_size()));
+        for (const auto& peer : response.leftpeers()) {
+            result.left.push_back(peer);
+        }
+        result.right.reserve(static_cast<size_t>(response.rightpeers_size()));
+        for (const auto& peer : response.rightpeers()) {
+            result.right.push_back(peer);
+        }
+        co_return result;
+    }
+
+    // virtual so tests can substitute a deterministic ping result.
+    virtual folly::coro::Task<bool> ping() {
+        PingRequest request;
+        request.set_requestid(Uuid::v4());
+        const std::string requestId = request.requestid();
+        auto options = this->formDhtRpcOptions();
+        auto timeout = this->getTimeout();
+        try {
+            const auto pong = co_await this->getClient().ping(
+                std::move(request), std::move(options), timeout);
+            if (pong.requestid() == requestId) {
+                co_return true;
+            }
+        } catch (const std::exception& err) {
+            SLogger::trace(
+                "ping failed to " + this->getNodeId() + " " +
+                std::string(err.what()));
+        }
+        co_return false;
+    }
+
+    void leaveNotice() {
+        LeaveNotice request;
+        auto options = this->formDhtRpcOptions();
+        auto timeout = this->getTimeout();
+        try {
+            streamr::utils::blockingWait(this->getClient().leaveNotice(
+                std::move(request), std::move(options), timeout));
+        } catch (const std::exception& err) {
+            SLogger::trace(
+                "Failed to send leaveNotice " + std::string(err.what()));
+        }
+    }
+};
+
+} // namespace streamr::dht

--- a/packages/streamr-dht/modules/dht/PeerManager.cppm
+++ b/packages/streamr-dht/modules/dht/PeerManager.cppm
@@ -1,0 +1,484 @@
+// Module streamr.dht.PeerManager
+// Ported from packages/dht/src/dht/PeerManager.ts (v103.8.0-rc.3).
+//
+// Manages the node's view of the network: the k-bucket 'neighbors', the
+// distance-sorted 'nearbyContacts', the 'randomContacts', the ring
+// 'ringContacts', and the set of 'activeContacts'. When a contact is added
+// to the k-bucket it is pinged; a contact that fails the ping is dropped
+// and replaced by the closest active nearby contact.
+//
+// Threading note (a C++ design point, since TS is single-threaded): the
+// ping is fired off the calling thread via AbortableTimers and its result
+// handled later, so every operation (and the k-bucket/contact-list event
+// handlers) runs under one recursive mutex; PeerManager is owned through a
+// shared_ptr so the deferred ping handler can pin it.
+module;
+
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+#include <coroutine> // IWYU pragma: keep
+
+export module streamr.dht.PeerManager;
+
+import streamr.eventemitter.EventEmitter;
+import streamr.utils.AbortController;
+import streamr.utils.AbortableTimers;
+import streamr.utils.CoroutineHelper;
+import streamr.utils.EnableSharedFromThis;
+import streamr.logger.SLogger;
+import streamr.dht.ConnectionLocker;
+import streamr.dht.ConnectionLockStates;
+import streamr.dht.ContactList;
+import streamr.dht.DhtNodeRpcRemote;
+import streamr.dht.Identifiers;
+import streamr.dht.KBucket;
+import streamr.dht.RandomContactList;
+import streamr.dht.RingContactList;
+import streamr.dht.ringIdentifiers;
+import streamr.dht.SortedContactList;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::eventemitter::Event;
+using streamr::eventemitter::EventEmitter;
+using streamr::logger::SLogger;
+using streamr::utils::AbortableTimers;
+using streamr::utils::AbortController;
+using streamr::utils::EnableSharedFromThis;
+
+export namespace streamr::dht {
+
+using ::dht::PeerDescriptor;
+using streamr::dht::connection::ConnectionLocker;
+using streamr::dht::connection::LockID;
+using streamr::dht::contact::getRingIdRawFromPeerDescriptor;
+using streamr::dht::contact::KBucket;
+using streamr::dht::contact::KBucketOptions;
+using streamr::dht::contact::RandomContactList;
+using streamr::dht::contact::RingContactList;
+using streamr::dht::contact::RingContacts;
+using streamr::dht::contact::RingIdRaw;
+using streamr::dht::contact::SortedContactList;
+using streamr::dht::contact::SortedContactListOptions;
+
+namespace kbucketevents = streamr::dht::contact::kbucketevents;
+namespace contactlistevents = streamr::dht::contact::contactlistevents;
+
+namespace peermanagerevents {
+struct NearbyContactAdded : Event<PeerDescriptor> {};
+struct NearbyContactRemoved : Event<PeerDescriptor> {};
+struct RandomContactAdded : Event<PeerDescriptor> {};
+struct RandomContactRemoved : Event<PeerDescriptor> {};
+struct RingContactAdded : Event<PeerDescriptor> {};
+struct RingContactRemoved : Event<PeerDescriptor> {};
+struct KBucketEmpty : Event<> {};
+} // namespace peermanagerevents
+
+using PeerManagerEvents = std::tuple<
+    peermanagerevents::NearbyContactAdded,
+    peermanagerevents::NearbyContactRemoved,
+    peermanagerevents::RandomContactAdded,
+    peermanagerevents::RandomContactRemoved,
+    peermanagerevents::RingContactAdded,
+    peermanagerevents::RingContactRemoved,
+    peermanagerevents::KBucketEmpty>;
+
+struct PeerManagerOptions {
+    size_t numberOfNodesPerKBucket;
+    size_t maxContactCount;
+    DhtAddress localNodeId;
+    PeerDescriptor localPeerDescriptor;
+    std::shared_ptr<ConnectionLocker> connectionLocker; // may be null
+    std::optional<size_t> neighborPingLimit;
+    LockID lockId;
+    std::function<std::shared_ptr<DhtNodeRpcRemote>(const PeerDescriptor&)>
+        createDhtNodeRpcRemote;
+    std::function<bool(const DhtAddress&)> hasConnection;
+};
+
+class PeerManager : public EventEmitter<PeerManagerEvents>,
+                    public EnableSharedFromThis {
+private:
+    PeerManagerOptions options;
+    std::recursive_mutex mutex;
+    AbortController abortController;
+    bool stopped = false;
+    std::set<DhtAddress> activeContacts;
+
+    std::unique_ptr<KBucket<DhtNodeRpcRemote>> neighbors;
+    std::unique_ptr<SortedContactList<DhtNodeRpcRemote>> nearbyContacts;
+    std::unique_ptr<RingContactList<DhtNodeRpcRemote>> ringContacts;
+    std::unique_ptr<RandomContactList<DhtNodeRpcRemote>> randomContacts;
+
+    void weakUnlock(const DhtAddress& nodeId) {
+        if (this->options.connectionLocker) {
+            this->options.connectionLocker->weakUnlockConnection(
+                nodeId, this->options.lockId);
+        }
+    }
+
+    void onKBucketPing(
+        const std::vector<std::shared_ptr<DhtNodeRpcRemote>>& oldContacts,
+        const std::shared_ptr<DhtNodeRpcRemote>& newContact) {
+        if (this->stopped) {
+            return;
+        }
+        SortedContactList<DhtNodeRpcRemote> sortingList(
+            SortedContactListOptions{
+                .referenceId = this->options.localNodeId,
+                .allowToContainReferenceId = false});
+        sortingList.addContacts(oldContacts);
+        const auto furthest = sortingList.getFurthestContacts(1);
+        if (furthest.empty()) {
+            return;
+        }
+        const DhtAddress removableNodeId = furthest[0]->getNodeId();
+        this->weakUnlock(removableNodeId);
+        this->neighbors->remove(
+            Identifiers::getRawFromDhtAddress(removableNodeId));
+        this->neighbors->add(newContact);
+    }
+
+    void onKBucketRemoved(const DhtAddress& nodeId) {
+        if (this->stopped) {
+            return;
+        }
+        this->weakUnlock(nodeId);
+        SLogger::trace("Removed contact " + nodeId);
+        if (this->neighbors->count() == 0) {
+            this->emit<peermanagerevents::KBucketEmpty>();
+        }
+    }
+
+    void onKBucketAdded(const std::shared_ptr<DhtNodeRpcRemote>& contact) {
+        if (this->stopped) {
+            return;
+        }
+        if (contact->getNodeId() == this->options.localNodeId) {
+            return;
+        }
+        const auto peerDescriptor = contact->getPeerDescriptor();
+        const auto nodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor);
+        // Lock before the ping result is known, matching TS.
+        if (this->options.connectionLocker) {
+            this->options.connectionLocker->weakLockConnection(
+                nodeId, this->options.lockId);
+        }
+        if (this->options.hasConnection(contact->getNodeId()) ||
+            (this->options.neighborPingLimit.has_value() &&
+             this->neighbors->count() >
+                 this->options.neighborPingLimit.value())) {
+            SLogger::trace("Added new contact " + nodeId);
+            return;
+        }
+        this->schedulePing(contact, nodeId);
+    }
+
+    // Fires the ping off this thread; on failure drops the contact and pulls
+    // in the closest active nearby contact.
+    void schedulePing(
+        const std::shared_ptr<DhtNodeRpcRemote>& contact,
+        const DhtAddress& nodeId) {
+        auto self = this->sharedFromThis<PeerManager>();
+        AbortableTimers::setAbortableTimeout(
+            [self, contact, nodeId]() {
+                bool result = false;
+                try {
+                    result = streamr::utils::blockingWait(contact->ping());
+                } catch (const std::exception& err) {
+                    SLogger::trace("ping threw " + std::string(err.what()));
+                    result = false;
+                }
+                std::scoped_lock lock(self->mutex);
+                if (self->stopped) {
+                    return;
+                }
+                if (result) {
+                    SLogger::trace("Added new contact " + nodeId);
+                } else {
+                    SLogger::trace("ping failed " + nodeId);
+                    self->weakUnlock(nodeId);
+                    self->removeContact(nodeId);
+                    self->addNearbyContactToNeighbors();
+                }
+            },
+            std::chrono::milliseconds(0),
+            self->abortController.getSignal());
+    }
+
+    void addNearbyContactToNeighbors() {
+        if (this->stopped) {
+            return;
+        }
+        const auto closest = this->getNearbyActiveContactNotInNeighbors();
+        if (closest) {
+            this->addContact(closest->getPeerDescriptor());
+        }
+    }
+
+    std::shared_ptr<DhtNodeRpcRemote> getNearbyActiveContactNotInNeighbors() {
+        for (const auto& contactId : this->nearbyContacts->getContactIds()) {
+            if (!this->neighbors->get(
+                    Identifiers::getRawFromDhtAddress(contactId)) &&
+                this->activeContacts.contains(contactId)) {
+                return this->nearbyContacts->getContact(contactId);
+            }
+        }
+        return nullptr;
+    }
+
+    void registerEventHandlers() {
+        this->ringContacts
+            ->on<contactlistevents::ContactAdded<DhtNodeRpcRemote>>(
+                [this](const std::shared_ptr<DhtNodeRpcRemote>& contact) {
+                    this->emit<peermanagerevents::RingContactAdded>(
+                        contact->getPeerDescriptor());
+                });
+        this->ringContacts
+            ->on<contactlistevents::ContactRemoved<DhtNodeRpcRemote>>(
+                [this](const std::shared_ptr<DhtNodeRpcRemote>& contact) {
+                    this->emit<peermanagerevents::RingContactRemoved>(
+                        contact->getPeerDescriptor());
+                });
+
+        this->neighbors->on<kbucketevents::Ping<DhtNodeRpcRemote>>(
+            [this](
+                const std::vector<std::shared_ptr<DhtNodeRpcRemote>>&
+                    oldContacts,
+                const std::shared_ptr<DhtNodeRpcRemote>& newContact) {
+                this->onKBucketPing(oldContacts, newContact);
+            });
+        this->neighbors->on<kbucketevents::Removed<DhtNodeRpcRemote>>(
+            [this](const std::shared_ptr<DhtNodeRpcRemote>& contact) {
+                this->onKBucketRemoved(
+                    Identifiers::getNodeIdFromPeerDescriptor(
+                        contact->getPeerDescriptor()));
+            });
+        this->neighbors->on<kbucketevents::Added<DhtNodeRpcRemote>>(
+            [this](const std::shared_ptr<DhtNodeRpcRemote>& contact) {
+                this->onKBucketAdded(contact);
+            });
+
+        this->nearbyContacts
+            ->on<contactlistevents::ContactRemoved<DhtNodeRpcRemote>>(
+                [this](const std::shared_ptr<DhtNodeRpcRemote>& contact) {
+                    if (this->stopped) {
+                        return;
+                    }
+                    this->emit<peermanagerevents::NearbyContactRemoved>(
+                        contact->getPeerDescriptor());
+                    this->randomContacts->addContact(
+                        this->options.createDhtNodeRpcRemote(
+                            contact->getPeerDescriptor()));
+                });
+        this->nearbyContacts
+            ->on<contactlistevents::ContactAdded<DhtNodeRpcRemote>>(
+                [this](const std::shared_ptr<DhtNodeRpcRemote>& contact) {
+                    this->emit<peermanagerevents::NearbyContactAdded>(
+                        contact->getPeerDescriptor());
+                });
+
+        this->randomContacts
+            ->on<contactlistevents::ContactRemoved<DhtNodeRpcRemote>>(
+                [this](const std::shared_ptr<DhtNodeRpcRemote>& contact) {
+                    this->emit<peermanagerevents::RandomContactRemoved>(
+                        contact->getPeerDescriptor());
+                });
+        this->randomContacts
+            ->on<contactlistevents::ContactAdded<DhtNodeRpcRemote>>(
+                [this](const std::shared_ptr<DhtNodeRpcRemote>& contact) {
+                    this->emit<peermanagerevents::RandomContactAdded>(
+                        contact->getPeerDescriptor());
+                });
+    }
+
+    explicit PeerManager(PeerManagerOptions options)
+        : options(std::move(options)) {
+        this->neighbors =
+            std::make_unique<KBucket<DhtNodeRpcRemote>>(KBucketOptions{
+                .localNodeId = Identifiers::getRawFromDhtAddress(
+                    this->options.localNodeId),
+                .numberOfNodesPerKBucket =
+                    this->options.numberOfNodesPerKBucket,
+                .numberOfNodesToPing = this->options.numberOfNodesPerKBucket});
+        this->ringContacts =
+            std::make_unique<RingContactList<DhtNodeRpcRemote>>(
+                getRingIdRawFromPeerDescriptor(
+                    this->options.localPeerDescriptor));
+        this->nearbyContacts =
+            std::make_unique<SortedContactList<DhtNodeRpcRemote>>(
+                SortedContactListOptions{
+                    .referenceId = this->options.localNodeId,
+                    .allowToContainReferenceId = false,
+                    .maxSize = this->options.maxContactCount});
+        this->randomContacts =
+            std::make_unique<RandomContactList<DhtNodeRpcRemote>>(
+                this->options.localNodeId, this->options.maxContactCount);
+    }
+
+public:
+    [[nodiscard]] static std::shared_ptr<PeerManager> newInstance(
+        PeerManagerOptions options) {
+        struct MakeSharedEnabler : public PeerManager {
+            explicit MakeSharedEnabler(PeerManagerOptions options)
+                : PeerManager(std::move(options)) {}
+        };
+        auto instance = std::make_shared<MakeSharedEnabler>(std::move(options));
+        instance->registerEventHandlers();
+        return instance;
+    }
+
+    ~PeerManager() override = default;
+
+    void removeContact(const DhtAddress& nodeId) {
+        std::scoped_lock lock(this->mutex);
+        if (this->stopped) {
+            return;
+        }
+        SLogger::trace("Removing contact " + nodeId);
+        this->ringContacts->removeContact(
+            this->nearbyContacts->getContact(nodeId));
+        this->neighbors->remove(Identifiers::getRawFromDhtAddress(nodeId));
+        this->nearbyContacts->removeContact(nodeId);
+        this->activeContacts.erase(nodeId);
+        this->randomContacts->removeContact(nodeId);
+    }
+
+    void removeNeighbor(const DhtAddress& nodeId) {
+        std::scoped_lock lock(this->mutex);
+        this->neighbors->remove(Identifiers::getRawFromDhtAddress(nodeId));
+    }
+
+    // Pings the given nodes and removes the ones that do not answer, marking
+    // the responders active. TS's pingNodes helper pings in parallel
+    // (Promise.allSettled); here the pings are awaited one at a time, which
+    // yields the same offline set and the same activeContacts updates. The
+    // mutex is never held across a co_await.
+    folly::coro::Task<void> pruneOfflineNodes(
+        std::vector<std::shared_ptr<DhtNodeRpcRemote>> nodes) {
+        SLogger::trace("Pruning offline nodes");
+        std::vector<PeerDescriptor> offlineNeighbors;
+        for (const auto& contact : nodes) {
+            bool isOnline = false;
+            try {
+                isOnline = co_await contact->ping();
+            } catch (const std::exception&) {
+                isOnline = false;
+            }
+            std::scoped_lock lock(this->mutex);
+            if (isOnline) {
+                this->activeContacts.insert(contact->getNodeId());
+            } else {
+                this->activeContacts.erase(contact->getNodeId());
+                offlineNeighbors.push_back(contact->getPeerDescriptor());
+            }
+        }
+        std::scoped_lock lock(this->mutex);
+        for (const auto& offlineNeighbor : offlineNeighbors) {
+            this->removeContact(
+                Identifiers::getNodeIdFromPeerDescriptor(offlineNeighbor));
+        }
+        co_return;
+    }
+
+    void stop() {
+        std::scoped_lock lock(this->mutex);
+        this->stopped = true;
+        this->abortController.abort();
+        for (const auto& rpcRemote : this->neighbors->toArray()) {
+            rpcRemote->leaveNotice();
+            this->neighbors->remove(rpcRemote->getId());
+        }
+        this->neighbors->removeAllListeners();
+        for (const auto& rpcRemote : this->ringContacts->getAllContacts()) {
+            rpcRemote->leaveNotice();
+            this->ringContacts->removeContact(rpcRemote);
+        }
+        this->nearbyContacts->stop();
+        this->randomContacts->stop();
+    }
+
+    [[nodiscard]] RingContacts<DhtNodeRpcRemote> getClosestRingContactsTo(
+        const RingIdRaw& ringIdRaw,
+        std::optional<size_t> limit = std::nullopt,
+        std::optional<std::set<DhtAddress>> excludedIds = std::nullopt) {
+        std::scoped_lock lock(this->mutex);
+        RingContactList<DhtNodeRpcRemote> closest(ringIdRaw, excludedIds);
+        for (const auto& contact : this->ringContacts->getAllContacts()) {
+            closest.addContact(contact);
+        }
+        constexpr size_t defaultLimit = 8;
+        return closest.getClosestContacts(limit.value_or(defaultLimit));
+    }
+
+    [[nodiscard]] size_t getNearbyContactCount(
+        const std::optional<std::set<DhtAddress>>& excludedNodeIds =
+            std::nullopt) {
+        std::scoped_lock lock(this->mutex);
+        return this->nearbyContacts->getSize(excludedNodeIds);
+    }
+
+    [[nodiscard]] size_t getNeighborCount() {
+        std::scoped_lock lock(this->mutex);
+        return this->neighbors->count();
+    }
+
+    [[nodiscard]] std::vector<std::shared_ptr<DhtNodeRpcRemote>>
+    getNeighbors() {
+        std::scoped_lock lock(this->mutex);
+        return this->neighbors->toArray();
+    }
+
+    void setContactActive(const DhtAddress& nodeId) {
+        std::scoped_lock lock(this->mutex);
+        this->activeContacts.insert(nodeId);
+    }
+
+    void addContact(const PeerDescriptor& peerDescriptor) {
+        std::scoped_lock lock(this->mutex);
+        if (this->stopped) {
+            return;
+        }
+        const auto nodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor);
+        if (nodeId == this->options.localNodeId) {
+            return;
+        }
+        SLogger::trace("Adding new contact " + nodeId);
+        const auto remote =
+            this->options.createDhtNodeRpcRemote(peerDescriptor);
+        const bool isInNeighbors =
+            this->neighbors->get(DhtAddressRaw{peerDescriptor.nodeid()}) !=
+            nullptr;
+        const bool isInNearbyContacts =
+            this->nearbyContacts->getContact(nodeId) != nullptr;
+        const bool isInRingContacts =
+            this->ringContacts->getContact(peerDescriptor) != nullptr;
+
+        if (isInNeighbors || isInNearbyContacts) {
+            this->randomContacts->addContact(remote);
+        }
+        if (!isInNeighbors) {
+            this->neighbors->add(remote);
+        }
+        if (!isInNearbyContacts) {
+            this->nearbyContacts->addContact(remote);
+        }
+        if (!isInRingContacts) {
+            this->ringContacts->addContact(remote);
+        }
+    }
+};
+
+} // namespace streamr::dht

--- a/packages/streamr-dht/test/integration/DhtNodeRpcRemoteTest.cpp
+++ b/packages/streamr-dht/test/integration/DhtNodeRpcRemoteTest.cpp
@@ -1,0 +1,143 @@
+// Ported from packages/dht/test/integration/DhtNodeRpcRemote.test.ts
+// (v103.8.0-rc.3): two RpcCommunicators wired together, the server side
+// answering ping / getClosestPeers, exercising DhtNodeRpcRemote's happy
+// and error paths.
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+
+#include <coroutine> // IWYU pragma: keep
+
+import streamr.utils.CoroutineHelper;
+import streamr.protorpc.RpcCommunicator;
+import streamr.protorpc.protos;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.DhtCallContext;
+import streamr.dht.DhtNodeRpcRemote;
+import streamr.dht.Identifiers;
+import streamr.dht.protos;
+import streamr.dht.TestUtils;
+
+using ::dht::ClosestPeersRequest;
+using ::dht::ClosestPeersResponse;
+using ::dht::PeerDescriptor;
+using ::dht::PingRequest;
+using ::dht::PingResponse;
+using ::protorpc::RpcMessage;
+using streamr::dht::DhtNodeRpcRemote;
+using streamr::dht::Identifiers;
+using streamr::dht::ServiceID;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::protorpc::RpcCommunicator;
+using streamr::utils::blockingWait;
+
+using DhtNodeRpcClient = ::dht::DhtNodeRpcClient<DhtCallContext>;
+using RpcCommunicatorType = RpcCommunicator<DhtCallContext>;
+
+namespace {
+
+constexpr auto serviceId = "test";
+constexpr size_t mockPeerCount = 4;
+
+std::vector<PeerDescriptor> createMockPeers() {
+    std::vector<PeerDescriptor> peers;
+    peers.reserve(mockPeerCount);
+    for (size_t i = 0; i < mockPeerCount; ++i) {
+        peers.push_back(createMockPeerDescriptor());
+    }
+    return peers;
+}
+
+} // namespace
+
+class DhtNodeRpcRemoteTest : public ::testing::Test {
+protected:
+    RpcCommunicatorType clientCommunicator;
+    RpcCommunicatorType serverCommunicator;
+    PeerDescriptor clientPeerDescriptor = createMockPeerDescriptor();
+    PeerDescriptor serverPeerDescriptor = createMockPeerDescriptor();
+    std::vector<PeerDescriptor> mockPeers = createMockPeers();
+    bool pingShouldThrow = false;
+    bool getClosestPeersShouldThrow = false;
+    std::optional<DhtNodeRpcRemote> rpcRemote;
+
+    void SetUp() override {
+        serverCommunicator
+            .registerRpcMethod<ClosestPeersRequest, ClosestPeersResponse>(
+                "getClosestPeers",
+                [this](
+                    const ClosestPeersRequest& request,
+                    const DhtCallContext& /*context*/) -> ClosestPeersResponse {
+                    if (this->getClosestPeersShouldThrow) {
+                        throw std::runtime_error("Closest peers error");
+                    }
+                    ClosestPeersResponse response;
+                    for (const auto& peer : this->mockPeers) {
+                        *response.add_peers() = peer;
+                    }
+                    response.set_requestid(request.requestid());
+                    return response;
+                });
+        serverCommunicator.registerRpcMethod<PingRequest, PingResponse>(
+            "ping",
+            [this](
+                const PingRequest& request,
+                const DhtCallContext& /*context*/) -> PingResponse {
+                if (this->pingShouldThrow) {
+                    throw std::runtime_error("Ping error");
+                }
+                PingResponse response;
+                response.set_requestid(request.requestid());
+                return response;
+            });
+        this->clientCommunicator.setOutgoingMessageCallback(
+            [this](
+                const RpcMessage& message,
+                const std::string& /*requestId*/,
+                const DhtCallContext& /*context*/) {
+                this->serverCommunicator.handleIncomingMessage(
+                    message, DhtCallContext());
+            });
+        this->serverCommunicator.setOutgoingMessageCallback(
+            [this](
+                const RpcMessage& message,
+                const std::string& /*requestId*/,
+                const DhtCallContext& /*context*/) {
+                this->clientCommunicator.handleIncomingMessage(
+                    message, DhtCallContext());
+            });
+        this->rpcRemote.emplace(
+            clientPeerDescriptor,
+            serverPeerDescriptor,
+            ServiceID{serviceId},
+            DhtNodeRpcClient(this->clientCommunicator));
+    }
+};
+
+TEST_F(DhtNodeRpcRemoteTest, PingHappyPath) {
+    const bool active = blockingWait(this->rpcRemote->ping());
+    EXPECT_TRUE(active);
+}
+
+TEST_F(DhtNodeRpcRemoteTest, GetClosestPeersHappyPath) {
+    const auto neighbors = blockingWait(this->rpcRemote->getClosestPeers(
+        Identifiers::getNodeIdFromPeerDescriptor(clientPeerDescriptor)));
+    EXPECT_EQ(neighbors.size(), mockPeers.size());
+}
+
+TEST_F(DhtNodeRpcRemoteTest, PingErrorPath) {
+    this->pingShouldThrow = true;
+    const bool active = blockingWait(this->rpcRemote->ping());
+    EXPECT_FALSE(active);
+}
+
+TEST_F(DhtNodeRpcRemoteTest, GetClosestPeersErrorPath) {
+    this->getClosestPeersShouldThrow = true;
+    EXPECT_THROW(
+        blockingWait(this->rpcRemote->getClosestPeers(
+            Identifiers::getNodeIdFromPeerDescriptor(clientPeerDescriptor))),
+        std::exception);
+}

--- a/packages/streamr-dht/test/unit/DhtNodeRpcLocalTest.cpp
+++ b/packages/streamr-dht/test/unit/DhtNodeRpcLocalTest.cpp
@@ -1,0 +1,119 @@
+// Unit coverage for DhtNodeRpcLocal (module streamr.dht.DhtNodeRpcLocal):
+// the server-side handlers, driven directly with a DhtCallContext carrying
+// the incoming source descriptor.
+#include <cstddef>
+#include <optional>
+#include <vector>
+#include <gtest/gtest.h>
+
+import streamr.dht.DhtNodeRpcLocal;
+import streamr.dht.DhtNodeRpcRemote;
+import streamr.dht.DhtCallContext;
+import streamr.dht.Identifiers;
+import streamr.dht.protos;
+import streamr.dht.ringIdentifiers;
+import streamr.dht.TestUtils;
+
+using ::dht::ClosestPeersRequest;
+using ::dht::ClosestRingPeersRequest;
+using ::dht::LeaveNotice;
+using ::dht::PeerDescriptor;
+using ::dht::PingRequest;
+using streamr::dht::ClosestRingPeerDescriptors;
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtNodeRpcLocal;
+using streamr::dht::DhtNodeRpcLocalOptions;
+using streamr::dht::Identifiers;
+using streamr::dht::contact::getRingIdRawFromPeerDescriptor;
+using streamr::dht::contact::RingIdRaw;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::testutils::createMockPeerDescriptor;
+
+namespace {
+
+constexpr size_t batchSize = 4;
+
+DhtCallContext contextFrom(const PeerDescriptor& source) {
+    DhtCallContext context;
+    context.incomingSourceDescriptor = source;
+    return context;
+}
+
+} // namespace
+
+class DhtNodeRpcLocalTest : public ::testing::Test {
+protected:
+    std::vector<PeerDescriptor> neighbors = {
+        createMockPeerDescriptor(),
+        createMockPeerDescriptor(),
+        createMockPeerDescriptor()};
+    std::vector<PeerDescriptor> addedContacts;
+    std::vector<DhtAddress> removedContacts;
+    ClosestRingPeerDescriptors ringContacts;
+
+    DhtNodeRpcLocal local{DhtNodeRpcLocalOptions{
+        .peerDiscoveryQueryBatchSize = batchSize,
+        .getNeighbors = [this]() { return this->neighbors; },
+        .getClosestRingContactsTo =
+            [this](const RingIdRaw& /*id*/, size_t /*limit*/) {
+                return this->ringContacts;
+            },
+        .addContact =
+            [this](const PeerDescriptor& contact) {
+                this->addedContacts.push_back(contact);
+            },
+        .removeContact =
+            [this](const DhtAddress& nodeId) {
+                this->removedContacts.push_back(nodeId);
+            }}};
+};
+
+TEST_F(DhtNodeRpcLocalTest, GetClosestPeersReturnsNeighborsAndAddsSource) {
+    const auto source = createMockPeerDescriptor();
+    ClosestPeersRequest request;
+    request.set_nodeid(source.nodeid());
+    request.set_requestid("req-1");
+    const auto response = local.getClosestPeers(request, contextFrom(source));
+    EXPECT_EQ(response.peers_size(), static_cast<int>(neighbors.size()));
+    EXPECT_EQ(response.requestid(), "req-1");
+    ASSERT_EQ(addedContacts.size(), 1U);
+    EXPECT_EQ(
+        Identifiers::getNodeIdFromPeerDescriptor(addedContacts[0]),
+        Identifiers::getNodeIdFromPeerDescriptor(source));
+}
+
+TEST_F(DhtNodeRpcLocalTest, GetClosestRingPeersReturnsBothSides) {
+    ringContacts.left = {createMockPeerDescriptor()};
+    ringContacts.right = {
+        createMockPeerDescriptor(), createMockPeerDescriptor()};
+    const auto source = createMockPeerDescriptor();
+    ClosestRingPeersRequest request;
+    request.set_ringid(getRingIdRawFromPeerDescriptor(source));
+    request.set_requestid("req-2");
+    const auto response =
+        local.getClosestRingPeers(request, contextFrom(source));
+    EXPECT_EQ(response.leftpeers_size(), 1);
+    EXPECT_EQ(response.rightpeers_size(), 2);
+    EXPECT_EQ(response.requestid(), "req-2");
+    EXPECT_EQ(addedContacts.size(), 1U);
+}
+
+TEST_F(DhtNodeRpcLocalTest, PingEchoesRequestIdAndAddsSource) {
+    const auto source = createMockPeerDescriptor();
+    PingRequest request;
+    request.set_requestid("ping-1");
+    const auto response = local.ping(request, contextFrom(source));
+    EXPECT_EQ(response.requestid(), "ping-1");
+    ASSERT_EQ(addedContacts.size(), 1U);
+    EXPECT_EQ(
+        Identifiers::getNodeIdFromPeerDescriptor(addedContacts[0]),
+        Identifiers::getNodeIdFromPeerDescriptor(source));
+}
+
+TEST_F(DhtNodeRpcLocalTest, LeaveNoticeRemovesSender) {
+    const auto source = createMockPeerDescriptor();
+    local.leaveNotice(LeaveNotice{}, contextFrom(source));
+    ASSERT_EQ(removedContacts.size(), 1U);
+    EXPECT_EQ(
+        removedContacts[0], Identifiers::getNodeIdFromPeerDescriptor(source));
+}

--- a/packages/streamr-dht/test/unit/PeerManagerTest.cpp
+++ b/packages/streamr-dht/test/unit/PeerManagerTest.cpp
@@ -1,0 +1,241 @@
+// Ported from packages/dht/test/unit/PeerManager.test.ts (v103.8.0-rc.3).
+//
+// The contacts are backed by a mock DhtNodeRpcRemote whose ping() result is
+// driven by a shared 'pingFailures' set (a node whose id is in the set is
+// treated as offline). The real RPC path is never exercised: a plain
+// RpcCommunicator with a no-op outgoing callback stands in for the network,
+// mirroring the TS MockRpcCommunicator (a RoutingRpcCommunicator with an
+// empty send function). PeerManager pings newly added contacts off the
+// calling thread (via AbortableTimers), so the async assertions wait on the
+// resulting state with waitForCondition.
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+#include <gtest/gtest.h>
+
+#include <coroutine> // IWYU pragma: keep
+
+import streamr.utils.CoroutineHelper;
+import streamr.utils.waitForCondition;
+import streamr.protorpc.RpcCommunicator;
+import streamr.protorpc.protos;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.DhtCallContext;
+import streamr.dht.PeerManager;
+import streamr.dht.DhtNodeRpcRemote;
+import streamr.dht.Identifiers;
+import streamr.dht.getClosestNodes;
+import streamr.dht.ConnectionLockStates;
+import streamr.dht.protos;
+import streamr.dht.TestUtils;
+
+using ::dht::PeerDescriptor;
+using ::protorpc::RpcMessage;
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtNodeRpcRemote;
+using streamr::dht::Identifiers;
+using streamr::dht::PeerManager;
+using streamr::dht::PeerManagerOptions;
+using streamr::dht::ServiceID;
+using streamr::dht::connection::LockID;
+using streamr::dht::contact::getClosestNodes;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::testutils::assertEqualPeerDescriptors;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::protorpc::RpcCommunicator;
+using streamr::utils::blockingWait;
+using streamr::utils::waitForCondition;
+
+using DhtNodeRpcClient = ::dht::DhtNodeRpcClient<DhtCallContext>;
+
+namespace {
+
+constexpr size_t numberOfNodesPerKBucket = 8;
+constexpr size_t maxContactCount = 200;
+constexpr size_t nearbyContactCount = 10;
+constexpr size_t successContactCount = 5;
+
+// The anonymous DhtNodeRpcRemote subclass from the TS test, which overrides
+// ping() to consult a shared pingFailures set instead of hitting the network.
+class MockDhtNodeRpcRemote : public DhtNodeRpcRemote {
+private:
+    std::shared_ptr<std::set<DhtAddress>> pingFailures;
+    DhtAddress nodeId;
+
+public:
+    MockDhtNodeRpcRemote(
+        PeerDescriptor localPeerDescriptor, // NOLINT
+        PeerDescriptor remotePeerDescriptor,
+        DhtNodeRpcClient client,
+        std::shared_ptr<std::set<DhtAddress>> pingFailures)
+        : DhtNodeRpcRemote(
+              std::move(localPeerDescriptor),
+              std::move(remotePeerDescriptor),
+              ServiceID{"mock"},
+              client),
+          pingFailures(std::move(pingFailures)),
+          nodeId(this->getNodeId()) {}
+
+    folly::coro::Task<bool> ping() override {
+        co_return !this->pingFailures->contains(this->nodeId);
+    }
+};
+
+} // namespace
+
+class PeerManagerTest : public ::testing::Test {
+protected:
+    RpcCommunicator<DhtCallContext> mockCommunicator;
+    std::shared_ptr<std::set<DhtAddress>> pingFailures =
+        std::make_shared<std::set<DhtAddress>>();
+    PeerDescriptor localPeerDescriptor = createMockPeerDescriptor();
+    std::shared_ptr<PeerManager> manager;
+
+    void SetUp() override {
+        this->mockCommunicator.setOutgoingMessageCallback(
+            [](const RpcMessage& /*message*/,
+               const std::string& /*requestId*/,
+               const DhtCallContext& /*context*/) {});
+    }
+
+    void TearDown() override {
+        if (this->manager) {
+            this->manager->stop();
+        }
+    }
+
+    PeerManagerOptions makeOptions() {
+        return PeerManagerOptions{
+            .numberOfNodesPerKBucket = numberOfNodesPerKBucket,
+            .maxContactCount = maxContactCount,
+            .localNodeId = Identifiers::getNodeIdFromPeerDescriptor(
+                this->localPeerDescriptor),
+            .localPeerDescriptor = this->localPeerDescriptor,
+            .connectionLocker = nullptr,
+            .neighborPingLimit = std::nullopt,
+            .lockId = LockID{"peer-manager"},
+            .createDhtNodeRpcRemote =
+                [this](const PeerDescriptor& peerDescriptor)
+                -> std::shared_ptr<DhtNodeRpcRemote> {
+                return std::make_shared<MockDhtNodeRpcRemote>(
+                    this->localPeerDescriptor,
+                    peerDescriptor,
+                    DhtNodeRpcClient(this->mockCommunicator),
+                    this->pingFailures);
+            },
+            .hasConnection =
+                [](const DhtAddress& /*nodeId*/) { return false; }};
+    }
+
+    std::shared_ptr<PeerManager> createPeerManager(
+        const std::vector<PeerDescriptor>& contacts) {
+        auto instance = PeerManager::newInstance(this->makeOptions());
+        for (const auto& contact : contacts) {
+            instance->addContact(contact);
+        }
+        return instance;
+    }
+
+    [[nodiscard]] bool neighborsContain(const DhtAddress& nodeId) {
+        const auto neighbors = this->manager->getNeighbors();
+        return std::ranges::any_of(
+            neighbors, [&nodeId](const std::shared_ptr<DhtNodeRpcRemote>& n) {
+                return n->getNodeId() == nodeId;
+            });
+    }
+};
+
+TEST_F(PeerManagerTest, GetNearbyContactCount) {
+    std::vector<PeerDescriptor> contacts;
+    std::vector<DhtAddress> nodeIds;
+    for (size_t i = 0; i < nearbyContactCount; ++i) {
+        const auto contact = createMockPeerDescriptor();
+        nodeIds.push_back(Identifiers::getNodeIdFromPeerDescriptor(contact));
+        contacts.push_back(contact);
+    }
+    this->manager = this->createPeerManager(contacts);
+
+    EXPECT_EQ(this->manager->getNearbyContactCount(), nearbyContactCount);
+    EXPECT_EQ(
+        this->manager->getNearbyContactCount(
+            std::set<DhtAddress>{nodeIds[0], nodeIds[1]}),
+        nearbyContactCount - 2);
+    EXPECT_EQ(
+        this->manager->getNearbyContactCount(
+            std::set<DhtAddress>{
+                nodeIds[0], Identifiers::createRandomDhtAddress()}),
+        nearbyContactCount - 1);
+}
+
+TEST_F(PeerManagerTest, AddContactPingFails) {
+    std::vector<PeerDescriptor> successContacts;
+    successContacts.reserve(successContactCount);
+    for (size_t i = 0; i < successContactCount; ++i) {
+        successContacts.push_back(createMockPeerDescriptor());
+    }
+    const auto failureContact = createMockPeerDescriptor();
+    this->pingFailures->insert(
+        Identifiers::getNodeIdFromPeerDescriptor(failureContact));
+
+    this->manager = this->createPeerManager({});
+    for (const auto& successContact : successContacts) {
+        const auto nodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(successContact);
+        this->manager->addContact(successContact);
+        this->manager->setContactActive(nodeId);
+        this->manager->removeNeighbor(nodeId);
+    }
+    EXPECT_EQ(this->manager->getNeighborCount(), 0U);
+
+    this->manager->addContact(failureContact);
+    const auto closestSuccessContact = getClosestNodes(
+        Identifiers::getNodeIdFromPeerDescriptor(this->localPeerDescriptor),
+        successContacts)[0];
+    const auto closestNodeId =
+        Identifiers::getNodeIdFromPeerDescriptor(closestSuccessContact);
+    blockingWait(waitForCondition([this, &closestNodeId]() {
+        return this->neighborsContain(closestNodeId);
+    }));
+
+    EXPECT_EQ(this->manager->getNeighborCount(), 1U);
+    EXPECT_PRED_FORMAT2(
+        assertEqualPeerDescriptors,
+        closestSuccessContact,
+        this->manager->getNeighbors()[0]->getPeerDescriptor());
+}
+
+TEST_F(PeerManagerTest, PruneOfflineNodesRemovesOfflineNodes) {
+    std::vector<PeerDescriptor> successContacts;
+    successContacts.reserve(successContactCount);
+    for (size_t i = 0; i < successContactCount; ++i) {
+        successContacts.push_back(createMockPeerDescriptor());
+    }
+    const auto failureContact = createMockPeerDescriptor();
+
+    this->manager = this->createPeerManager({});
+    for (const auto& successContact : successContacts) {
+        this->manager->addContact(successContact);
+    }
+    this->manager->addContact(failureContact);
+    EXPECT_EQ(this->manager->getNeighborCount(), successContactCount + 1);
+
+    this->pingFailures->insert(
+        Identifiers::getNodeIdFromPeerDescriptor(failureContact));
+    std::vector<std::shared_ptr<DhtNodeRpcRemote>> nodes;
+    for (const auto& neighbor : this->manager->getNeighbors()) {
+        nodes.push_back(
+            std::make_shared<MockDhtNodeRpcRemote>(
+                this->localPeerDescriptor,
+                neighbor->getPeerDescriptor(),
+                DhtNodeRpcClient(this->mockCommunicator),
+                this->pingFailures));
+    }
+    blockingWait(this->manager->pruneOfflineNodes(nodes));
+
+    EXPECT_EQ(this->manager->getNeighborCount(), successContactCount);
+}


### PR DESCRIPTION
Phase A3 of the trackerless-network completion plan: the DhtNodeRpc client/server pair and the neighbor manager, ported line-by-line from the pinned TS (`v103.8.0-rc.3`).

## What this adds

- **`DhtNodeRpcRemote`** (`modules/dht/DhtNodeRpcRemote.cppm`) — the client-side wrapper for a peer's DhtNodeRpc service. It doubles as the k-bucket contact for that peer (`getId()` / `getVectorClock()`), so `PeerManager`'s k-bucket can hold it directly. Methods: `getClosestPeers`, `getClosestRingPeers`, `ping`, `leaveNotice`.
- **`DhtNodeRpcLocal`** (`modules/dht/DhtNodeRpcLocal.cppm`) — the server-side handlers (`getClosestPeers`, `getClosestRingPeers`, `ping`, `leaveNotice`), driven by injected callbacks rather than owning the node state.
- **`PeerManager`** (`modules/dht/PeerManager.cppm`) — owns the node's view of the network: the k-bucket `neighbors`, the distance-sorted `nearbyContacts`, the `randomContacts` and the ring `ringContacts`. Newly added contacts are pinged; an unresponsive one is dropped and replaced by the closest active nearby contact.

### One C++ design point

TS handles the ping result on a later microtask (`contact.ping().then(...)`). The C++ port fires the ping off the calling thread via `AbortableTimers::setAbortableTimeout(..., 0ms, ...)` and handles the result later, so every operation and every k-bucket / contact-list event handler runs under one `recursive_mutex`. `PeerManager` is created through a `newInstance` factory and owned via `shared_ptr` (it is an `EnableSharedFromThis`), so the deferred ping handler pins it for the duration of the callback. `stop()` aborts the controller, cancelling any pending pings.

## Tests (each ported from the matching TS test)

- **`DhtNodeRpcRemoteTest`** (integration) — happy and error paths for `ping` and `getClosestPeers` over two directly wired `RpcCommunicator`s.
- **`DhtNodeRpcLocalTest`** (unit) — the four server handlers, driven with a `DhtCallContext` carrying the incoming source descriptor.
- **`PeerManagerTest`** (unit) — `getNearbyContactCount` (with excluded-id sets), the `addContact` ping-fails replacement flow, and `pruneOfflineNodes`. The contacts are backed by a mock `DhtNodeRpcRemote` whose `ping()` result is driven by a shared `pingFailures` set; the real RPC path is stubbed with a no-op `RpcCommunicator` (mirroring the TS `MockRpcCommunicator`).

## Verification

- `./test.sh` — 387/387 tests pass (includes the 3 new `PeerManagerTest` cases, the 4 `DhtNodeRpcLocalTest` cases, and the 4 `DhtNodeRpcRemoteTest` cases).
- `PeerManagerTest` run at `--gtest_repeat=50` with zero failures, to stress the off-thread ping paths.
- `./lint.sh` — green across all packages.

### Lint note

`DhtNodeRpcLocalTest.cpp` and `DhtNodeRpcRemoteTest.cpp` are excluded from `clangd-tidy` (still checked by `clang-format`): they trip the known clangd module std-type unification false positive, which surfaces as ambiguous calls to gtest's own `CodeLocation` / `MakeAndRegisterTestInfo`. The compiler builds and runs both on every platform. This follows the existing exclusion pattern in `packages/streamr-dht/lint.sh`. `PeerManagerTest.cpp` imports the same module cluster but does not trip it, so it stays in the clangd-tidy set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)