### PR TITLE
Phase A4: Router, RoutingSession and the RouterRpc layer

### DIFF
--- a/packages/streamr-dht/CMakeLists.txt
+++ b/packages/streamr-dht/CMakeLists.txt
@@ -213,6 +213,8 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         test/unit/KBucketTest.cpp
         test/unit/DhtNodeRpcLocalTest.cpp
         test/unit/PeerManagerTest.cpp
+        test/unit/RoutingSessionTest.cpp
+        test/unit/RouterTest.cpp
     )
 
     target_include_directories(streamr-dht-test-unit
@@ -245,6 +247,7 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         test/integration/SimultaneousConnectionsTest.cpp
         test/integration/ConnectionManagerIntegrationTest.cpp
         test/integration/DhtNodeRpcRemoteTest.cpp
+        test/integration/RouterRpcRemoteTest.cpp
     )
 
     target_include_directories(streamr-dht-test-integration

--- a/packages/streamr-dht/lint.sh
+++ b/packages/streamr-dht/lint.sh
@@ -37,7 +37,12 @@ echo "Running clangd-tidy on $FILES"
 # mismatch). The compiler accepts and runs both on every platform;
 # clang-format still checks them. (PeerManagerTest.cpp imports the same
 # cluster but does NOT trip it, so it stays in the clangd-tidy set.)
-TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/integration/ConnectionLockingTest.cpp' | grep -v 'test/unit/PendingConnectionTest.cpp' | grep -v 'test/unit/SimulatorTest.cpp' | grep -v 'test/integration/SimultaneousConnectionsTest.cpp' | grep -v 'test/integration/ConnectionManagerIntegrationTest.cpp' | grep -v 'test/unit/DhtNodeRpcLocalTest.cpp' | grep -v 'test/integration/DhtNodeRpcRemoteTest.cpp' | tr '\n' ' ')
+# RoutingSessionTest.cpp (phase A4) trips the same std-type unification
+# false positive through the RoutingSession coroutine cluster; the compiler
+# builds and runs it, and clang-format still checks it. (RouterTest.cpp and
+# RouterRpcRemoteTest.cpp import the same cluster but do NOT trip it, so
+# they stay in the clangd-tidy set.)
+TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/integration/ConnectionLockingTest.cpp' | grep -v 'test/unit/PendingConnectionTest.cpp' | grep -v 'test/unit/SimulatorTest.cpp' | grep -v 'test/integration/SimultaneousConnectionsTest.cpp' | grep -v 'test/integration/ConnectionManagerIntegrationTest.cpp' | grep -v 'test/unit/DhtNodeRpcLocalTest.cpp' | grep -v 'test/integration/DhtNodeRpcRemoteTest.cpp' | grep -v 'test/unit/RoutingSessionTest.cpp' | tr '\n' ' ')
 clangd-tidy -p "$COMPILE_DB" $TIDY_FILES
 
 echo "Running clang-format --dry-run on $FILES"

--- a/packages/streamr-dht/modules/dht/recursive-operation/RecursiveOperationRpcRemote.cppm
+++ b/packages/streamr-dht/modules/dht/recursive-operation/RecursiveOperationRpcRemote.cppm
@@ -1,0 +1,92 @@
+// Module streamr.dht.RecursiveOperationRpcRemote
+// Ported from packages/dht/src/dht/recursive-operation/
+// RecursiveOperationRpcRemote.ts (v103.8.0-rc.3).
+//
+// Pulled forward into phase A4 (the rest of the recursive-operation cluster
+// lands in A5): RoutingSession's RoutingRemoteContact constructs one of
+// these for every contact, so RoutingSession cannot compile without it.
+// Only the routeRequest client call is needed here.
+module;
+
+#include <coroutine> // IWYU pragma: keep
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <utility>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.RecursiveOperationRpcRemote;
+
+import streamr.utils.CoroutineHelper;
+import streamr.utils.Uuid;
+import streamr.logger.SLogger;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.DhtCallContext;
+import streamr.dht.Identifiers;
+import streamr.dht.RpcRemote;
+import streamr.dht.getPreviousPeer;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+using streamr::utils::Uuid;
+
+export namespace streamr::dht::recursiveoperation {
+
+using ::dht::PeerDescriptor;
+using ::dht::RouteMessageWrapper;
+using streamr::dht::Identifiers;
+using streamr::dht::contact::RpcRemote;
+using streamr::dht::routing::getPreviousPeer;
+using streamr::dht::rpcprotocol::DhtCallContext;
+
+using RecursiveOperationRpcClient =
+    ::dht::RecursiveOperationRpcClient<DhtCallContext>;
+
+class RecursiveOperationRpcRemote
+    : public RpcRemote<RecursiveOperationRpcClient> {
+public:
+    RecursiveOperationRpcRemote(
+        PeerDescriptor localPeerDescriptor, // NOLINT
+        PeerDescriptor remotePeerDescriptor,
+        RecursiveOperationRpcClient client,
+        std::optional<std::chrono::milliseconds> timeout = std::nullopt)
+        : RpcRemote<RecursiveOperationRpcClient>(
+              std::move(localPeerDescriptor),
+              std::move(remotePeerDescriptor),
+              std::move(client),
+              timeout) {}
+
+    folly::coro::Task<bool> routeRequest(const RouteMessageWrapper& params) {
+        RouteMessageWrapper message = params;
+        if (message.requestid().empty()) {
+            message.set_requestid(Uuid::v4());
+        }
+        DhtCallContext context;
+        context.connect = false;
+        auto options = this->formDhtRpcOptions(context);
+        auto timeout = this->getTimeout();
+        try {
+            const auto ack = co_await this->getClient().routeRequest(
+                std::move(message), std::move(options), timeout);
+            if (ack.has_error()) {
+                SLogger::trace("Next hop responded with error");
+                co_return false;
+            }
+        } catch (const std::exception& err) {
+            const auto previousPeer = getPreviousPeer(params);
+            const DhtAddress fromNode = previousPeer.has_value()
+                ? Identifiers::getNodeIdFromPeerDescriptor(previousPeer.value())
+                : Identifiers::getNodeIdFromPeerDescriptor(params.sourcepeer());
+            const DhtAddress toNode = Identifiers::getNodeIdFromPeerDescriptor(
+                this->getPeerDescriptor());
+            SLogger::debug(
+                "Failed to send routeRequest message from " + fromNode +
+                " to " + toNode + " " + std::string(err.what()));
+            co_return false;
+        }
+        co_return true;
+    }
+};
+
+} // namespace streamr::dht::recursiveoperation

--- a/packages/streamr-dht/modules/dht/routing/Router.cppm
+++ b/packages/streamr-dht/modules/dht/routing/Router.cppm
@@ -1,0 +1,431 @@
+// Module streamr.dht.Router
+// Ported from packages/dht/src/dht/routing/Router.ts (v103.8.0-rc.3). The
+// Router receives routeMessage/forwardMessage RPCs, decides the next hops
+// (via a RoutingSession over the cached routing tables), and forwards the
+// message, deduplicating with a DuplicateDetector.
+//
+// C++ threading (the routing operations proved heavy in TS): the Router
+// owns a dedicated single-thread worker executor and runs ALL routing work
+// on it — the RPC handlers hop onto the worker and block for the ack, the
+// session send-completions resume on the worker, and the cross-thread
+// entry points (onNodeConnected/Disconnected, resetCache, stop, the
+// duplicate-detector accessors) dispatch onto it too. Because every access
+// to the routing state (routing-tables cache, ongoing sessions, forwarding
+// table, duplicate detector) happens on that one worker thread, the state
+// needs no additional locks, and the heavy routing computation never runs
+// on the transport/RPC delivery thread. (Server-side RPC handlers run
+// inline on the delivering thread, so this offload is not free — see the
+// worker-thread note in the phase A4 PR.) A single worker serializes
+// routing; scaling it to a pool would require finer-grained locking of the
+// cache and sessions.
+module;
+
+#include <coroutine> // IWYU pragma: keep
+
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.Router;
+
+import streamr.eventemitter.EventEmitter;
+import streamr.utils.AbortController;
+import streamr.utils.AbortableTimers;
+import streamr.utils.CoroutineHelper;
+import streamr.utils.EnableSharedFromThis;
+import streamr.utils.ExecutorHelper;
+import streamr.utils.Uuid;
+import streamr.logger.SLogger;
+import streamr.protorpc.RpcCommunicator;
+import streamr.dht.DhtCallContext;
+import streamr.dht.DuplicateDetector;
+import streamr.dht.Identifiers;
+import streamr.dht.RouterRpcLocal;
+import streamr.dht.RoutingRemoteContact;
+import streamr.dht.RoutingSession;
+import streamr.dht.RoutingTablesCache;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+using streamr::utils::AbortableTimers;
+using streamr::utils::AbortController;
+using streamr::utils::EnableSharedFromThis;
+using streamr::utils::Uuid;
+
+export namespace streamr::dht::routing {
+
+using ::dht::Message;
+using ::dht::PeerDescriptor;
+using ::dht::RouteMessageAck;
+using ::dht::RouteMessageError;
+using ::dht::RouteMessageWrapper;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+using streamr::dht::routing::DuplicateDetector;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::protorpc::RpcCommunicator;
+
+struct RouterOptions {
+    RpcCommunicator<DhtCallContext>& rpcCommunicator;
+    PeerDescriptor localPeerDescriptor;
+    std::function<void(const Message&)> handleMessage;
+    std::function<std::vector<PeerDescriptor>()> getConnections;
+};
+
+class Router : public EnableSharedFromThis {
+private:
+    static constexpr size_t routingWorkerThreadCount = 1;
+    static constexpr size_t duplicateDetectorSize = 10000;
+    static constexpr std::chrono::milliseconds forwardingEntryTtl{10000};
+    static constexpr std::chrono::milliseconds sessionTimeout{10000};
+
+    struct ForwardingTableEntry {
+        std::vector<PeerDescriptor> peerDescriptors;
+        std::shared_ptr<AbortController> timeoutAbort;
+    };
+
+    RouterOptions options;
+    folly::CPUThreadPoolExecutor routingExecutor{routingWorkerThreadCount};
+    AbortController abortController; // cancels the session-cleanup timeouts
+    std::map<DhtAddress, ForwardingTableEntry> forwardingTable;
+    RoutingTablesCache routingTablesCache;
+    std::map<std::string, std::shared_ptr<RoutingSession>>
+        ongoingRoutingSessions;
+    DuplicateDetector duplicateRequestDetector{duplicateDetectorSize};
+    bool stopped = false;
+    std::unique_ptr<RouterRpcLocal> routerRpcLocal;
+
+    explicit Router(RouterOptions options) : options(std::move(options)) {}
+
+    // Runs `fn` on the routing worker and blocks for its result. Callers must
+    // NOT already be on the worker thread (that would self-deadlock the
+    // single-thread executor); every caller here is an off-worker entry
+    // point.
+    template <typename Fn>
+    auto runOnWorker(Fn fn) -> decltype(fn()) {
+        using Ret = decltype(fn());
+        return streamr::utils::blockingWait(
+            streamr::utils::co_withExecutor(
+                &this->routingExecutor,
+                folly::coro::co_invoke(
+                    [fn = std::move(fn)]() -> folly::coro::Task<Ret> {
+                        co_return fn();
+                    })));
+    }
+
+    void registerLocalRpcMethods() {
+        this->routerRpcLocal =
+            std::make_unique<RouterRpcLocal>(RouterRpcLocalOptions{
+                .doRouteMessage =
+                    [this](
+                        const RouteMessageWrapper& routedMessage,
+                        std::optional<RoutingMode> mode) {
+                        return this->doRouteMessage(
+                            routedMessage,
+                            mode.value_or(RoutingMode::ROUTE),
+                            std::nullopt);
+                    },
+                .setForwardingEntries =
+                    [this](const RouteMessageWrapper& routedMessage) {
+                        this->setForwardingEntries(routedMessage);
+                    },
+                .handleMessage = this->options.handleMessage,
+                .duplicateRequestDetector = this->duplicateRequestDetector,
+                .localPeerDescriptor = this->options.localPeerDescriptor});
+
+        std::weak_ptr<Router> weakSelf = this->sharedFromThis<Router>();
+        this->options.rpcCommunicator
+            .template registerRpcMethod<RouteMessageWrapper, RouteMessageAck>(
+                "routeMessage",
+                [weakSelf](
+                    const RouteMessageWrapper& routedMessage,
+                    const DhtCallContext& callContext) -> RouteMessageAck {
+                    auto self = weakSelf.lock();
+                    if (!self) {
+                        return createRouteMessageAck(
+                            routedMessage, RouteMessageError::STOPPED);
+                    }
+                    return self->runOnWorker(
+                        [&self, &routedMessage, &callContext]() {
+                            if (self->stopped) {
+                                return createRouteMessageAck(
+                                    routedMessage, RouteMessageError::STOPPED);
+                            }
+                            return self->routerRpcLocal->routeMessage(
+                                routedMessage, callContext);
+                        });
+                });
+        this->options.rpcCommunicator
+            .template registerRpcMethod<RouteMessageWrapper, RouteMessageAck>(
+                "forwardMessage",
+                [weakSelf](
+                    const RouteMessageWrapper& forwardMessage,
+                    const DhtCallContext& callContext) -> RouteMessageAck {
+                    auto self = weakSelf.lock();
+                    if (!self) {
+                        return createRouteMessageAck(
+                            forwardMessage, RouteMessageError::STOPPED);
+                    }
+                    return self->runOnWorker(
+                        [&self, &forwardMessage, &callContext]() {
+                            if (self->stopped) {
+                                return createRouteMessageAck(
+                                    forwardMessage, RouteMessageError::STOPPED);
+                            }
+                            return self->routerRpcLocal->forwardMessage(
+                                forwardMessage, callContext);
+                        });
+                });
+    }
+
+    // Runs on the routing worker.
+    void cleanupSession(const std::string& sessionId) {
+        const auto it = this->ongoingRoutingSessions.find(sessionId);
+        if (it == this->ongoingRoutingSessions.end()) {
+            return;
+        }
+        auto session = it->second;
+        this->ongoingRoutingSessions.erase(it);
+        session->stop();
+    }
+
+    std::shared_ptr<RoutingSession> createRoutingSession(
+        const RouteMessageWrapper& routedMessage,
+        RoutingMode mode,
+        std::optional<DhtAddress> excludedNode) {
+        std::set<DhtAddress> excludedNodeIds;
+        for (const auto& descriptor : routedMessage.routingpath()) {
+            excludedNodeIds.insert(
+                Identifiers::getNodeIdFromPeerDescriptor(descriptor));
+        }
+        if (excludedNode.has_value()) {
+            excludedNodeIds.insert(excludedNode.value());
+        }
+        for (const auto& nodeId : routedMessage.parallelrootnodeids()) {
+            excludedNodeIds.insert(DhtAddress{nodeId});
+        }
+        constexpr size_t sourceParallelism = 2;
+        constexpr size_t forwardParallelism = 1;
+        const size_t parallelism =
+            Identifiers::areEqualPeerDescriptors(
+                this->options.localPeerDescriptor, routedMessage.sourcepeer())
+            ? sourceParallelism
+            : forwardParallelism;
+        return RoutingSession::newInstance(
+            RoutingSessionOptions{
+                .rpcCommunicator = this->options.rpcCommunicator,
+                .localPeerDescriptor = this->options.localPeerDescriptor,
+                .routedMessage = routedMessage,
+                .parallelism = parallelism,
+                .mode = mode,
+                .excludedNodeIds = excludedNodeIds,
+                .routingTablesCache = this->routingTablesCache,
+                .getConnections = this->options.getConnections,
+                .executor = &this->routingExecutor});
+    }
+
+    // Runs on the routing worker.
+    void setForwardingEntries(const RouteMessageWrapper& routedMessage) {
+        std::vector<PeerDescriptor> reachableThroughWithoutSelf;
+        for (const auto& peer : routedMessage.reachablethrough()) {
+            if (!Identifiers::areEqualPeerDescriptors(
+                    peer, this->options.localPeerDescriptor)) {
+                reachableThroughWithoutSelf.push_back(peer);
+            }
+        }
+        if (reachableThroughWithoutSelf.empty()) {
+            return;
+        }
+        const DhtAddress sourceNodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(
+                routedMessage.sourcepeer());
+        const auto existing = this->forwardingTable.find(sourceNodeId);
+        if (existing != this->forwardingTable.end()) {
+            existing->second.timeoutAbort->abort();
+            this->forwardingTable.erase(existing);
+        }
+        auto timeoutAbort = std::make_shared<AbortController>();
+        auto self = this->sharedFromThis<Router>();
+        AbortableTimers::setAbortableTimeout(
+            [self, sourceNodeId]() {
+                streamr::utils::co_withExecutor(
+                    &self->routingExecutor,
+                    folly::coro::co_invoke(
+                        [self, sourceNodeId]() -> folly::coro::Task<void> {
+                            self->forwardingTable.erase(sourceNodeId);
+                            co_return;
+                        }))
+                    .start();
+            },
+            forwardingEntryTtl,
+            timeoutAbort->getSignal());
+        this->forwardingTable.emplace(
+            sourceNodeId,
+            ForwardingTableEntry{
+                std::move(reachableThroughWithoutSelf),
+                std::move(timeoutAbort)});
+    }
+
+public:
+    [[nodiscard]] static std::shared_ptr<Router> newInstance(
+        RouterOptions options) {
+        struct MakeSharedEnabler : public Router {
+            explicit MakeSharedEnabler(RouterOptions options)
+                : Router(std::move(options)) {}
+        };
+        auto instance = std::make_shared<MakeSharedEnabler>(std::move(options));
+        instance->registerLocalRpcMethods();
+        return instance;
+    }
+
+    ~Router() override = default;
+
+    // Runs on the routing worker (called from the RPC handlers and, via
+    // runOnWorker, from send()).
+    RouteMessageAck doRouteMessage(
+        const RouteMessageWrapper& routedMessage,
+        RoutingMode mode = RoutingMode::ROUTE,
+        std::optional<DhtAddress> excludedPeer = std::nullopt) {
+        if (this->stopped) {
+            return createRouteMessageAck(
+                routedMessage, RouteMessageError::STOPPED);
+        }
+        auto session =
+            this->createRoutingSession(routedMessage, mode, excludedPeer);
+        const auto contacts = session->updateAndGetRoutablePeers();
+        if (contacts.empty()) {
+            return createRouteMessageAck(
+                routedMessage, RouteMessageError::NO_TARGETS);
+        }
+        const std::string sessionId = session->getSessionId();
+        this->ongoingRoutingSessions.emplace(sessionId, session);
+        auto self = this->sharedFromThis<Router>();
+        auto onDone = [self, sessionId]() { self->cleanupSession(sessionId); };
+        session->once<routingsessionevents::RoutingSucceeded>(
+            [onDone]() { onDone(); });
+        session->once<routingsessionevents::PartialSuccess>(
+            [onDone]() { onDone(); });
+        session->once<routingsessionevents::RoutingFailed>(
+            [onDone]() { onDone(); });
+        session->once<routingsessionevents::Stopped>([onDone]() { onDone(); });
+        AbortableTimers::setAbortableTimeout(
+            [self, sessionId]() {
+                streamr::utils::co_withExecutor(
+                    &self->routingExecutor,
+                    folly::coro::co_invoke(
+                        [self, sessionId]() -> folly::coro::Task<void> {
+                            self->cleanupSession(sessionId);
+                            co_return;
+                        }))
+                    .start();
+            },
+            sessionTimeout,
+            this->abortController.getSignal());
+        session->sendMoreRequests(contacts);
+        return createRouteMessageAck(routedMessage);
+    }
+
+    void send(
+        const Message& msg,
+        const std::vector<PeerDescriptor>& reachableThrough) {
+        auto self = this->sharedFromThis<Router>();
+        Message message = msg;
+        *message.mutable_sourcedescriptor() = this->options.localPeerDescriptor;
+        this->runOnWorker([&]() -> std::monostate {
+            const DhtAddress targetNodeId =
+                Identifiers::getNodeIdFromPeerDescriptor(
+                    message.targetdescriptor());
+            const auto forwardingEntry =
+                this->forwardingTable.find(targetNodeId);
+            RouteMessageWrapper routedMessage;
+            *routedMessage.mutable_message() = message;
+            routedMessage.set_requestid(Uuid::v4());
+            *routedMessage.mutable_sourcepeer() =
+                this->options.localPeerDescriptor;
+            for (const auto& peer : reachableThrough) {
+                *routedMessage.add_reachablethrough() = peer;
+            }
+            RoutingMode mode = RoutingMode::ROUTE;
+            if (forwardingEntry != this->forwardingTable.end() &&
+                !forwardingEntry->second.peerDescriptors.empty()) {
+                routedMessage.set_target(
+                    forwardingEntry->second.peerDescriptors[0].nodeid());
+                mode = RoutingMode::FORWARD;
+            } else {
+                routedMessage.set_target(message.targetdescriptor().nodeid());
+            }
+            this->doRouteMessage(routedMessage, mode, std::nullopt);
+            return std::monostate{};
+        });
+    }
+
+    [[nodiscard]] bool isMostLikelyDuplicate(const std::string& requestId) {
+        return this->runOnWorker([&]() {
+            return this->duplicateRequestDetector.isMostLikelyDuplicate(
+                requestId);
+        });
+    }
+
+    void addToDuplicateDetector(const std::string& requestId) {
+        this->runOnWorker([&]() -> std::monostate {
+            this->duplicateRequestDetector.add(requestId);
+            return std::monostate{};
+        });
+    }
+
+    void onNodeConnected(const PeerDescriptor& peerDescriptor) {
+        this->runOnWorker([&]() -> std::monostate {
+            auto remote = std::make_shared<RoutingRemoteContact>(
+                peerDescriptor,
+                this->options.localPeerDescriptor,
+                this->options.rpcCommunicator);
+            this->routingTablesCache.onNodeConnected(remote);
+            return std::monostate{};
+        });
+    }
+
+    void onNodeDisconnected(const PeerDescriptor& peerDescriptor) {
+        this->runOnWorker([&]() -> std::monostate {
+            this->routingTablesCache.onNodeDisconnected(
+                Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor));
+            return std::monostate{};
+        });
+    }
+
+    void resetCache() {
+        this->runOnWorker([&]() -> std::monostate {
+            this->routingTablesCache.reset();
+            return std::monostate{};
+        });
+    }
+
+    void stop() {
+        this->runOnWorker([&]() -> std::monostate {
+            this->stopped = true;
+            auto sessions = this->ongoingRoutingSessions;
+            this->ongoingRoutingSessions.clear();
+            for (auto& [sessionId, session] : sessions) {
+                session->stop();
+            }
+            for (auto& [nodeId, entry] : this->forwardingTable) {
+                entry.timeoutAbort->abort();
+            }
+            this->forwardingTable.clear();
+            this->duplicateRequestDetector.clear();
+            this->routingTablesCache.reset();
+            return std::monostate{};
+        });
+        this->abortController.abort();
+    }
+};
+
+} // namespace streamr::dht::routing

--- a/packages/streamr-dht/modules/dht/routing/RouterRpcLocal.cppm
+++ b/packages/streamr-dht/modules/dht/routing/RouterRpcLocal.cppm
@@ -1,0 +1,133 @@
+// Module streamr.dht.RouterRpcLocal
+// Ported from packages/dht/src/dht/routing/RouterRpcLocal.ts
+// (v103.8.0-rc.3). The server-side handlers for the RouterRpc service:
+// routeMessage (forward towards the target by distance, or deliver if this
+// node is the target) and forwardMessage (forward towards a reachable-
+// through peer, or deliver). Both drop duplicates via the shared detector.
+module;
+
+#include <functional>
+#include <optional>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.RouterRpcLocal;
+
+import streamr.logger.SLogger;
+import streamr.utils.Uuid;
+import streamr.dht.DhtRpcServer;
+import streamr.dht.DhtCallContext;
+import streamr.dht.DuplicateDetector;
+import streamr.dht.Identifiers;
+import streamr.dht.RoutingSession;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+using streamr::utils::Uuid;
+
+export namespace streamr::dht::routing {
+
+using ::dht::Message;
+using ::dht::PeerDescriptor;
+using ::dht::RouteMessageAck;
+using ::dht::RouteMessageError;
+using ::dht::RouteMessageWrapper;
+using streamr::dht::Identifiers;
+using streamr::dht::routing::DuplicateDetector;
+using streamr::dht::rpcprotocol::DhtCallContext;
+
+using RouterRpc = ::dht::RouterRpc<DhtCallContext>;
+
+inline RouteMessageAck createRouteMessageAck(
+    const RouteMessageWrapper& routedMessage,
+    std::optional<RouteMessageError> error = std::nullopt) {
+    RouteMessageAck ack;
+    ack.set_requestid(routedMessage.requestid());
+    if (error.has_value()) {
+        ack.set_error(error.value());
+    }
+    return ack;
+}
+
+struct RouterRpcLocalOptions {
+    std::function<RouteMessageAck(
+        const RouteMessageWrapper&, std::optional<RoutingMode>)>
+        doRouteMessage;
+    std::function<void(const RouteMessageWrapper&)> setForwardingEntries;
+    std::function<void(const Message&)> handleMessage;
+    DuplicateDetector& duplicateRequestDetector;
+    PeerDescriptor localPeerDescriptor;
+};
+
+class RouterRpcLocal : public RouterRpc {
+private:
+    RouterRpcLocalOptions options;
+
+    RouteMessageAck forwardToDestination(
+        const RouteMessageWrapper& routedMessage) {
+        SLogger::trace(
+            "Forwarding found message targeted to self " +
+            routedMessage.requestid());
+        const Message& forwardedMessage = routedMessage.message();
+        if (Identifiers::areEqualPeerDescriptors(
+                this->options.localPeerDescriptor,
+                forwardedMessage.targetdescriptor())) {
+            this->options.handleMessage(forwardedMessage);
+            return createRouteMessageAck(routedMessage);
+        }
+        RouteMessageWrapper rerouted = routedMessage;
+        rerouted.set_requestid(Uuid::v4());
+        rerouted.set_target(forwardedMessage.targetdescriptor().nodeid());
+        return this->options.doRouteMessage(rerouted, std::nullopt);
+    }
+
+public:
+    explicit RouterRpcLocal(RouterRpcLocalOptions options)
+        : options(std::move(options)) {}
+
+    ~RouterRpcLocal() override = default;
+
+    RouteMessageAck routeMessage(
+        const RouteMessageWrapper& routedMessage,
+        const DhtCallContext& /*callContext*/) override {
+        if (this->options.duplicateRequestDetector.isMostLikelyDuplicate(
+                routedMessage.requestid())) {
+            return createRouteMessageAck(
+                routedMessage, RouteMessageError::DUPLICATE);
+        }
+        SLogger::trace(
+            "Processing received routeMessage " + routedMessage.requestid());
+        this->options.duplicateRequestDetector.add(routedMessage.requestid());
+        if (this->options.localPeerDescriptor.nodeid() ==
+            routedMessage.target()) {
+            SLogger::trace(
+                "routing message targeted to self " +
+                routedMessage.requestid());
+            this->options.setForwardingEntries(routedMessage);
+            this->options.handleMessage(routedMessage.message());
+            return createRouteMessageAck(routedMessage);
+        }
+        return this->options.doRouteMessage(routedMessage, std::nullopt);
+    }
+
+    RouteMessageAck forwardMessage(
+        const RouteMessageWrapper& forwardMessage,
+        const DhtCallContext& /*callContext*/) override {
+        if (this->options.duplicateRequestDetector.isMostLikelyDuplicate(
+                forwardMessage.requestid())) {
+            return createRouteMessageAck(
+                forwardMessage, RouteMessageError::DUPLICATE);
+        }
+        SLogger::trace(
+            "Processing received forward routeMessage " +
+            forwardMessage.requestid());
+        this->options.duplicateRequestDetector.add(forwardMessage.requestid());
+        if (this->options.localPeerDescriptor.nodeid() ==
+            forwardMessage.target()) {
+            return this->forwardToDestination(forwardMessage);
+        }
+        return this->options.doRouteMessage(
+            forwardMessage, RoutingMode::FORWARD);
+    }
+};
+
+} // namespace streamr::dht::routing

--- a/packages/streamr-dht/modules/dht/routing/RouterRpcRemote.cppm
+++ b/packages/streamr-dht/modules/dht/routing/RouterRpcRemote.cppm
@@ -1,0 +1,127 @@
+// Module streamr.dht.RouterRpcRemote
+// Ported from packages/dht/src/dht/routing/RouterRpcRemote.ts
+// (v103.8.0-rc.3). The client-side wrapper for a peer's RouterRpc service:
+// routeMessage (forward towards the target by distance) and forwardMessage
+// (forward towards a known reachable-through peer).
+module;
+
+// std::coroutine_traits must be visible in the TU that defines a coroutine.
+#include <coroutine> // IWYU pragma: keep
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <utility>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.RouterRpcRemote;
+
+import streamr.utils.CoroutineHelper;
+import streamr.utils.Uuid;
+import streamr.logger.SLogger;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.DhtCallContext;
+import streamr.dht.Identifiers;
+import streamr.dht.RpcRemote;
+import streamr.dht.getPreviousPeer;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+using streamr::utils::Uuid;
+
+export namespace streamr::dht::routing {
+
+using ::dht::PeerDescriptor;
+using ::dht::RouteMessageAck;
+using ::dht::RouteMessageError;
+using ::dht::RouteMessageWrapper;
+using streamr::dht::Identifiers;
+using streamr::dht::contact::RpcRemote;
+using streamr::dht::rpcprotocol::DhtCallContext;
+
+using RouterRpcClient = ::dht::RouterRpcClient<DhtCallContext>;
+
+// default routing RPC timeout
+inline constexpr std::chrono::milliseconds routingTimeout{2000};
+
+class RouterRpcRemote : public RpcRemote<RouterRpcClient> {
+public:
+    RouterRpcRemote(
+        PeerDescriptor localPeerDescriptor, // NOLINT
+        PeerDescriptor remotePeerDescriptor,
+        RouterRpcClient client,
+        std::optional<std::chrono::milliseconds> timeout = std::nullopt)
+        : RpcRemote<RouterRpcClient>(
+              std::move(localPeerDescriptor),
+              std::move(remotePeerDescriptor),
+              std::move(client),
+              timeout) {}
+
+    folly::coro::Task<bool> routeMessage(const RouteMessageWrapper& params) {
+        RouteMessageWrapper message = params;
+        if (message.requestid().empty()) {
+            message.set_requestid(Uuid::v4());
+        }
+        DhtCallContext context;
+        context.connect = false;
+        auto options = this->formDhtRpcOptions(context);
+        auto timeout = this->getTimeout();
+        try {
+            const auto ack = co_await this->getClient().routeMessage(
+                std::move(message), std::move(options), timeout);
+            // Success signal if sent to destination and error is a duplicate.
+            if (ack.has_error() &&
+                ack.error() == RouteMessageError::DUPLICATE &&
+                params.target() == this->getPeerDescriptor().nodeid()) {
+                co_return true;
+            }
+            if (ack.has_error()) {
+                co_return false;
+            }
+        } catch (const std::exception& err) {
+            this->logSendFailure("routeMessage", params, err);
+            co_return false;
+        }
+        co_return true;
+    }
+
+    folly::coro::Task<bool> forwardMessage(const RouteMessageWrapper& params) {
+        RouteMessageWrapper message = params;
+        if (message.requestid().empty()) {
+            message.set_requestid(Uuid::v4());
+        }
+        DhtCallContext context;
+        context.connect = false;
+        auto options = this->formDhtRpcOptions(context);
+        auto timeout = this->getTimeout();
+        try {
+            const auto ack = co_await this->getClient().forwardMessage(
+                std::move(message), std::move(options), timeout);
+            if (ack.has_error()) {
+                co_return false;
+            }
+        } catch (const std::exception& err) {
+            this->logSendFailure("forwardMessage", params, err);
+            co_return false;
+        }
+        co_return true;
+    }
+
+private:
+    void logSendFailure(
+        const std::string& method,
+        const RouteMessageWrapper& params,
+        const std::exception& err) {
+        const auto previousPeer = getPreviousPeer(params);
+        const DhtAddress fromNode = previousPeer.has_value()
+            ? Identifiers::getNodeIdFromPeerDescriptor(previousPeer.value())
+            : Identifiers::getNodeIdFromPeerDescriptor(params.sourcepeer());
+        const DhtAddress toNode =
+            Identifiers::getNodeIdFromPeerDescriptor(this->getPeerDescriptor());
+        SLogger::trace(
+            "Failed to send " + method + " from " + fromNode + " to " + toNode +
+            " " + std::string(err.what()));
+    }
+};
+
+} // namespace streamr::dht::routing

--- a/packages/streamr-dht/modules/dht/routing/RoutingRemoteContact.cppm
+++ b/packages/streamr-dht/modules/dht/routing/RoutingRemoteContact.cppm
@@ -1,0 +1,65 @@
+// Module streamr.dht.RoutingRemoteContact
+// Ported from the RoutingRemoteContact class in
+// packages/dht/src/dht/routing/RoutingSession.ts (v103.8.0-rc.3).
+//
+// Extracted into its own module (TS keeps it inside RoutingSession.ts):
+// RoutingTablesCache holds RoutingRemoteContact and RoutingSession holds
+// RoutingTablesCache, which is a circular import TS tolerates but C++
+// modules cannot. Giving RoutingRemoteContact its own module breaks the
+// cycle.
+module;
+
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.RoutingRemoteContact;
+
+import streamr.protorpc.RpcCommunicator;
+import streamr.dht.Contact;
+import streamr.dht.DhtCallContext;
+import streamr.dht.RouterRpcRemote;
+import streamr.dht.RecursiveOperationRpcRemote;
+
+export namespace streamr::dht::routing {
+
+using ::dht::PeerDescriptor;
+using streamr::dht::contact::Contact;
+using streamr::dht::recursiveoperation::RecursiveOperationRpcClient;
+using streamr::dht::recursiveoperation::RecursiveOperationRpcRemote;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::protorpc::RpcCommunicator;
+// RouterRpcRemote, RouterRpcClient and routingTimeout are visible from the
+// imported streamr.dht.RouterRpcRemote (same namespace).
+
+class RoutingRemoteContact : public Contact {
+private:
+    RouterRpcRemote routerRpcRemote;
+    RecursiveOperationRpcRemote recursiveOperationRpcRemote;
+
+public:
+    RoutingRemoteContact(
+        const PeerDescriptor& peer,
+        const PeerDescriptor& localPeerDescriptor,
+        RpcCommunicator<DhtCallContext>& rpcCommunicator)
+        : Contact(peer),
+          routerRpcRemote(
+              localPeerDescriptor,
+              peer,
+              RouterRpcClient(rpcCommunicator),
+              routingTimeout),
+          recursiveOperationRpcRemote(
+              localPeerDescriptor,
+              peer,
+              RecursiveOperationRpcClient(rpcCommunicator),
+              routingTimeout) {}
+
+    [[nodiscard]] RouterRpcRemote& getRouterRpcRemote() {
+        return this->routerRpcRemote;
+    }
+
+    [[nodiscard]] RecursiveOperationRpcRemote&
+    getRecursiveOperationRpcRemote() {
+        return this->recursiveOperationRpcRemote;
+    }
+};
+
+} // namespace streamr::dht::routing

--- a/packages/streamr-dht/modules/dht/routing/RoutingSession.cppm
+++ b/packages/streamr-dht/modules/dht/routing/RoutingSession.cppm
@@ -1,0 +1,351 @@
+// Module streamr.dht.RoutingSession
+// Ported from packages/dht/src/dht/routing/RoutingSession.ts
+// (v103.8.0-rc.3). One session drives a single routed message towards its
+// target: it pulls the closest routable contacts (from the shared
+// RoutingTablesCache), sends the message to up to `parallelism` of them at
+// a time, and retries on failure until it succeeds, partially succeeds, or
+// runs out of contacts.
+//
+// C++ threading (TS is single-threaded and uses setImmediate): the message
+// sends are dispatched onto the worker executor supplied by the Router, so
+// the per-hop send orchestration and its retries run off the RPC/transport
+// thread. State is guarded by one recursive mutex, the session is owned via
+// shared_ptr so an in-flight send can pin it, and an AbortController lets
+// stop() cancel outstanding sends promptly (the RPC layer detaches on
+// cancel).
+//
+// RoutingRemoteContact lives in its own module (streamr.dht.
+// RoutingRemoteContact) to break the RoutingTablesCache <-> RoutingSession
+// import cycle that TS tolerates but C++ modules cannot.
+module;
+
+#include <coroutine> // IWYU pragma: keep
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.RoutingSession;
+
+import streamr.eventemitter.EventEmitter;
+import streamr.utils.AbortController;
+import streamr.utils.CoroutineHelper;
+import streamr.utils.EnableSharedFromThis;
+import streamr.utils.ExecutorHelper;
+import streamr.utils.Uuid;
+import streamr.logger.SLogger;
+import streamr.protorpc.RpcCommunicator;
+import streamr.dht.DhtCallContext;
+import streamr.dht.Identifiers;
+import streamr.dht.getPreviousPeer;
+import streamr.dht.RoutingRemoteContact;
+import streamr.dht.RoutingTablesCache;
+import streamr.dht.SortedContactList;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::eventemitter::Event;
+using streamr::eventemitter::EventEmitter;
+using streamr::logger::SLogger;
+using streamr::utils::AbortController;
+using streamr::utils::EnableSharedFromThis;
+using streamr::utils::Uuid;
+
+export namespace streamr::dht::routing {
+
+using ::dht::PeerDescriptor;
+using ::dht::RouteMessageWrapper;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+using streamr::dht::contact::SortedContactList;
+using streamr::dht::contact::SortedContactListOptions;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::protorpc::RpcCommunicator;
+
+enum class RoutingMode { ROUTE, FORWARD, RECURSIVE };
+
+namespace routingsessionevents {
+// A peer answered a routeMessage call with a success ack.
+struct RoutingSucceeded : Event<> {};
+struct PartialSuccess : Event<> {};
+// All candidates were tried and none answered with a success ack.
+struct RoutingFailed : Event<> {};
+struct Stopped : Event<> {};
+} // namespace routingsessionevents
+
+using RoutingSessionEvents = std::tuple<
+    routingsessionevents::RoutingSucceeded,
+    routingsessionevents::PartialSuccess,
+    routingsessionevents::RoutingFailed,
+    routingsessionevents::Stopped>;
+
+struct RoutingSessionOptions {
+    RpcCommunicator<DhtCallContext>& rpcCommunicator;
+    PeerDescriptor localPeerDescriptor;
+    RouteMessageWrapper routedMessage;
+    size_t parallelism;
+    RoutingMode mode;
+    std::set<DhtAddress> excludedNodeIds;
+    RoutingTablesCache& routingTablesCache;
+    std::function<std::vector<PeerDescriptor>()> getConnections;
+    // Worker executor the sends are dispatched onto (owned by the Router).
+    folly::CPUThreadPoolExecutor* executor;
+};
+
+class RoutingSession : public EventEmitter<RoutingSessionEvents>,
+                       public EnableSharedFromThis {
+private:
+    static constexpr int maxFailedHops = 2;
+    static constexpr int routingTableMaxSize = 5;
+
+    RoutingSessionOptions options;
+    std::string sessionId = Uuid::v4();
+    std::recursive_mutex mutex;
+    AbortController abortController;
+    std::set<DhtAddress> ongoingRequests;
+    std::set<DhtAddress> contactedPeers;
+    int failedHopCounter = 0;
+    int successfulHopCounter = 0;
+    bool stopped = false;
+
+    explicit RoutingSession(RoutingSessionOptions options)
+        : options(std::move(options)) {}
+
+    void emitFailure() {
+        if (this->successfulHopCounter >= 1) {
+            this->emit<routingsessionevents::PartialSuccess>();
+        } else {
+            this->emit<routingsessionevents::RoutingFailed>();
+        }
+    }
+
+    void onRequestFailed(const DhtAddress& nodeId) {
+        std::scoped_lock lock(this->mutex);
+        SLogger::trace("onRequestFailed() sessionId: " + this->sessionId);
+        if (this->stopped) {
+            return;
+        }
+        this->ongoingRequests.erase(nodeId);
+        this->deleteParallelRootIfSource(nodeId);
+        this->failedHopCounter += 1;
+        if (this->failedHopCounter >= maxFailedHops) {
+            this->emitFailure();
+            return;
+        }
+        const auto contacts = this->updateAndGetRoutablePeers();
+        if (contacts.empty() && this->ongoingRequests.empty()) {
+            this->emitFailure();
+        } else {
+            this->sendMoreRequests(contacts);
+        }
+    }
+
+    void onRequestSucceeded() {
+        std::scoped_lock lock(this->mutex);
+        SLogger::trace("onRequestSucceeded() sessionId: " + this->sessionId);
+        if (this->stopped) {
+            return;
+        }
+        this->successfulHopCounter += 1;
+        if (this->successfulHopCounter >=
+            static_cast<int>(this->options.parallelism)) {
+            this->emit<routingsessionevents::RoutingSucceeded>();
+            return;
+        }
+        const auto contacts = this->updateAndGetRoutablePeers();
+        if (contacts.empty()) {
+            this->emit<routingsessionevents::RoutingSucceeded>();
+        } else if (this->ongoingRequests.empty()) {
+            this->sendMoreRequests(contacts);
+        }
+    }
+
+    folly::coro::Task<bool> sendRouteMessageRequest(
+        std::shared_ptr<RoutingRemoteContact> contact) {
+        {
+            std::scoped_lock lock(this->mutex);
+            if (this->stopped) {
+                co_return false;
+            }
+        }
+        RouteMessageWrapper msg = this->options.routedMessage;
+        *msg.add_routingpath() = this->options.localPeerDescriptor;
+        if (this->options.mode == RoutingMode::FORWARD) {
+            co_return co_await contact->getRouterRpcRemote().forwardMessage(
+                msg);
+        }
+        if (this->options.mode == RoutingMode::RECURSIVE) {
+            co_return co_await contact->getRecursiveOperationRpcRemote()
+                .routeRequest(msg);
+        }
+        co_return co_await contact->getRouterRpcRemote().routeMessage(msg);
+    }
+
+    // Dispatches one send onto the worker executor (TS uses setImmediate).
+    // The session is pinned for the send's lifetime and the call is made
+    // cancellable so stop() can abandon it promptly.
+    void dispatchSend(const std::shared_ptr<RoutingRemoteContact>& contact) {
+        auto self = this->sharedFromThis<RoutingSession>();
+        const DhtAddress nodeId = contact->getNodeId();
+        // co_invoke keeps the lambda (and its captured self/contact) alive
+        // for the coroutine's whole lifetime; invoking the lambda directly
+        // would destroy the closure while the coroutine is still suspended.
+        streamr::utils::co_withExecutor(
+            this->options.executor,
+            folly::coro::co_invoke(
+                [self, contact, nodeId]() -> folly::coro::Task<void> {
+                    bool succeeded = false;
+                    try {
+                        succeeded =
+                            co_await streamr::utils::co_withCancellation(
+                                self->abortController.getSignal()
+                                    .getCancellationToken(),
+                                self->sendRouteMessageRequest(contact));
+                    } catch (const std::exception& err) {
+                        SLogger::debug(
+                            "Unable to route message ",
+                            std::string(err.what()));
+                        co_return;
+                    }
+                    if (succeeded) {
+                        self->onRequestSucceeded();
+                    } else {
+                        self->onRequestFailed(nodeId);
+                    }
+                }))
+            .start();
+    }
+
+    void addParallelRootIfSource(const DhtAddress& nodeId) {
+        if (this->options.mode == RoutingMode::RECURSIVE &&
+            Identifiers::areEqualPeerDescriptors(
+                this->options.localPeerDescriptor,
+                this->options.routedMessage.sourcepeer())) {
+            this->options.routedMessage.add_parallelrootnodeids(
+                std::string(nodeId));
+        }
+    }
+
+    void deleteParallelRootIfSource(const DhtAddress& nodeId) {
+        if (this->options.mode == RoutingMode::RECURSIVE &&
+            Identifiers::areEqualPeerDescriptors(
+                this->options.localPeerDescriptor,
+                this->options.routedMessage.sourcepeer())) {
+            auto* const roots =
+                this->options.routedMessage.mutable_parallelrootnodeids();
+            for (int i = roots->size() - 1; i >= 0; --i) {
+                if (roots->Get(i) == std::string(nodeId)) {
+                    roots->DeleteSubrange(i, 1);
+                }
+            }
+        }
+    }
+
+public:
+    [[nodiscard]] static std::shared_ptr<RoutingSession> newInstance(
+        RoutingSessionOptions options) {
+        struct MakeSharedEnabler : public RoutingSession {
+            explicit MakeSharedEnabler(RoutingSessionOptions options)
+                : RoutingSession(std::move(options)) {}
+        };
+        return std::make_shared<MakeSharedEnabler>(std::move(options));
+    }
+
+    ~RoutingSession() override = default;
+
+    [[nodiscard]] const std::string& getSessionId() const {
+        return this->sessionId;
+    }
+
+    std::vector<std::shared_ptr<RoutingRemoteContact>>
+    updateAndGetRoutablePeers() {
+        std::scoped_lock lock(this->mutex);
+        SLogger::trace(
+            "updateAndGetRoutablePeers() sessionId: " + this->sessionId);
+        const auto previousPeer = getPreviousPeer(this->options.routedMessage);
+        const std::optional<DhtAddress> previousId = previousPeer.has_value()
+            ? std::optional<
+                  DhtAddress>{Identifiers::getNodeIdFromPeerDescriptor(
+                  previousPeer.value())}
+            : std::nullopt;
+        const DhtAddress targetId = Identifiers::getDhtAddressFromRaw(
+            DhtAddressRaw{this->options.routedMessage.target()});
+
+        RoutingTable routingTable;
+        if (this->options.routingTablesCache.has(targetId, previousId) &&
+            this->options.routingTablesCache.get(targetId, previousId)
+                    ->getSize() > 0) {
+            routingTable =
+                this->options.routingTablesCache.get(targetId, previousId);
+        } else {
+            routingTable =
+                std::make_shared<SortedContactList<RoutingRemoteContact>>(
+                    SortedContactListOptions{
+                        .referenceId = targetId,
+                        .allowToContainReferenceId = true,
+                        .maxSize = static_cast<size_t>(routingTableMaxSize),
+                        .nodeIdDistanceLimit = previousId});
+            std::vector<std::shared_ptr<RoutingRemoteContact>> contacts;
+            for (const auto& peer : this->options.getConnections()) {
+                contacts.push_back(
+                    std::make_shared<RoutingRemoteContact>(
+                        peer,
+                        this->options.localPeerDescriptor,
+                        this->options.rpcCommunicator));
+            }
+            routingTable->addContacts(contacts);
+            this->options.routingTablesCache.set(
+                targetId, routingTable, previousId);
+        }
+        std::vector<std::shared_ptr<RoutingRemoteContact>> result;
+        for (const auto& contact : routingTable->getClosestContacts()) {
+            const DhtAddress contactId = contact->getNodeId();
+            if (!this->contactedPeers.contains(contactId) &&
+                !this->options.excludedNodeIds.contains(contactId)) {
+                result.push_back(contact);
+            }
+        }
+        return result;
+    }
+
+    void sendMoreRequests(
+        std::vector<std::shared_ptr<RoutingRemoteContact>> uncontacted) {
+        std::scoped_lock lock(this->mutex);
+        SLogger::trace("sendMoreRequests() sessionId: " + this->sessionId);
+        if (this->stopped) {
+            return;
+        }
+        if (uncontacted.empty()) {
+            this->emitFailure();
+            return;
+        }
+        size_t index = 0;
+        while (this->ongoingRequests.size() < this->options.parallelism &&
+               index < uncontacted.size() && !this->stopped) {
+            const auto nextPeer = uncontacted[index];
+            ++index;
+            const DhtAddress nodeId = nextPeer->getNodeId();
+            this->contactedPeers.insert(nodeId);
+            this->ongoingRequests.insert(nodeId);
+            this->addParallelRootIfSource(nodeId);
+            this->dispatchSend(nextPeer);
+        }
+    }
+
+    void stop() {
+        std::scoped_lock lock(this->mutex);
+        this->stopped = true;
+        this->abortController.abort();
+        this->emit<routingsessionevents::Stopped>();
+        this->removeAllListeners();
+    }
+};
+
+} // namespace streamr::dht::routing

--- a/packages/streamr-dht/modules/dht/routing/RoutingTablesCache.cppm
+++ b/packages/streamr-dht/modules/dht/routing/RoutingTablesCache.cppm
@@ -1,0 +1,184 @@
+// Module streamr.dht.RoutingTablesCache
+// Ported from packages/dht/src/dht/routing/RoutingTablesCache.ts
+// (v103.8.0-rc.3).
+//
+// A cache of per-(targetId, previousId) routing tables. Storing previousId
+// matters: it is the minimum-distance bound of the table's contacts.
+// Building a table from scratch is O(n log n) in the number of a node's
+// connections; adding/removing a single contact is O(log n)/O(1), so
+// keeping the hottest tables in memory and updating them on connect/
+// disconnect is a large win. TS uses the npm lru-cache (max 1000, 15 s
+// TTL); this file ports that with a small internal LRU-with-TTL.
+module;
+
+#include <chrono>
+#include <cstddef>
+#include <list>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+export module streamr.dht.RoutingTablesCache;
+
+import streamr.dht.Identifiers;
+import streamr.dht.RoutingRemoteContact;
+import streamr.dht.SortedContactList;
+
+export namespace streamr::dht::routing {
+
+using streamr::dht::DhtAddress;
+using streamr::dht::contact::SortedContactList;
+
+// A routing table is a distance-sorted contact list; the cache only ever
+// uses the subset of its API listed in the TS `RoutingTable` Pick type
+// (getClosestContacts / addContacts / addContact / removeContact / stop /
+// getSize).
+using RoutingTable = std::shared_ptr<SortedContactList<RoutingRemoteContact>>;
+
+namespace detail {
+
+// Minimal LRU cache with a per-entry time-to-live, matching the semantics
+// the routing cache relies on: get() refreshes recency and drops stale
+// entries; has() checks presence and staleness without reordering; the
+// least-recently-used entry is evicted once the size bound is exceeded.
+template <typename Value>
+class LruCache {
+private:
+    struct Entry {
+        std::string key;
+        Value value;
+        std::chrono::steady_clock::time_point insertedAt;
+    };
+
+    size_t maxSize;
+    std::chrono::milliseconds maxAge;
+    std::list<Entry> entries; // front = most recently used
+    std::unordered_map<std::string, typename std::list<Entry>::iterator> index;
+
+    [[nodiscard]] bool expired(
+        const Entry& entry, std::chrono::steady_clock::time_point now) const {
+        return (now - entry.insertedAt) > this->maxAge;
+    }
+
+public:
+    LruCache(size_t maxSize, std::chrono::milliseconds maxAge)
+        : maxSize(maxSize), maxAge(maxAge) {}
+
+    std::optional<Value> get(const std::string& key) {
+        const auto it = this->index.find(key);
+        if (it == this->index.end()) {
+            return std::nullopt;
+        }
+        const auto now = std::chrono::steady_clock::now();
+        if (this->expired(*it->second, now)) {
+            this->entries.erase(it->second);
+            this->index.erase(it);
+            return std::nullopt;
+        }
+        this->entries.splice(this->entries.begin(), this->entries, it->second);
+        return it->second->value;
+    }
+
+    [[nodiscard]] bool has(const std::string& key) {
+        const auto it = this->index.find(key);
+        if (it == this->index.end()) {
+            return false;
+        }
+        if (this->expired(*it->second, std::chrono::steady_clock::now())) {
+            this->entries.erase(it->second);
+            this->index.erase(it);
+            return false;
+        }
+        return true;
+    }
+
+    void set(const std::string& key, Value value) {
+        const auto now = std::chrono::steady_clock::now();
+        const auto it = this->index.find(key);
+        if (it != this->index.end()) {
+            it->second->value = std::move(value);
+            it->second->insertedAt = now;
+            this->entries.splice(
+                this->entries.begin(), this->entries, it->second);
+            return;
+        }
+        this->entries.push_front(Entry{key, std::move(value), now});
+        this->index[key] = this->entries.begin();
+        if (this->index.size() > this->maxSize) {
+            this->index.erase(this->entries.back().key);
+            this->entries.pop_back();
+        }
+    }
+
+    template <typename Fn>
+    void forEach(Fn fn) {
+        for (auto& entry : this->entries) {
+            fn(entry.value);
+        }
+    }
+
+    void clear() {
+        this->entries.clear();
+        this->index.clear();
+    }
+};
+
+} // namespace detail
+
+class RoutingTablesCache {
+private:
+    static constexpr size_t defaultMaxTables = 1000;
+    static constexpr std::chrono::milliseconds defaultMaxAge{15000};
+
+    detail::LruCache<RoutingTable> tables{defaultMaxTables, defaultMaxAge};
+
+    static std::string createRoutingTableId(
+        const DhtAddress& targetId,
+        const std::optional<DhtAddress>& previousId) {
+        return std::string(targetId) +
+            (previousId.has_value() ? std::string(previousId.value())
+                                    : std::string());
+    }
+
+public:
+    [[nodiscard]] RoutingTable get(
+        const DhtAddress& targetId,
+        const std::optional<DhtAddress>& previousId = std::nullopt) {
+        return this->tables.get(createRoutingTableId(targetId, previousId))
+            .value_or(nullptr);
+    }
+
+    void set(
+        const DhtAddress& targetId,
+        const RoutingTable& table,
+        const std::optional<DhtAddress>& previousId = std::nullopt) {
+        this->tables.set(createRoutingTableId(targetId, previousId), table);
+    }
+
+    [[nodiscard]] bool has(
+        const DhtAddress& targetId,
+        const std::optional<DhtAddress>& previousId = std::nullopt) {
+        return this->tables.has(createRoutingTableId(targetId, previousId));
+    }
+
+    void onNodeDisconnected(const DhtAddress& nodeId) {
+        this->tables.forEach([&nodeId](const RoutingTable& table) {
+            table->removeContact(nodeId);
+        });
+    }
+
+    void onNodeConnected(const std::shared_ptr<RoutingRemoteContact>& remote) {
+        this->tables.forEach([&remote](const RoutingTable& table) {
+            table->addContact(remote);
+        });
+    }
+
+    void reset() {
+        this->tables.forEach([](const RoutingTable& table) { table->stop(); });
+        this->tables.clear();
+    }
+};
+
+} // namespace streamr::dht::routing

--- a/packages/streamr-dht/modules/dht/routing/getPreviousPeer.cppm
+++ b/packages/streamr-dht/modules/dht/routing/getPreviousPeer.cppm
@@ -1,0 +1,25 @@
+// Module streamr.dht.getPreviousPeer
+// Ported from packages/dht/src/dht/routing/getPreviousPeer.ts
+// (v103.8.0-rc.3). The previous hop is the last entry appended to the
+// routed message's routingPath.
+module;
+
+#include <optional>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.getPreviousPeer;
+
+export namespace streamr::dht::routing {
+
+using ::dht::PeerDescriptor;
+using ::dht::RouteMessageWrapper;
+
+inline std::optional<PeerDescriptor> getPreviousPeer(
+    const RouteMessageWrapper& routeMessage) {
+    if (routeMessage.routingpath_size() == 0) {
+        return std::nullopt;
+    }
+    return routeMessage.routingpath(routeMessage.routingpath_size() - 1);
+}
+
+} // namespace streamr::dht::routing

--- a/packages/streamr-dht/test/integration/RouterRpcRemoteTest.cpp
+++ b/packages/streamr-dht/test/integration/RouterRpcRemoteTest.cpp
@@ -1,0 +1,113 @@
+// Ported from packages/dht/test/integration/RouterRpcRemote.test.ts
+// (v103.8.0-rc.3): two RpcCommunicators wired together, the server side
+// answering routeMessage, exercising RouterRpcRemote's happy and error
+// paths.
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <gtest/gtest.h>
+
+#include <coroutine> // IWYU pragma: keep
+
+import streamr.utils.CoroutineHelper;
+import streamr.protorpc.RpcCommunicator;
+import streamr.protorpc.protos;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.DhtCallContext;
+import streamr.dht.RouterRpcRemote;
+import streamr.dht.protos;
+import streamr.dht.TestUtils;
+
+using ::dht::Message;
+using ::dht::PeerDescriptor;
+using ::dht::RouteMessageAck;
+using ::dht::RouteMessageWrapper;
+using ::protorpc::RpcMessage;
+using streamr::dht::routing::RouterRpcRemote;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::protorpc::RpcCommunicator;
+using streamr::utils::blockingWait;
+
+using RouterRpcClient = ::dht::RouterRpcClient<DhtCallContext>;
+using RpcCommunicatorType = RpcCommunicator<DhtCallContext>;
+
+namespace {
+
+constexpr auto serviceId = "test";
+
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
+RouteMessageWrapper createRoutedMessage(
+    const PeerDescriptor& source, const PeerDescriptor& destination) {
+    Message message;
+    message.set_serviceid(serviceId);
+    message.set_messageid("routed");
+    RouteMessageWrapper routed;
+    routed.set_requestid("routed");
+    *routed.mutable_message() = message;
+    *routed.mutable_sourcepeer() = source;
+    routed.set_target(destination.nodeid());
+    return routed;
+}
+// NOLINTEND(bugprone-easily-swappable-parameters)
+
+} // namespace
+
+class RouterRpcRemoteTest : public ::testing::Test {
+protected:
+    RpcCommunicatorType clientCommunicator;
+    RpcCommunicatorType serverCommunicator;
+    PeerDescriptor clientPeerDescriptor = createMockPeerDescriptor();
+    PeerDescriptor serverPeerDescriptor = createMockPeerDescriptor();
+    bool routeMessageShouldThrow = false;
+    std::optional<RouterRpcRemote> rpcRemote;
+
+    void SetUp() override {
+        serverCommunicator
+            .registerRpcMethod<RouteMessageWrapper, RouteMessageAck>(
+                "routeMessage",
+                [this](
+                    const RouteMessageWrapper& request,
+                    const DhtCallContext& /*context*/) -> RouteMessageAck {
+                    if (this->routeMessageShouldThrow) {
+                        throw std::runtime_error("Route message error");
+                    }
+                    RouteMessageAck ack;
+                    ack.set_requestid(request.requestid());
+                    return ack;
+                });
+        this->clientCommunicator.setOutgoingMessageCallback(
+            [this](
+                const RpcMessage& message,
+                const std::string& /*requestId*/,
+                const DhtCallContext& /*context*/) {
+                this->serverCommunicator.handleIncomingMessage(
+                    message, DhtCallContext());
+            });
+        this->serverCommunicator.setOutgoingMessageCallback(
+            [this](
+                const RpcMessage& message,
+                const std::string& /*requestId*/,
+                const DhtCallContext& /*context*/) {
+                this->clientCommunicator.handleIncomingMessage(
+                    message, DhtCallContext());
+            });
+        this->rpcRemote.emplace(
+            clientPeerDescriptor,
+            serverPeerDescriptor,
+            RouterRpcClient(this->clientCommunicator));
+    }
+};
+
+TEST_F(RouterRpcRemoteTest, RouteMessageHappyPath) {
+    const bool routable = blockingWait(this->rpcRemote->routeMessage(
+        createRoutedMessage(clientPeerDescriptor, serverPeerDescriptor)));
+    EXPECT_TRUE(routable);
+}
+
+TEST_F(RouterRpcRemoteTest, RouteMessageErrorPath) {
+    this->routeMessageShouldThrow = true;
+    const bool routable = blockingWait(this->rpcRemote->routeMessage(
+        createRoutedMessage(clientPeerDescriptor, serverPeerDescriptor)));
+    EXPECT_FALSE(routable);
+}

--- a/packages/streamr-dht/test/unit/RouterTest.cpp
+++ b/packages/streamr-dht/test/unit/RouterTest.cpp
@@ -1,0 +1,228 @@
+// Ported from packages/dht/test/unit/Router.test.ts (v103.8.0-rc.3).
+//
+// Router registers its routeMessage/forwardMessage handlers on an
+// RpcCommunicator; the test drives them through a FakeRpcCommunicator that
+// invokes the registered handler by name (the TS test's FakeRpcCommunicator
+// captures the handler and calls it directly; here it goes through the real
+// server registry via handleIncomingMessage and unpacks the response ack).
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+
+import streamr.utils.Uuid;
+import streamr.protorpc.RpcCommunicator;
+import streamr.protorpc.protos;
+import streamr.dht.DhtCallContext;
+import streamr.dht.Identifiers;
+import streamr.dht.Router;
+import streamr.dht.RouterRpcLocal;
+import streamr.dht.protos;
+import streamr.dht.TestUtils;
+
+using ::dht::Message;
+using ::dht::PeerDescriptor;
+using ::dht::RouteMessageAck;
+using ::dht::RouteMessageError;
+using ::dht::RouteMessageWrapper;
+using ::protorpc::RpcMessage;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+using streamr::dht::routing::Router;
+using streamr::dht::routing::RouterOptions;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::protorpc::RpcCommunicator;
+using streamr::utils::Uuid;
+
+namespace {
+
+// A real RpcCommunicator (so Router can register on it and build remotes
+// from it) with a helper to invoke a registered handler by name and hand
+// back the unpacked response, standing in for the TS FakeRpcCommunicator.
+class FakeRpcCommunicator : public RpcCommunicator<DhtCallContext> {
+private:
+    bool capturing = false;
+    std::string captureRequestId;
+    std::optional<RpcMessage> captured;
+
+public:
+    FakeRpcCommunicator() {
+        this->setOutgoingMessageCallback(
+            [this](
+                const RpcMessage& message,
+                const std::string& /*requestId*/,
+                const DhtCallContext& /*context*/) {
+                if (this->capturing &&
+                    message.requestid() == this->captureRequestId) {
+                    this->captured = message;
+                }
+            });
+    }
+
+    template <typename Req, typename Resp>
+    Resp callRpcMethod(const std::string& methodName, const Req& request) {
+        RpcMessage requestMessage;
+        requestMessage.mutable_body()->PackFrom(request);
+        (*requestMessage.mutable_header())["method"] = methodName;
+        (*requestMessage.mutable_header())["request"] = "request";
+        requestMessage.set_requestid(Uuid::v4());
+
+        this->captured.reset();
+        this->captureRequestId = requestMessage.requestid();
+        this->capturing = true;
+        this->handleIncomingMessage(requestMessage, DhtCallContext());
+        this->capturing = false;
+
+        Resp response;
+        if (this->captured.has_value()) {
+            this->captured->body().UnpackTo(&response);
+        }
+        return response;
+    }
+};
+
+} // namespace
+
+class RouterTest : public ::testing::Test {
+protected:
+    FakeRpcCommunicator rpcCommunicator;
+    PeerDescriptor peerDescriptor1 = createMockPeerDescriptor();
+    PeerDescriptor peerDescriptor2 = createMockPeerDescriptor();
+    std::map<DhtAddress, PeerDescriptor> connections;
+    std::shared_ptr<Router> router;
+
+    [[nodiscard]] Message createMessage() const {
+        Message message;
+        message.set_serviceid("unknown");
+        message.set_messageid(Uuid::v4());
+        *message.mutable_sourcedescriptor() = this->peerDescriptor1;
+        *message.mutable_targetdescriptor() = this->peerDescriptor2;
+        return message;
+    }
+
+    // The message whose target is a third node (peerDescriptor2), i.e. this
+    // node must route it onward.
+    [[nodiscard]] RouteMessageWrapper createForwardTarget() const {
+        RouteMessageWrapper routed;
+        *routed.mutable_message() = this->createMessage();
+        routed.set_requestid(Uuid::v4());
+        routed.set_target(this->peerDescriptor2.nodeid());
+        *routed.mutable_sourcepeer() = this->peerDescriptor1;
+        return routed;
+    }
+
+    // The message whose target is this node (peerDescriptor1).
+    [[nodiscard]] RouteMessageWrapper createSelfTarget() const {
+        RouteMessageWrapper routed;
+        *routed.mutable_message() = this->createMessage();
+        routed.set_requestid("REQ");
+        routed.set_target(this->peerDescriptor1.nodeid());
+        *routed.mutable_sourcepeer() = this->peerDescriptor2;
+        return routed;
+    }
+
+    void SetUp() override {
+        this->router = Router::newInstance(
+            RouterOptions{
+                .rpcCommunicator = this->rpcCommunicator,
+                .localPeerDescriptor = this->peerDescriptor1,
+                .handleMessage = [](const Message& /*message*/) {},
+                .getConnections =
+                    [this]() {
+                        std::vector<PeerDescriptor> result;
+                        result.reserve(this->connections.size());
+                        for (const auto& [id, descriptor] : this->connections) {
+                            result.push_back(descriptor);
+                        }
+                        return result;
+                    }});
+    }
+
+    void TearDown() override {
+        if (this->router) {
+            this->router->stop();
+        }
+    }
+
+    void addConnection(const PeerDescriptor& descriptor) {
+        this->connections[Identifiers::getNodeIdFromPeerDescriptor(
+            descriptor)] = descriptor;
+    }
+
+    RouteMessageAck route(const RouteMessageWrapper& message) {
+        return this->rpcCommunicator
+            .callRpcMethod<RouteMessageWrapper, RouteMessageAck>(
+                "routeMessage", message);
+    }
+
+    RouteMessageAck forward(const RouteMessageWrapper& message) {
+        return this->rpcCommunicator
+            .callRpcMethod<RouteMessageWrapper, RouteMessageAck>(
+                "forwardMessage", message);
+    }
+};
+
+TEST_F(RouterTest, DoRouteMessageWithoutConnections) {
+    const auto ack = route(createForwardTarget());
+    ASSERT_TRUE(ack.has_error());
+    EXPECT_EQ(ack.error(), RouteMessageError::NO_TARGETS);
+}
+
+TEST_F(RouterTest, DoRouteMessageWithConnections) {
+    addConnection(peerDescriptor2);
+    const auto ack = route(createForwardTarget());
+    EXPECT_FALSE(ack.has_error());
+}
+
+TEST_F(RouterTest, DoRouteMessageWithParallelRootNodeIds) {
+    addConnection(peerDescriptor2);
+    auto message = createForwardTarget();
+    message.add_parallelrootnodeids(
+        std::string(Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor2)));
+    const auto ack = route(message);
+    ASSERT_TRUE(ack.has_error());
+    EXPECT_EQ(ack.error(), RouteMessageError::NO_TARGETS);
+}
+
+TEST_F(RouterTest, RouteServerIsDestinationWithoutConnections) {
+    const auto ack = route(createSelfTarget());
+    EXPECT_FALSE(ack.has_error());
+}
+
+TEST_F(RouterTest, RouteServerWithConnections) {
+    addConnection(peerDescriptor2);
+    const auto ack = route(createSelfTarget());
+    EXPECT_FALSE(ack.has_error());
+}
+
+TEST_F(RouterTest, RouteServerOnDuplicateMessage) {
+    const auto message = createSelfTarget();
+    router->addToDuplicateDetector(message.requestid());
+    const auto ack = route(message);
+    ASSERT_TRUE(ack.has_error());
+    EXPECT_EQ(ack.error(), RouteMessageError::DUPLICATE);
+}
+
+TEST_F(RouterTest, ForwardServerNoConnections) {
+    const auto ack = forward(createSelfTarget());
+    ASSERT_TRUE(ack.has_error());
+    EXPECT_EQ(ack.error(), RouteMessageError::NO_TARGETS);
+}
+
+TEST_F(RouterTest, ForwardServerWithConnections) {
+    addConnection(peerDescriptor2);
+    const auto ack = forward(createSelfTarget());
+    EXPECT_FALSE(ack.has_error());
+}
+
+TEST_F(RouterTest, ForwardServerOnDuplicateMessage) {
+    const auto message = createSelfTarget();
+    router->addToDuplicateDetector(message.requestid());
+    const auto ack = forward(message);
+    ASSERT_TRUE(ack.has_error());
+    EXPECT_EQ(ack.error(), RouteMessageError::DUPLICATE);
+}

--- a/packages/streamr-dht/test/unit/RoutingSessionTest.cpp
+++ b/packages/streamr-dht/test/unit/RoutingSessionTest.cpp
@@ -1,0 +1,109 @@
+// Ported from packages/dht/test/unit/RoutingSession.test.ts
+// (v103.8.0-rc.3): exercises updateAndGetRoutablePeers over the shared
+// RoutingTablesCache — the routable set tracks the node's connections and
+// the cached table is recalculated once it empties.
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+
+import streamr.utils.ExecutorHelper;
+import streamr.protorpc.RpcCommunicator;
+import streamr.protorpc.protos;
+import streamr.dht.DhtCallContext;
+import streamr.dht.Identifiers;
+import streamr.dht.RoutingSession;
+import streamr.dht.RoutingTablesCache;
+import streamr.dht.protos;
+import streamr.dht.TestUtils;
+
+using ::dht::PeerDescriptor;
+using ::dht::RouteMessageWrapper;
+using ::protorpc::RpcMessage;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+using streamr::dht::routing::RoutingMode;
+using streamr::dht::routing::RoutingSession;
+using streamr::dht::routing::RoutingSessionOptions;
+using streamr::dht::routing::RoutingTablesCache;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::protorpc::RpcCommunicator;
+
+namespace {
+constexpr size_t parallelism = 2;
+}
+
+class RoutingSessionTest : public ::testing::Test {
+protected:
+    folly::CPUThreadPoolExecutor executor{1};
+    RpcCommunicator<DhtCallContext> mockCommunicator;
+    RoutingTablesCache routingTablesCache;
+    PeerDescriptor localPeerDescriptor = createMockPeerDescriptor();
+    PeerDescriptor peer = createMockPeerDescriptor();
+    std::map<DhtAddress, PeerDescriptor> connections;
+    std::shared_ptr<RoutingSession> session;
+
+    [[nodiscard]] static DhtAddress nodeId(const PeerDescriptor& descriptor) {
+        return Identifiers::getNodeIdFromPeerDescriptor(descriptor);
+    }
+
+    void SetUp() override {
+        this->mockCommunicator.setOutgoingMessageCallback(
+            [](const RpcMessage& /*message*/,
+               const std::string& /*requestId*/,
+               const DhtCallContext& /*context*/) {});
+        RouteMessageWrapper routedMessage;
+        routedMessage.set_requestid("REQ");
+        routedMessage.set_target(this->localPeerDescriptor.nodeid());
+        *routedMessage.mutable_sourcepeer() = createMockPeerDescriptor();
+        this->session = RoutingSession::newInstance(
+            RoutingSessionOptions{
+                .rpcCommunicator = this->mockCommunicator,
+                .localPeerDescriptor = this->localPeerDescriptor,
+                .routedMessage = routedMessage,
+                .parallelism = parallelism,
+                .mode = RoutingMode::ROUTE,
+                .excludedNodeIds = std::set<DhtAddress>{},
+                .routingTablesCache = this->routingTablesCache,
+                .getConnections =
+                    [this]() {
+                        std::vector<PeerDescriptor> result;
+                        result.reserve(this->connections.size());
+                        for (const auto& [id, descriptor] : this->connections) {
+                            result.push_back(descriptor);
+                        }
+                        return result;
+                    },
+                .executor = &this->executor});
+    }
+
+    void TearDown() override {
+        if (this->session) {
+            this->session->stop();
+        }
+    }
+};
+
+TEST_F(RoutingSessionTest, FindMoreContacts) {
+    this->connections[nodeId(peer)] = peer;
+    EXPECT_EQ(this->session->updateAndGetRoutablePeers().size(), 1U);
+}
+
+TEST_F(RoutingSessionTest, FindMoreContactsPeerDisconnects) {
+    this->connections[nodeId(peer)] = peer;
+    EXPECT_EQ(this->session->updateAndGetRoutablePeers().size(), 1U);
+    this->connections.erase(nodeId(peer));
+    this->routingTablesCache.onNodeDisconnected(nodeId(peer));
+    EXPECT_EQ(this->session->updateAndGetRoutablePeers().size(), 0U);
+}
+
+TEST_F(RoutingSessionTest, RecalculatesRoutingTableIfEmpty) {
+    this->connections[nodeId(peer)] = peer;
+    EXPECT_EQ(this->session->updateAndGetRoutablePeers().size(), 1U);
+    this->routingTablesCache.onNodeDisconnected(nodeId(peer));
+    EXPECT_EQ(this->session->updateAndGetRoutablePeers().size(), 1U);
+}


### PR DESCRIPTION
Phase A4 of the trackerless-network completion plan: the DHT routing layer, ported from the pinned TS (`v103.8.0-rc.3`).

## What this adds

- **`getPreviousPeer`** — the last hop appended to a routed message's path.
- **`RouterRpcRemote` / `RouterRpcLocal`** — the client/server `RouterRpc` service (`routeMessage`, `forwardMessage`), with duplicate detection and self-target delivery.
- **`RoutingTablesCache`** — an LRU-with-TTL cache of per-`(target, previous)` routing tables, updated on connect/disconnect. TS uses the `lru-cache` npm package (max 1000, 15 s TTL); this ports it with a small internal LRU-with-TTL.
- **`RoutingRemoteContact`** — a `Contact` that also holds the per-peer `RouterRpcRemote` and `RecursiveOperationRpcRemote`.
- **`RoutingSession`** — drives a single routed message to its target, sending to up to `parallelism` contacts at a time and retrying on failure.
- **`Router`** — receives `routeMessage`/`forwardMessage` RPCs, runs a `RoutingSession` over the cached routing tables, and forwards the message.

## Structural deviations from a literal port

- **Import cycle broken.** TS's `RoutingTablesCache` imports `RoutingRemoteContact` from `RoutingSession.ts`, and `RoutingSession.ts` imports `RoutingTablesCache` — a cycle TS tolerates but C++ modules cannot. `RoutingRemoteContact` is extracted into its own module to break it.
- **`RecursiveOperationRpcRemote` pulled forward from A5.** `RoutingRemoteContact` constructs one for every contact, so `RoutingSession` can't compile without it. Only that ~45-line `RpcRemote` wrapper is pulled forward; the rest of the recursive-operation cluster stays in A5.
- **`RouteMessage.test.ts` deferred to A8.** It builds full `DhtNode`s (via `createMockConnectionDhtNode`), which aren't assembled until A8. A4 ports the other three tests.

## Worker-thread review (as requested)

The routing operations proved heavy in TS, so the goal was to keep them off the threads that serve everything else. Here is what I found and what I did:

- **Outgoing RPC sends — offloaded for free.** The `RpcCommunicator` client API owns its own `folly::CPUThreadPoolExecutor` and runs every outgoing call on it (`co_withExecutor`). So the actual `routeMessage`/`forwardMessage` network sends to next hops already run off the caller's thread — the folly machinery gives this for free, as expected.
- **Server-side routing decision — NOT free, so explicitly offloaded.** The server API (`RpcCommunicatorServerApi::handleRequest`) invokes the registered handler **inline** on the delivering thread. So the heavy part — building the routing table (`updateAndGetRoutablePeers`, O(n·log n) on a cache miss, constructing two `RpcRemote`s per connection) and deciding the ack — would run on the transport thread if left inline. The `Router` therefore owns a dedicated single-thread worker executor and dispatches **all** routing work onto it: the RPC handlers, `doRouteMessage`, the session send-completions, `onNodeConnected`/`onNodeDisconnected`, `resetCache`, and the duplicate-detector accessors. The heavy computation runs on the worker, never on the transport thread. As a bonus, because every access to the routing state (cache, sessions, forwarding table, detector) happens on that one thread, the state needs no additional locks.
- **Honest caveat.** The C++ server handler is synchronous and the ack encodes `NO_TARGETS`, so the ack depends on the routing-table computation. The handler therefore **blocks (idle-waits)** on the worker for the result. The CPU work is isolated to the worker — it can't saturate the transport/reactor threads or run concurrently across them, which is the "don't slow other parts" goal — but the individual `routeMessage` RPC does not return before the routing decision is made. Making it truly non-blocking would mean returning an early ack, changing the wire semantics, which I did not do (TS/wire compatibility wins).
- **Serialization tradeoff.** The worker is single-threaded so routing state is lock-free. This serializes routing among itself. Scaling to a pool is possible but would need finer-grained locking of the cache and sessions; this is flagged in the `Router` module header.

**Bottom line:** the heavy routing operations do run on a worker thread — partly for free (client sends), partly by explicit offload (the server-side routing decision). The single limitation is that synchronous ack semantics keep the delivery thread blocked while the worker computes.

## Tests

- **`RouterRpcRemoteTest`** (integration) — happy/error paths over two wired `RpcCommunicator`s.
- **`RoutingSessionTest`** (unit) — `updateAndGetRoutablePeers` over the cache (routable set tracks connections; table recalculates once it empties).
- **`RouterTest`** (unit) — the `routeMessage`/`forwardMessage` handler paths (no-targets, duplicate, self-target, forward-to-destination), driven through a `FakeRpcCommunicator` that invokes the registered handler and unpacks the response ack.

## Verification

- `./test.sh` — **401/401 tests pass** (14 new: 2 `RouterRpcRemoteTest`, 3 `RoutingSessionTest`, 9 `RouterTest`).
- The Router/RoutingSession tests run at `--gtest_repeat=30` with zero failures, to stress the off-thread send + cancellation paths. (A coroutine-lambda dangling-capture in the send dispatch was found and fixed with `folly::coro::co_invoke`.)
- `./lint.sh` — green across all packages.

### Lint note

`RoutingSessionTest.cpp` is excluded from `clangd-tidy` (still checked by `clang-format`): it trips the known clangd module std-type unification false positive on gtest's own `CodeLocation`/`MakeAndRegisterTestInfo`, following the existing exclusion pattern. `RouterTest.cpp` and `RouterRpcRemoteTest.cpp` import the same cluster but do not trip it, so they stay in the clangd-tidy set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)