### PR TITLE
Phase A5: recursive operations (find / fetch-data / delete-data)

### DIFF
--- a/packages/streamr-dht/CMakeLists.txt
+++ b/packages/streamr-dht/CMakeLists.txt
@@ -215,6 +215,8 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         test/unit/PeerManagerTest.cpp
         test/unit/RoutingSessionTest.cpp
         test/unit/RouterTest.cpp
+        test/unit/RecursiveOperationSessionTest.cpp
+        test/unit/RecursiveOperationManagerTest.cpp
     )
 
     target_include_directories(streamr-dht-test-unit

--- a/packages/streamr-dht/lint.sh
+++ b/packages/streamr-dht/lint.sh
@@ -42,7 +42,11 @@ echo "Running clangd-tidy on $FILES"
 # builds and runs it, and clang-format still checks it. (RouterTest.cpp and
 # RouterRpcRemoteTest.cpp import the same cluster but do NOT trip it, so
 # they stay in the clangd-tidy set.)
-TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/integration/ConnectionLockingTest.cpp' | grep -v 'test/unit/PendingConnectionTest.cpp' | grep -v 'test/unit/SimulatorTest.cpp' | grep -v 'test/integration/SimultaneousConnectionsTest.cpp' | grep -v 'test/integration/ConnectionManagerIntegrationTest.cpp' | grep -v 'test/unit/DhtNodeRpcLocalTest.cpp' | grep -v 'test/integration/DhtNodeRpcRemoteTest.cpp' | grep -v 'test/unit/RoutingSessionTest.cpp' | tr '\n' ' ')
+# RecursiveOperationSessionTest.cpp (phase A5) trips the same false positive
+# through the RecursiveOperationSession coroutine cluster; the compiler
+# builds and runs it, clang-format still checks it. (RecursiveOperation-
+# ManagerTest.cpp imports the same cluster but does NOT trip it.)
+TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/integration/ConnectionLockingTest.cpp' | grep -v 'test/unit/PendingConnectionTest.cpp' | grep -v 'test/unit/SimulatorTest.cpp' | grep -v 'test/integration/SimultaneousConnectionsTest.cpp' | grep -v 'test/integration/ConnectionManagerIntegrationTest.cpp' | grep -v 'test/unit/DhtNodeRpcLocalTest.cpp' | grep -v 'test/integration/DhtNodeRpcRemoteTest.cpp' | grep -v 'test/unit/RoutingSessionTest.cpp' | grep -v 'test/unit/RecursiveOperationSessionTest.cpp' | tr '\n' ' ')
 clangd-tidy -p "$COMPILE_DB" $TIDY_FILES
 
 echo "Running clang-format --dry-run on $FILES"

--- a/packages/streamr-dht/modules/dht/recursive-operation/RecursiveOperationManager.cppm
+++ b/packages/streamr-dht/modules/dht/recursive-operation/RecursiveOperationManager.cppm
@@ -1,0 +1,400 @@
+// Module streamr.dht.RecursiveOperationManager
+// Ported from packages/dht/src/dht/recursive-operation/
+// RecursiveOperationManager.ts (v103.8.0-rc.3). Drives recursive DHT
+// operations (find-closest-nodes, fetch-data, delete-data): it forwards a
+// routeRequest towards the target over the A4 Router (RECURSIVE mode),
+// answers with the closest connected nodes and any locally stored data,
+// and runs an initiator-side RecursiveOperationSession to collect results.
+//
+// The three Router operations are taken as callbacks (doRouteMessage /
+// isMostLikelyDuplicate / addToDuplicateDetector) rather than a Router
+// handle, matching this package's callback-options style (PeerManager,
+// DhtNodeRpcLocal, RouterRpcLocal) and letting the unit test substitute a
+// mock router.
+module;
+
+#include <coroutine> // IWYU pragma: keep
+
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.RecursiveOperationManager;
+
+import streamr.utils.CoroutineHelper;
+import streamr.utils.EnableSharedFromThis;
+import streamr.utils.waitForEvent;
+import streamr.logger.SLogger;
+import streamr.protorpc.RpcCommunicator;
+import streamr.dht.DhtCallContext;
+import streamr.dht.DhtNodeRpcRemote;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.getPeerDistance;
+import streamr.dht.Identifiers;
+import streamr.dht.ListeningRpcCommunicator;
+import streamr.dht.LocalDataStore;
+import streamr.dht.RecursiveOperationRpcLocal;
+import streamr.dht.RecursiveOperationSession;
+import streamr.dht.RecursiveOperationSessionRpcRemote;
+import streamr.dht.RouterRpcLocal;
+import streamr.dht.RoutingSession;
+import streamr.dht.SortedContactList;
+import streamr.dht.Transport;
+import streamr.dht.ConnectionsView;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+using streamr::utils::EnableSharedFromThis;
+
+export namespace streamr::dht::recursiveoperation {
+
+using ::dht::DataEntry;
+using ::dht::Message;
+using ::dht::PeerDescriptor;
+using ::dht::RecursiveOperation;
+using ::dht::RecursiveOperationRequest;
+using ::dht::RouteMessageAck;
+using ::dht::RouteMessageError;
+using ::dht::RouteMessageWrapper;
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtNodeRpcRemote;
+using streamr::dht::Identifiers;
+using streamr::dht::ServiceID;
+using streamr::dht::connection::ConnectionsView;
+using streamr::dht::contact::SortedContactList;
+using streamr::dht::contact::SortedContactListOptions;
+using streamr::dht::helpers::getPeerDistance;
+using streamr::dht::routing::createRouteMessageAck;
+using streamr::dht::routing::RoutingMode;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::store::LocalDataStore;
+using streamr::dht::transport::ListeningRpcCommunicator;
+using streamr::dht::transport::Transport;
+using streamr::protorpc::RpcCommunicator;
+using streamr::protorpc::RpcCommunicatorOptions;
+
+using RecursiveOperationSessionRpcClient =
+    ::dht::RecursiveOperationSessionRpcClient<DhtCallContext>;
+
+struct RecursiveOperationManagerOptions {
+    RpcCommunicator<DhtCallContext>& rpcCommunicator;
+    Transport& sessionTransport;
+    ConnectionsView& connectionsView;
+    PeerDescriptor localPeerDescriptor;
+    ServiceID serviceId;
+    LocalDataStore& localDataStore;
+    std::function<void(const PeerDescriptor&)> addContact;
+    std::function<std::shared_ptr<DhtNodeRpcRemote>(const PeerDescriptor&)>
+        createDhtNodeRpcRemote;
+    // The Router operations (see the module comment).
+    std::function<RouteMessageAck(
+        const RouteMessageWrapper&, RoutingMode, std::optional<DhtAddress>)>
+        doRouteMessage;
+    std::function<bool(const std::string&)> isMostLikelyDuplicate;
+    std::function<void(const std::string&)> addToDuplicateDetector;
+};
+
+class RecursiveOperationManager : public EnableSharedFromThis {
+private:
+    static constexpr size_t closestConnectedNodesCount = 5;
+    static constexpr std::chrono::milliseconds sessionRpcTimeout{10000};
+    static constexpr std::chrono::milliseconds deleteWaitTime{50};
+
+    RecursiveOperationManagerOptions options;
+    std::recursive_mutex mutex;
+    std::map<std::string, std::shared_ptr<RecursiveOperationSession>>
+        ongoingSessions;
+    bool stopped = false;
+    std::unique_ptr<RecursiveOperationRpcLocal> rpcLocal;
+
+    explicit RecursiveOperationManager(RecursiveOperationManagerOptions options)
+        : options(std::move(options)) {}
+
+    void registerLocalRpcMethods() {
+        this->rpcLocal = std::make_unique<RecursiveOperationRpcLocal>(
+            RecursiveOperationRpcLocalOptions{
+                .doRouteRequest =
+                    [this](const RouteMessageWrapper& routedMessage) {
+                        return this->doRouteRequest(
+                            routedMessage, std::nullopt);
+                    },
+                .addContact =
+                    [this](const PeerDescriptor& contact, bool /*setActive*/) {
+                        this->options.addContact(contact);
+                    },
+                .isMostLikelyDuplicate =
+                    [this](const std::string& requestId) {
+                        return this->options.isMostLikelyDuplicate(requestId);
+                    },
+                .addToDuplicateDetector =
+                    [this](const std::string& requestId) {
+                        this->options.addToDuplicateDetector(requestId);
+                    }});
+        std::weak_ptr<RecursiveOperationManager> weakSelf =
+            this->sharedFromThis<RecursiveOperationManager>();
+        this->options.rpcCommunicator
+            .template registerRpcMethod<RouteMessageWrapper, RouteMessageAck>(
+                "routeRequest",
+                [weakSelf](
+                    const RouteMessageWrapper& routedMessage,
+                    const DhtCallContext& callContext) -> RouteMessageAck {
+                    auto self = weakSelf.lock();
+                    if (!self || self->stopped) {
+                        return createRouteMessageAck(
+                            routedMessage, RouteMessageError::STOPPED);
+                    }
+                    return self->rpcLocal->routeRequest(
+                        routedMessage, callContext);
+                });
+    }
+
+    [[nodiscard]] std::vector<PeerDescriptor> getClosestConnectedNodes(
+        const DhtAddress& referenceId, size_t limit) {
+        std::vector<std::shared_ptr<DhtNodeRpcRemote>> connectedNodes;
+        for (const auto& connection :
+             this->options.connectionsView.getConnections()) {
+            connectedNodes.push_back(
+                this->options.createDhtNodeRpcRemote(connection));
+        }
+        SortedContactList<DhtNodeRpcRemote> sorted(
+            SortedContactListOptions{
+                .referenceId = referenceId,
+                .allowToContainReferenceId = true,
+                .maxSize = limit});
+        sorted.addContacts(connectedNodes);
+        std::vector<PeerDescriptor> result;
+        for (const auto& peer :
+             sorted.getClosestContacts(static_cast<int>(limit))) {
+            result.push_back(peer->getPeerDescriptor());
+        }
+        return result;
+    }
+
+    [[nodiscard]] bool isPeerCloserToIdThanSelf(
+        const PeerDescriptor& peer, const DhtAddress& nodeIdOrDataKey) {
+        const DhtAddressRaw raw =
+            Identifiers::getRawFromDhtAddress(nodeIdOrDataKey);
+        const double distance1 =
+            getPeerDistance(DhtAddressRaw{peer.nodeid()}, raw);
+        const double distance2 = getPeerDistance(
+            DhtAddressRaw{this->options.localPeerDescriptor.nodeid()}, raw);
+        return distance1 < distance2;
+    }
+
+    void sendResponse(
+        const std::vector<PeerDescriptor>& routingPath,
+        const PeerDescriptor& targetPeerDescriptor,
+        const ServiceID& serviceId,
+        const std::vector<PeerDescriptor>& closestConnectedNodes,
+        const std::vector<DataEntry>& dataEntries,
+        bool noCloserNodesFound) {
+        const bool isOwnNode = Identifiers::areEqualPeerDescriptors(
+            this->options.localPeerDescriptor, targetPeerDescriptor);
+        const auto it = this->ongoingSessions.find(serviceId);
+        if (isOwnNode && it != this->ongoingSessions.end()) {
+            it->second->onResponseReceived(
+                Identifiers::getNodeIdFromPeerDescriptor(
+                    this->options.localPeerDescriptor),
+                routingPath,
+                closestConnectedNodes,
+                dataEntries,
+                noCloserNodesFound);
+        } else {
+            ListeningRpcCommunicator remoteCommunicator(
+                ServiceID{serviceId},
+                this->options.sessionTransport,
+                RpcCommunicatorOptions{.rpcRequestTimeout = sessionRpcTimeout});
+            RecursiveOperationSessionRpcRemote rpcRemote(
+                this->options.localPeerDescriptor,
+                targetPeerDescriptor,
+                RecursiveOperationSessionRpcClient(remoteCommunicator),
+                sessionRpcTimeout);
+            rpcRemote.sendResponse(
+                routingPath,
+                closestConnectedNodes,
+                dataEntries,
+                noCloserNodesFound);
+            remoteCommunicator.destroy();
+        }
+    }
+
+    RouteMessageAck doRouteRequest(
+        const RouteMessageWrapper& routedMessage,
+        std::optional<DhtAddress> excludedPeer) {
+        std::scoped_lock lock(this->mutex);
+        if (this->stopped) {
+            return createRouteMessageAck(
+                routedMessage, RouteMessageError::STOPPED);
+        }
+        if (!routedMessage.message().has_recursiveoperationrequest()) {
+            throw std::runtime_error(
+                "routeRequest payload is not a RecursiveOperationRequest");
+        }
+        const DhtAddress targetId = Identifiers::getDhtAddressFromRaw(
+            DhtAddressRaw{routedMessage.target()});
+        const RecursiveOperationRequest& request =
+            routedMessage.message().recursiveoperationrequest();
+        const auto closestConnectedNodes = this->getClosestConnectedNodes(
+            targetId, closestConnectedNodesCount);
+        std::vector<DataEntry> dataEntries;
+        if (request.operation() == RecursiveOperation::FETCH_DATA) {
+            dataEntries = this->options.localDataStore.values(targetId);
+        }
+        if (request.operation() == RecursiveOperation::DELETE_DATA) {
+            this->options.localDataStore.markAsDeleted(
+                targetId,
+                Identifiers::getNodeIdFromPeerDescriptor(
+                    routedMessage.sourcepeer()));
+        }
+        const std::vector<PeerDescriptor> routingPath(
+            routedMessage.routingpath().begin(),
+            routedMessage.routingpath().end());
+        if (this->options.localPeerDescriptor.nodeid() ==
+            routedMessage.target()) {
+            this->sendResponse(
+                routingPath,
+                routedMessage.sourcepeer(),
+                ServiceID{request.sessionid()},
+                closestConnectedNodes,
+                dataEntries,
+                true);
+            return createRouteMessageAck(routedMessage);
+        }
+        const RouteMessageAck ack = this->options.doRouteMessage(
+            routedMessage, RoutingMode::RECURSIVE, excludedPeer);
+        if (!ack.has_error() || ack.error() == RouteMessageError::NO_TARGETS) {
+            const bool noCloserContactsFound =
+                (ack.has_error() &&
+                 ack.error() == RouteMessageError::NO_TARGETS) ||
+                (!closestConnectedNodes.empty() &&
+                 getPreviousPeer(routedMessage).has_value() &&
+                 !this->isPeerCloserToIdThanSelf(
+                     closestConnectedNodes[0], targetId));
+            this->sendResponse(
+                routingPath,
+                routedMessage.sourcepeer(),
+                ServiceID{request.sessionid()},
+                closestConnectedNodes,
+                dataEntries,
+                noCloserContactsFound);
+        }
+        return ack;
+    }
+
+public:
+    [[nodiscard]] static std::shared_ptr<RecursiveOperationManager> newInstance(
+        RecursiveOperationManagerOptions options) {
+        struct MakeSharedEnabler : public RecursiveOperationManager {
+            explicit MakeSharedEnabler(RecursiveOperationManagerOptions options)
+                : RecursiveOperationManager(std::move(options)) {}
+        };
+        auto instance = std::make_shared<MakeSharedEnabler>(std::move(options));
+        instance->registerLocalRpcMethods();
+        return instance;
+    }
+
+    ~RecursiveOperationManager() override = default;
+
+    folly::coro::Task<RecursiveOperationResult> execute(
+        DhtAddress targetId,
+        RecursiveOperation operation,
+        std::optional<DhtAddress> excludedPeer = std::nullopt,
+        bool waitForCompletion = true) {
+        {
+            std::scoped_lock lock(this->mutex);
+            if (this->stopped) {
+                co_return RecursiveOperationResult{};
+            }
+        }
+        auto self = this->sharedFromThis<RecursiveOperationManager>();
+        const size_t waitedRoutingPathCompletions =
+            this->options.connectionsView.getConnectionCount() > 1 ? 2 : 1;
+        auto session = RecursiveOperationSession::newInstance(
+            RecursiveOperationSessionOptions{
+                .transport = this->options.sessionTransport,
+                .targetId = targetId,
+                .localPeerDescriptor = this->options.localPeerDescriptor,
+                .waitedRoutingPathCompletions = waitedRoutingPathCompletions,
+                .operation = operation,
+                .doRouteRequest =
+                    [self, excludedPeer](const RouteMessageWrapper& message) {
+                        return self->doRouteRequest(message, excludedPeer);
+                    }});
+        if (this->options.connectionsView.getConnectionCount() == 0) {
+            const auto dataEntries =
+                this->options.localDataStore.values(targetId);
+            session->onResponseReceived(
+                Identifiers::getNodeIdFromPeerDescriptor(
+                    this->options.localPeerDescriptor),
+                {this->options.localPeerDescriptor},
+                {this->options.localPeerDescriptor},
+                dataEntries,
+                true);
+            co_return session->getResults();
+        }
+        {
+            std::scoped_lock lock(this->mutex);
+            this->ongoingSessions.emplace(session->getId(), session);
+        }
+        if (waitForCompletion) {
+            session->start(this->options.serviceId);
+            if (!session->isCompletionEmitted()) {
+                try {
+                    co_await streamr::utils::waitForEvent<
+                        recursiveoperationsessionevents::Completed>(
+                        session.get(), recursiveOperationTimeout);
+                } catch (const std::exception& err) {
+                    SLogger::debug("start failed " + std::string(err.what()));
+                }
+            }
+        } else {
+            session->start(this->options.serviceId);
+            // Give the router time to send the delete out.
+            co_await folly::coro::sleep(deleteWaitTime);
+        }
+        if (operation == RecursiveOperation::FETCH_DATA) {
+            const auto dataEntries =
+                this->options.localDataStore.values(targetId);
+            if (!dataEntries.empty()) {
+                this->sendResponse(
+                    {this->options.localPeerDescriptor},
+                    this->options.localPeerDescriptor,
+                    ServiceID{session->getId()},
+                    {},
+                    dataEntries,
+                    true);
+            }
+        } else if (operation == RecursiveOperation::DELETE_DATA) {
+            this->options.localDataStore.markAsDeleted(
+                targetId,
+                Identifiers::getNodeIdFromPeerDescriptor(
+                    this->options.localPeerDescriptor));
+        }
+        {
+            std::scoped_lock lock(this->mutex);
+            this->ongoingSessions.erase(session->getId());
+        }
+        session->stop();
+        co_return session->getResults();
+    }
+
+    void stop() {
+        std::scoped_lock lock(this->mutex);
+        this->stopped = true;
+        for (auto& [sessionId, session] : this->ongoingSessions) {
+            session->stop();
+        }
+        this->ongoingSessions.clear();
+    }
+};
+
+} // namespace streamr::dht::recursiveoperation

--- a/packages/streamr-dht/modules/dht/recursive-operation/RecursiveOperationRpcLocal.cppm
+++ b/packages/streamr-dht/modules/dht/recursive-operation/RecursiveOperationRpcLocal.cppm
@@ -1,0 +1,75 @@
+// Module streamr.dht.RecursiveOperationRpcLocal
+// Ported from packages/dht/src/dht/recursive-operation/
+// RecursiveOperationRpcLocal.ts (v103.8.0-rc.3). The server side of the
+// RecursiveOperationRpc service: routeRequest forwards a recursive
+// operation onward (dropping duplicates), delegating the actual routing to
+// the manager's doRouteRequest.
+module;
+
+#include <functional>
+#include <string>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.RecursiveOperationRpcLocal;
+
+import streamr.logger.SLogger;
+import streamr.dht.DhtRpcServer;
+import streamr.dht.DhtCallContext;
+import streamr.dht.Identifiers;
+import streamr.dht.RouterRpcLocal;
+import streamr.dht.getPreviousPeer;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+
+export namespace streamr::dht::recursiveoperation {
+
+using ::dht::PeerDescriptor;
+using ::dht::RouteMessageAck;
+using ::dht::RouteMessageError;
+using ::dht::RouteMessageWrapper;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+using streamr::dht::routing::createRouteMessageAck;
+using streamr::dht::routing::getPreviousPeer;
+using streamr::dht::rpcprotocol::DhtCallContext;
+
+using RecursiveOperationRpc = ::dht::RecursiveOperationRpc<DhtCallContext>;
+
+struct RecursiveOperationRpcLocalOptions {
+    std::function<RouteMessageAck(const RouteMessageWrapper&)> doRouteRequest;
+    std::function<void(const PeerDescriptor&, bool)> addContact;
+    std::function<bool(const std::string&)> isMostLikelyDuplicate;
+    std::function<void(const std::string&)> addToDuplicateDetector;
+};
+
+class RecursiveOperationRpcLocal : public RecursiveOperationRpc {
+private:
+    RecursiveOperationRpcLocalOptions options;
+
+public:
+    explicit RecursiveOperationRpcLocal(
+        RecursiveOperationRpcLocalOptions options)
+        : options(std::move(options)) {}
+
+    ~RecursiveOperationRpcLocal() override = default;
+
+    RouteMessageAck routeRequest(
+        const RouteMessageWrapper& routedMessage,
+        const DhtCallContext& /*callContext*/) override {
+        if (this->options.isMostLikelyDuplicate(routedMessage.requestid())) {
+            return createRouteMessageAck(
+                routedMessage, RouteMessageError::DUPLICATE);
+        }
+        const auto previousPeer = getPreviousPeer(routedMessage);
+        const DhtAddress remoteNodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(
+                previousPeer.has_value() ? previousPeer.value()
+                                         : routedMessage.sourcepeer());
+        SLogger::trace("Received routeRequest call from " + remoteNodeId);
+        this->options.addToDuplicateDetector(routedMessage.requestid());
+        return this->options.doRouteRequest(routedMessage);
+    }
+};
+
+} // namespace streamr::dht::recursiveoperation

--- a/packages/streamr-dht/modules/dht/recursive-operation/RecursiveOperationSession.cppm
+++ b/packages/streamr-dht/modules/dht/recursive-operation/RecursiveOperationSession.cppm
@@ -1,0 +1,351 @@
+// Module streamr.dht.RecursiveOperationSession
+// Ported from packages/dht/src/dht/recursive-operation/
+// RecursiveOperationSession.ts (v103.8.0-rc.3). The initiator's side of a
+// recursive operation: it starts the routed request, collects the
+// per-hop RecursiveOperationResponse reports (closest nodes + any data),
+// and emits `completed` once every routing path has reported back (or a
+// fallback timeout fires).
+//
+// RecursiveOperationResult is defined here (TS keeps it in
+// RecursiveOperationManager) to break the Session <-> Manager import cycle
+// that C++ modules cannot express.
+module;
+
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.RecursiveOperationSession;
+
+import streamr.eventemitter.EventEmitter;
+import streamr.utils.AbortController;
+import streamr.utils.AbortableTimers;
+import streamr.utils.EnableSharedFromThis;
+import streamr.utils.Uuid;
+import streamr.logger.SLogger;
+import streamr.protorpc.RpcCommunicator;
+import streamr.dht.Contact;
+import streamr.dht.DhtCallContext;
+import streamr.dht.Identifiers;
+import streamr.dht.ListeningRpcCommunicator;
+import streamr.dht.RecursiveOperationSessionRpcLocal;
+import streamr.dht.SortedContactList;
+import streamr.dht.Transport;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::eventemitter::Event;
+using streamr::eventemitter::EventEmitter;
+using streamr::logger::SLogger;
+using streamr::utils::AbortableTimers;
+using streamr::utils::AbortController;
+using streamr::utils::EnableSharedFromThis;
+using streamr::utils::Uuid;
+
+export namespace streamr::dht::recursiveoperation {
+
+using ::dht::DataEntry;
+using ::dht::Message;
+using ::dht::PeerDescriptor;
+using ::dht::RecursiveOperation;
+using ::dht::RecursiveOperationRequest;
+using ::dht::RouteMessageAck;
+using ::dht::RouteMessageWrapper;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+using streamr::dht::ServiceID;
+using streamr::dht::contact::Contact;
+using streamr::dht::contact::SortedContactList;
+using streamr::dht::contact::SortedContactListOptions;
+using streamr::dht::transport::ListeningRpcCommunicator;
+using streamr::dht::transport::Transport;
+using streamr::protorpc::RpcCommunicatorOptions;
+
+struct RecursiveOperationResult {
+    std::vector<PeerDescriptor> closestNodes;
+    std::vector<DataEntry> dataEntries;
+};
+
+namespace recursiveoperationsessionevents {
+struct Completed : Event<> {};
+} // namespace recursiveoperationsessionevents
+
+using RecursiveOperationSessionEvents =
+    std::tuple<recursiveoperationsessionevents::Completed>;
+
+inline constexpr std::chrono::milliseconds recursiveOperationTimeout{10000};
+
+struct RecursiveOperationSessionOptions {
+    Transport& transport;
+    DhtAddress targetId;
+    PeerDescriptor localPeerDescriptor;
+    size_t waitedRoutingPathCompletions;
+    RecursiveOperation operation;
+    std::function<RouteMessageAck(const RouteMessageWrapper&)> doRouteRequest;
+};
+
+class RecursiveOperationSession
+    : public EventEmitter<RecursiveOperationSessionEvents>,
+      public EnableSharedFromThis {
+private:
+    static constexpr int resultsMaxSize = 10;
+    static constexpr std::chrono::milliseconds noCloserNodesTimeout{4000};
+
+    RecursiveOperationSessionOptions options;
+    std::string id = Uuid::v4();
+    std::recursive_mutex mutex;
+    ListeningRpcCommunicator rpcCommunicator;
+    SortedContactList<Contact> results;
+    std::map<DhtAddress, DataEntry> foundData;
+    std::set<DhtAddress> allKnownHops;
+    std::set<DhtAddress> reportedHops;
+    std::set<DhtAddress> noCloserNodesReceivedFrom;
+    AbortController abortController; // cancels the fallback timeout on stop
+    bool completionEventEmitted = false;
+    bool timeoutScheduled = false;
+    int noCloserNodesReceivedCounter = 0;
+
+    explicit RecursiveOperationSession(RecursiveOperationSessionOptions options)
+        : options(std::move(options)),
+          rpcCommunicator(
+              ServiceID{this->id},
+              this->options.transport,
+              RpcCommunicatorOptions{
+                  .rpcRequestTimeout = recursiveOperationTimeout}),
+          results(
+              SortedContactList<Contact>(SortedContactListOptions{
+                  .referenceId = this->options.targetId,
+                  .allowToContainReferenceId = true,
+                  .maxSize = static_cast<size_t>(resultsMaxSize)})) {}
+
+    void registerLocalRpcMethods() {
+        auto rpcLocal = std::make_shared<RecursiveOperationSessionRpcLocal>(
+            RecursiveOperationSessionRpcLocalOptions{
+                .onResponseReceived =
+                    [this](
+                        const DhtAddress& remoteNodeId,
+                        const std::vector<PeerDescriptor>& routingPath,
+                        const std::vector<PeerDescriptor>&
+                            closestConnectedNodes,
+                        const std::vector<DataEntry>& dataEntries,
+                        bool noCloserNodesFound) {
+                        this->onResponseReceived(
+                            remoteNodeId,
+                            routingPath,
+                            closestConnectedNodes,
+                            dataEntries,
+                            noCloserNodesFound);
+                    }});
+        this->rpcCommunicator
+            .registerRpcNotification<::dht::RecursiveOperationResponse>(
+                "sendResponse",
+                [rpcLocal](
+                    const ::dht::RecursiveOperationResponse& request,
+                    const streamr::dht::rpcprotocol::DhtCallContext& context) {
+                    rpcLocal->sendResponse(request, context);
+                });
+    }
+
+    [[nodiscard]] bool hasNonStaleData() const {
+        for (const auto& [creator, entry] : this->foundData) {
+            if (!entry.stale()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    [[nodiscard]] bool isCompleted() const {
+        std::set<DhtAddress> unreportedHops = this->allKnownHops;
+        for (const auto& id : this->reportedHops) {
+            unreportedHops.erase(id);
+        }
+        if (this->noCloserNodesReceivedCounter >= 1 && unreportedHops.empty()) {
+            if (this->options.operation == RecursiveOperation::FETCH_DATA &&
+                (this->hasNonStaleData() ||
+                 this->noCloserNodesReceivedCounter >=
+                     static_cast<int>(
+                         this->options.waitedRoutingPathCompletions))) {
+                return true;
+            }
+            if (this->options.operation == RecursiveOperation::FETCH_DATA) {
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    void addKnownHops(const std::vector<PeerDescriptor>& routingPath) {
+        const DhtAddress localNodeId = Identifiers::getNodeIdFromPeerDescriptor(
+            this->options.localPeerDescriptor);
+        for (const auto& descriptor : routingPath) {
+            const DhtAddress newNodeId =
+                Identifiers::getNodeIdFromPeerDescriptor(descriptor);
+            if (localNodeId != newNodeId) {
+                this->allKnownHops.insert(newNodeId);
+            }
+        }
+    }
+
+    void emitCompleted() {
+        this->abortController.abort();
+        this->completionEventEmitted = true;
+        this->emit<recursiveoperationsessionevents::Completed>();
+    }
+
+    void setHopAsReported(const PeerDescriptor& descriptor) {
+        const DhtAddress localNodeId = Identifiers::getNodeIdFromPeerDescriptor(
+            this->options.localPeerDescriptor);
+        const DhtAddress newNodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(descriptor);
+        if (localNodeId != newNodeId) {
+            this->reportedHops.insert(newNodeId);
+        }
+        if (!this->completionEventEmitted && this->isCompleted()) {
+            this->emitCompleted();
+        }
+    }
+
+    static bool isNewerTimestamp(
+        const ::google::protobuf::Timestamp& candidate,
+        const ::google::protobuf::Timestamp& existing) {
+        if (candidate.seconds() != existing.seconds()) {
+            return candidate.seconds() > existing.seconds();
+        }
+        return candidate.nanos() > existing.nanos();
+    }
+
+    void processFoundData(const std::vector<DataEntry>& dataEntries) {
+        for (const auto& entry : dataEntries) {
+            const DhtAddress creatorNodeId = Identifiers::getDhtAddressFromRaw(
+                DhtAddressRaw{entry.creator()});
+            const auto it = this->foundData.find(creatorNodeId);
+            if (it == this->foundData.end() ||
+                isNewerTimestamp(entry.createdat(), it->second.createdat()) ||
+                (!isNewerTimestamp(it->second.createdat(), entry.createdat()) &&
+                 entry.deleted())) {
+                this->foundData.insert_or_assign(creatorNodeId, entry);
+            }
+        }
+    }
+
+    void onNoCloserPeersFound(const DhtAddress& remoteNodeId) {
+        this->noCloserNodesReceivedCounter += 1;
+        this->noCloserNodesReceivedFrom.insert(remoteNodeId);
+        if (this->isCompleted()) {
+            this->emitCompleted();
+        } else if (!this->timeoutScheduled && !this->completionEventEmitted) {
+            this->timeoutScheduled = true;
+            auto self = this->sharedFromThis<RecursiveOperationSession>();
+            AbortableTimers::setAbortableTimeout(
+                [self]() {
+                    std::scoped_lock lock(self->mutex);
+                    if (!self->completionEventEmitted) {
+                        self->emitCompleted();
+                    }
+                },
+                noCloserNodesTimeout,
+                this->abortController.getSignal());
+        }
+    }
+
+    RouteMessageWrapper wrapRequest(const ServiceID& serviceId) {
+        RecursiveOperationRequest request;
+        request.set_sessionid(this->id);
+        request.set_operation(this->options.operation);
+        Message msg;
+        msg.set_messageid(Uuid::v4());
+        msg.set_serviceid(serviceId);
+        *msg.mutable_recursiveoperationrequest() = request;
+        RouteMessageWrapper routeMessage;
+        *routeMessage.mutable_message() = msg;
+        routeMessage.set_requestid(Uuid::v4());
+        routeMessage.set_target(
+            Identifiers::getRawFromDhtAddress(this->options.targetId));
+        *routeMessage.mutable_sourcepeer() = this->options.localPeerDescriptor;
+        return routeMessage;
+    }
+
+public:
+    [[nodiscard]] static std::shared_ptr<RecursiveOperationSession> newInstance(
+        RecursiveOperationSessionOptions options) {
+        struct MakeSharedEnabler : public RecursiveOperationSession {
+            explicit MakeSharedEnabler(RecursiveOperationSessionOptions options)
+                : RecursiveOperationSession(std::move(options)) {}
+        };
+        auto instance = std::make_shared<MakeSharedEnabler>(std::move(options));
+        instance->registerLocalRpcMethods();
+        return instance;
+    }
+
+    ~RecursiveOperationSession() override = default;
+
+    void start(const ServiceID& serviceId) {
+        std::scoped_lock lock(this->mutex);
+        const auto routeMessage = this->wrapRequest(serviceId);
+        this->options.doRouteRequest(routeMessage);
+    }
+
+    void onResponseReceived(
+        const DhtAddress& remoteNodeId,
+        const std::vector<PeerDescriptor>& routingPath,
+        const std::vector<PeerDescriptor>& closestConnectedNodes,
+        const std::vector<DataEntry>& dataEntries,
+        bool noCloserNodesFound) {
+        std::scoped_lock lock(this->mutex);
+        this->addKnownHops(routingPath);
+        if (!routingPath.empty()) {
+            this->setHopAsReported(routingPath.back());
+        }
+        for (const auto& descriptor : closestConnectedNodes) {
+            this->results.addContact(std::make_shared<Contact>(descriptor));
+        }
+        this->processFoundData(dataEntries);
+        if (noCloserNodesFound ||
+            this->noCloserNodesReceivedFrom.contains(remoteNodeId)) {
+            this->onNoCloserPeersFound(remoteNodeId);
+        }
+    }
+
+    [[nodiscard]] RecursiveOperationResult getResults() {
+        std::scoped_lock lock(this->mutex);
+        RecursiveOperationResult result;
+        for (const auto& contact : this->results.getClosestContacts()) {
+            result.closestNodes.push_back(contact->getPeerDescriptor());
+        }
+        for (const auto& [creator, entry] : this->foundData) {
+            result.dataEntries.push_back(entry);
+        }
+        return result;
+    }
+
+    [[nodiscard]] const std::string& getId() const { return this->id; }
+
+    // Lets the manager skip waiting when start() completed synchronously
+    // (e.g. this node is the target), avoiding a missed 'completed' event.
+    [[nodiscard]] bool isCompletionEmitted() {
+        std::scoped_lock lock(this->mutex);
+        return this->completionEventEmitted;
+    }
+
+    void stop() {
+        std::scoped_lock lock(this->mutex);
+        this->abortController.abort();
+        this->rpcCommunicator.destroy();
+        if (!this->completionEventEmitted) {
+            this->completionEventEmitted = true;
+            this->emit<recursiveoperationsessionevents::Completed>();
+        }
+    }
+};
+
+} // namespace streamr::dht::recursiveoperation

--- a/packages/streamr-dht/modules/dht/recursive-operation/RecursiveOperationSessionRpcLocal.cppm
+++ b/packages/streamr-dht/modules/dht/recursive-operation/RecursiveOperationSessionRpcLocal.cppm
@@ -1,0 +1,78 @@
+// Module streamr.dht.RecursiveOperationSessionRpcLocal
+// Ported from packages/dht/src/dht/recursive-operation/
+// RecursiveOperationSessionRpcLocal.ts (v103.8.0-rc.3). The initiator's
+// session registers this to receive the per-hop RecursiveOperationResponse
+// reports.
+module;
+
+#include <functional>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.RecursiveOperationSessionRpcLocal;
+
+import streamr.logger.SLogger;
+import streamr.dht.DhtRpcServer;
+import streamr.dht.DhtCallContext;
+import streamr.dht.Identifiers;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+
+export namespace streamr::dht::recursiveoperation {
+
+using ::dht::DataEntry;
+using ::dht::PeerDescriptor;
+using ::dht::RecursiveOperationResponse;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+using streamr::dht::rpcprotocol::DhtCallContext;
+
+using RecursiveOperationSessionRpc =
+    ::dht::RecursiveOperationSessionRpc<DhtCallContext>;
+
+struct RecursiveOperationSessionRpcLocalOptions {
+    std::function<void(
+        const DhtAddress& remoteNodeId,
+        const std::vector<PeerDescriptor>& routingPath,
+        const std::vector<PeerDescriptor>& nodes,
+        const std::vector<DataEntry>& dataEntries,
+        bool noCloserNodesFound)>
+        onResponseReceived;
+};
+
+class RecursiveOperationSessionRpcLocal : public RecursiveOperationSessionRpc {
+private:
+    RecursiveOperationSessionRpcLocalOptions options;
+
+public:
+    explicit RecursiveOperationSessionRpcLocal(
+        RecursiveOperationSessionRpcLocalOptions options)
+        : options(std::move(options)) {}
+
+    ~RecursiveOperationSessionRpcLocal() override = default;
+
+    void sendResponse(
+        const RecursiveOperationResponse& report,
+        const DhtCallContext& callContext) override {
+        const DhtAddress remoteNodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(
+                callContext.incomingSourceDescriptor.value());
+        SLogger::trace("RecursiveOperationResponse arrived");
+        std::vector<PeerDescriptor> routingPath(
+            report.routingpath().begin(), report.routingpath().end());
+        std::vector<PeerDescriptor> closestConnectedNodes(
+            report.closestconnectednodes().begin(),
+            report.closestconnectednodes().end());
+        std::vector<DataEntry> dataEntries(
+            report.dataentries().begin(), report.dataentries().end());
+        this->options.onResponseReceived(
+            remoteNodeId,
+            routingPath,
+            closestConnectedNodes,
+            dataEntries,
+            report.noclosernodesfound());
+    }
+};
+
+} // namespace streamr::dht::recursiveoperation

--- a/packages/streamr-dht/modules/dht/recursive-operation/RecursiveOperationSessionRpcRemote.cppm
+++ b/packages/streamr-dht/modules/dht/recursive-operation/RecursiveOperationSessionRpcRemote.cppm
@@ -1,0 +1,79 @@
+// Module streamr.dht.RecursiveOperationSessionRpcRemote
+// Ported from packages/dht/src/dht/recursive-operation/
+// RecursiveOperationSessionRpcRemote.ts (v103.8.0-rc.3). The client used by
+// a hop to report a recursive operation's result back to the initiator's
+// session (fire-and-forget sendResponse).
+module;
+
+#include <coroutine> // IWYU pragma: keep
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.RecursiveOperationSessionRpcRemote;
+
+import streamr.utils.CoroutineHelper;
+import streamr.logger.SLogger;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.DhtCallContext;
+import streamr.dht.RpcRemote;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+
+export namespace streamr::dht::recursiveoperation {
+
+using ::dht::DataEntry;
+using ::dht::PeerDescriptor;
+using ::dht::RecursiveOperationResponse;
+using streamr::dht::contact::RpcRemote;
+using streamr::dht::rpcprotocol::DhtCallContext;
+
+using RecursiveOperationSessionRpcClient =
+    ::dht::RecursiveOperationSessionRpcClient<DhtCallContext>;
+
+class RecursiveOperationSessionRpcRemote
+    : public RpcRemote<RecursiveOperationSessionRpcClient> {
+public:
+    RecursiveOperationSessionRpcRemote(
+        PeerDescriptor localPeerDescriptor, // NOLINT
+        PeerDescriptor remotePeerDescriptor,
+        RecursiveOperationSessionRpcClient client,
+        std::optional<std::chrono::milliseconds> timeout = std::nullopt)
+        : RpcRemote<RecursiveOperationSessionRpcClient>(
+              std::move(localPeerDescriptor),
+              std::move(remotePeerDescriptor),
+              std::move(client),
+              timeout) {}
+
+    void sendResponse(
+        const std::vector<PeerDescriptor>& routingPath,
+        const std::vector<PeerDescriptor>& closestConnectedNodes,
+        const std::vector<DataEntry>& dataEntries,
+        bool noCloserNodesFound) {
+        RecursiveOperationResponse report;
+        for (const auto& peer : routingPath) {
+            *report.add_routingpath() = peer;
+        }
+        for (const auto& peer : closestConnectedNodes) {
+            *report.add_closestconnectednodes() = peer;
+        }
+        for (const auto& entry : dataEntries) {
+            *report.add_dataentries() = entry;
+        }
+        report.set_noclosernodesfound(noCloserNodesFound);
+        auto options = this->formDhtRpcOptions();
+        try {
+            streamr::utils::blockingWait(this->getClient().sendResponse(
+                std::move(report), std::move(options), this->getTimeout()));
+        } catch (const std::exception& /*err*/) {
+            SLogger::trace("Failed to send RecursiveOperationResponse");
+        }
+    }
+};
+
+} // namespace streamr::dht::recursiveoperation

--- a/packages/streamr-dht/modules/dht/store/LocalDataStore.cppm
+++ b/packages/streamr-dht/modules/dht/store/LocalDataStore.cppm
@@ -1,0 +1,140 @@
+// Module streamr.dht.LocalDataStore
+// Ported from packages/dht/src/dht/store/LocalDataStore.ts
+// (v103.8.0-rc.3).
+//
+// Pulled forward into phase A5 (the rest of the store cluster lands in A6):
+// RecursiveOperationManager reads it to answer FIND queries and the A5 unit
+// test constructs a real one. Each node can store one value per (data key,
+// creator) pair; entries expire after min(entry.ttl, maxTtl).
+module;
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.LocalDataStore;
+
+import streamr.utils.MapWithTtl;
+import streamr.dht.Identifiers;
+
+export namespace streamr::dht::store {
+
+using ::dht::DataEntry;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+using streamr::utils::MapWithTtl;
+
+class LocalDataStore {
+private:
+    uint32_t maxTtl;
+    // The outer key is the data key, the inner key is the creator's node id.
+    std::map<DhtAddress, MapWithTtl<DhtAddress, DataEntry>> store;
+
+    template <typename Timestamp>
+    [[nodiscard]] static int64_t toMillis(const Timestamp& timestamp) {
+        constexpr int64_t millisPerSecond = 1000;
+        constexpr int64_t nanosPerMilli = 1000000;
+        return (timestamp.seconds() * millisPerSecond) +
+            (timestamp.nanos() / nanosPerMilli);
+    }
+
+public:
+    explicit LocalDataStore(uint32_t maxTtl) : maxTtl(maxTtl) {}
+
+    bool storeEntry(const DataEntry& dataEntry) {
+        const DhtAddress key =
+            Identifiers::getDhtAddressFromRaw(DhtAddressRaw{dataEntry.key()});
+        const DhtAddress creatorNodeId = Identifiers::getDhtAddressFromRaw(
+            DhtAddressRaw{dataEntry.creator()});
+        if (!this->store.contains(key)) {
+            const uint32_t maxTtlCapture = this->maxTtl;
+            this->store.emplace(
+                key,
+                MapWithTtl<DhtAddress, DataEntry>(
+                    [maxTtlCapture](const DataEntry& entry) {
+                        return std::chrono::milliseconds(
+                            std::min(entry.ttl(), maxTtlCapture));
+                    }));
+        }
+        auto& inner = this->store.at(key);
+        if (inner.has(creatorNodeId)) {
+            const int64_t storedMillis = toMillis(dataEntry.createdat());
+            const int64_t oldStoredMillis =
+                toMillis(inner.get(creatorNodeId)->createdat());
+            // Do nothing if the local entry is newer than the replicated one.
+            if (oldStoredMillis >= storedMillis) {
+                return false;
+            }
+        }
+        inner.set(creatorNodeId, dataEntry);
+        return true;
+    }
+
+    bool markAsDeleted(const DhtAddress& key, const DhtAddress& creator) {
+        const auto it = this->store.find(key);
+        if (it == this->store.end() || !it->second.has(creator)) {
+            return false;
+        }
+        it->second.get(creator)->set_deleted(true);
+        return true;
+    }
+
+    [[nodiscard]] std::vector<DataEntry> values(
+        const std::optional<DhtAddress>& key = std::nullopt) {
+        std::vector<DataEntry> result;
+        if (key.has_value()) {
+            const auto it = this->store.find(key.value());
+            if (it != this->store.end()) {
+                auto entries = it->second.values();
+                result.insert(result.end(), entries.begin(), entries.end());
+            }
+        } else {
+            for (auto& [dataKey, map] : this->store) {
+                auto entries = map.values();
+                result.insert(result.end(), entries.begin(), entries.end());
+            }
+        }
+        return result;
+    }
+
+    [[nodiscard]] std::vector<DhtAddress> keys() {
+        std::vector<DhtAddress> result;
+        result.reserve(this->store.size());
+        for (const auto& [key, map] : this->store) {
+            result.push_back(key);
+        }
+        return result;
+    }
+
+    void setAllEntriesAsStale(const DhtAddress& key) {
+        const auto it = this->store.find(key);
+        if (it != this->store.end()) {
+            it->second.forEach(
+                [](DataEntry& value, const DhtAddress& /*creator*/) {
+                    value.set_stale(true);
+                });
+        }
+    }
+
+    void deleteEntry(const DhtAddress& key, const DhtAddress& creator) {
+        const auto it = this->store.find(key);
+        if (it != this->store.end() && it->second.get(creator) != nullptr) {
+            it->second.remove(creator);
+            if (it->second.size() == 0) {
+                this->store.erase(it);
+            }
+        }
+    }
+
+    void clear() {
+        for (auto& [key, map] : this->store) {
+            map.clear();
+        }
+        this->store.clear();
+    }
+};
+
+} // namespace streamr::dht::store

--- a/packages/streamr-dht/test/unit/RecursiveOperationManagerTest.cpp
+++ b/packages/streamr-dht/test/unit/RecursiveOperationManagerTest.cpp
@@ -1,0 +1,279 @@
+// Ported from packages/dht/test/unit/RecursiveOperationManager.test.ts
+// (v103.8.0-rc.3): exercises the routeRequest server path (success,
+// no-targets, duplicate, bad-payload) and the no-connections execute path.
+// The Router is substituted by callbacks (the C++ Router is concrete);
+// MockTransport / MockConnectionsView stand in for the transport.
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+
+#include <coroutine> // IWYU pragma: keep
+
+import streamr.utils.CoroutineHelper;
+import streamr.utils.Uuid;
+import streamr.protorpc.RpcCommunicator;
+import streamr.protorpc.protos;
+import streamr.dht.ConnectionsView;
+import streamr.dht.DhtCallContext;
+import streamr.dht.DhtNodeRpcRemote;
+import streamr.dht.Identifiers;
+import streamr.dht.LocalDataStore;
+import streamr.dht.RecursiveOperationManager;
+import streamr.dht.RoutingSession;
+import streamr.dht.Transport;
+import streamr.dht.protos;
+import streamr.dht.TestUtils;
+
+using ::dht::Message;
+using ::dht::PeerDescriptor;
+using ::dht::RecursiveOperation;
+using ::dht::RecursiveOperationRequest;
+using ::dht::RouteMessageAck;
+using ::dht::RouteMessageError;
+using ::dht::RouteMessageWrapper;
+using ::protorpc::RpcMessage;
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtNodeRpcRemote;
+using streamr::dht::Identifiers;
+using streamr::dht::ServiceID;
+using streamr::dht::connection::ConnectionsView;
+using streamr::dht::recursiveoperation::RecursiveOperationManager;
+using streamr::dht::recursiveoperation::RecursiveOperationManagerOptions;
+using streamr::dht::routing::RoutingMode;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::store::LocalDataStore;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::dht::testutils::createWrappedClosestPeersRequest;
+using streamr::dht::transport::SendOptions;
+using streamr::dht::transport::Transport;
+using streamr::protorpc::RpcCommunicator;
+using streamr::utils::blockingWait;
+using streamr::utils::Uuid;
+
+namespace {
+
+constexpr uint32_t maxTtl = 3000;
+
+// A real RpcCommunicator with a helper to invoke a registered handler by
+// name; surfaces a handler exception as a thrown error (the response
+// carries errorType).
+class FakeRpcCommunicator : public RpcCommunicator<DhtCallContext> {
+private:
+    bool capturing = false;
+    std::string captureRequestId;
+    std::optional<RpcMessage> captured;
+
+public:
+    FakeRpcCommunicator() {
+        this->setOutgoingMessageCallback(
+            [this](
+                const RpcMessage& message,
+                const std::string& /*requestId*/,
+                const DhtCallContext& /*context*/) {
+                if (this->capturing &&
+                    message.requestid() == this->captureRequestId) {
+                    this->captured = message;
+                }
+            });
+    }
+
+    template <typename Req, typename Resp>
+    Resp callRpcMethod(const std::string& methodName, const Req& request) {
+        RpcMessage requestMessage;
+        requestMessage.mutable_body()->PackFrom(request);
+        (*requestMessage.mutable_header())["method"] = methodName;
+        (*requestMessage.mutable_header())["request"] = "request";
+        requestMessage.set_requestid(Uuid::v4());
+        this->captured.reset();
+        this->captureRequestId = requestMessage.requestid();
+        this->capturing = true;
+        this->handleIncomingMessage(requestMessage, DhtCallContext());
+        this->capturing = false;
+        Resp response;
+        if (this->captured.has_value()) {
+            if (this->captured->has_errortype()) {
+                throw std::runtime_error("RPC handler returned an error");
+            }
+            this->captured->body().UnpackTo(&response);
+        }
+        return response;
+    }
+};
+
+class MockTransport : public Transport {
+public:
+    size_t sendCount = 0;
+    PeerDescriptor localPeerDescriptor = createMockPeerDescriptor();
+
+    void send(const Message& /*msg*/, const SendOptions& /*opts*/) override {
+        ++this->sendCount;
+    }
+    [[nodiscard]] PeerDescriptor getLocalPeerDescriptor() const override {
+        return this->localPeerDescriptor;
+    }
+    void stop() override {}
+};
+
+class MockConnectionsView : public ConnectionsView {
+public:
+    [[nodiscard]] std::vector<PeerDescriptor> getConnections() override {
+        return {};
+    }
+    [[nodiscard]] size_t getConnectionCount() override { return 0; }
+    [[nodiscard]] bool hasConnection(const DhtAddress& /*id*/) override {
+        return false;
+    }
+};
+
+} // namespace
+
+class RecursiveOperationManagerTest : public ::testing::Test {
+protected:
+    FakeRpcCommunicator rpcCommunicator;
+    MockTransport transport;
+    MockConnectionsView connectionsView;
+    LocalDataStore localDataStore{maxTtl};
+    PeerDescriptor peerDescriptor1 = createMockPeerDescriptor();
+    PeerDescriptor peerDescriptor2 = createMockPeerDescriptor();
+
+    using RouteFn = std::function<RouteMessageAck(
+        const RouteMessageWrapper&, RoutingMode, std::optional<DhtAddress>)>;
+
+    [[nodiscard]] Message createMessage() const {
+        RecursiveOperationRequest request;
+        request.set_operation(RecursiveOperation::FIND_CLOSEST_NODES);
+        request.set_sessionid(Uuid::v4());
+        Message message;
+        message.set_serviceid("unknown");
+        message.set_messageid(Uuid::v4());
+        *message.mutable_recursiveoperationrequest() = request;
+        *message.mutable_sourcedescriptor() = this->peerDescriptor1;
+        *message.mutable_targetdescriptor() = this->peerDescriptor2;
+        return message;
+    }
+
+    [[nodiscard]] RouteMessageWrapper createRoutedMessage() const {
+        RouteMessageWrapper routed;
+        *routed.mutable_message() = this->createMessage();
+        routed.set_requestid("REQ");
+        *routed.mutable_sourcepeer() = this->peerDescriptor1;
+        routed.set_target(this->peerDescriptor2.nodeid());
+        return routed;
+    }
+
+    [[nodiscard]] std::shared_ptr<RecursiveOperationManager> makeManager(
+        RouteFn doRouteMessage) {
+        return RecursiveOperationManager::newInstance(
+            RecursiveOperationManagerOptions{
+                .rpcCommunicator = this->rpcCommunicator,
+                .sessionTransport = this->transport,
+                .connectionsView = this->connectionsView,
+                .localPeerDescriptor = this->peerDescriptor1,
+                .serviceId = ServiceID{"RecursiveOperationManager"},
+                .localDataStore = this->localDataStore,
+                .addContact = [](const PeerDescriptor& /*contact*/) {},
+                .createDhtNodeRpcRemote =
+                    [](const PeerDescriptor& /*peerDescriptor*/)
+                    -> std::shared_ptr<DhtNodeRpcRemote> { return nullptr; },
+                .doRouteMessage = std::move(doRouteMessage),
+                .isMostLikelyDuplicate =
+                    [](const std::string& /*requestId*/) { return false; },
+                .addToDuplicateDetector =
+                    [](const std::string& /*requestId*/) {}});
+    }
+
+    // The default mock router: an empty ack (no error).
+    [[nodiscard]] std::shared_ptr<RecursiveOperationManager> makeManager() {
+        return this->makeManager(
+            [](const RouteMessageWrapper& /*message*/,
+               RoutingMode /*mode*/,
+               const std::optional<DhtAddress>& /*excludedPeer*/) {
+                return RouteMessageAck{};
+            });
+    }
+
+    // A mock router whose doRouteMessage returns the given error.
+    [[nodiscard]] static RouteFn routerReturning(RouteMessageError error) {
+        return [error](
+                   const RouteMessageWrapper& message,
+                   RoutingMode /*mode*/,
+                   const std::optional<DhtAddress>& /*excludedPeer*/) {
+            RouteMessageAck ack;
+            ack.set_requestid(message.requestid());
+            ack.set_error(error);
+            return ack;
+        };
+    }
+};
+
+TEST_F(RecursiveOperationManagerTest, Server) {
+    auto manager = this->makeManager();
+    const auto ack = this->rpcCommunicator
+                         .callRpcMethod<RouteMessageWrapper, RouteMessageAck>(
+                             "routeRequest", this->createRoutedMessage());
+    EXPECT_FALSE(ack.has_error());
+    manager->stop();
+}
+
+TEST_F(RecursiveOperationManagerTest, FindClosestNodesReturnsSelfIfNoPeers) {
+    auto manager = this->makeManager();
+    const auto result = blockingWait(manager->execute(
+        Identifiers::createRandomDhtAddress(),
+        RecursiveOperation::FIND_CLOSEST_NODES));
+    ASSERT_FALSE(result.closestNodes.empty());
+    EXPECT_TRUE(
+        Identifiers::areEqualPeerDescriptors(
+            result.closestNodes[0], this->peerDescriptor1));
+    manager->stop();
+}
+
+TEST_F(RecursiveOperationManagerTest, ServerThrowsIfPayloadNotRecursive) {
+    auto manager = this->makeManager();
+    Message badMessage;
+    badMessage.set_serviceid("unknown");
+    badMessage.set_messageid(Uuid::v4());
+    *badMessage.mutable_rpcmessage() =
+        createWrappedClosestPeersRequest(this->peerDescriptor1);
+    *badMessage.mutable_sourcedescriptor() = this->peerDescriptor2;
+    *badMessage.mutable_targetdescriptor() = this->peerDescriptor2;
+    RouteMessageWrapper routed;
+    *routed.mutable_message() = badMessage;
+    routed.set_requestid("REQ");
+    *routed.mutable_sourcepeer() = this->peerDescriptor2;
+    routed.set_target(this->peerDescriptor1.nodeid());
+    EXPECT_THROW(
+        (this->rpcCommunicator
+             .callRpcMethod<RouteMessageWrapper, RouteMessageAck>(
+                 "routeRequest", routed)),
+        std::exception);
+    manager->stop();
+}
+
+TEST_F(RecursiveOperationManagerTest, NoTargets) {
+    auto manager =
+        this->makeManager(routerReturning(RouteMessageError::NO_TARGETS));
+    const auto ack = this->rpcCommunicator
+                         .callRpcMethod<RouteMessageWrapper, RouteMessageAck>(
+                             "routeRequest", this->createRoutedMessage());
+    ASSERT_TRUE(ack.has_error());
+    EXPECT_EQ(ack.error(), RouteMessageError::NO_TARGETS);
+    EXPECT_EQ(this->transport.sendCount, 1U);
+    manager->stop();
+}
+
+TEST_F(RecursiveOperationManagerTest, Error) {
+    auto manager =
+        this->makeManager(routerReturning(RouteMessageError::DUPLICATE));
+    const auto ack = this->rpcCommunicator
+                         .callRpcMethod<RouteMessageWrapper, RouteMessageAck>(
+                             "routeRequest", this->createRoutedMessage());
+    ASSERT_TRUE(ack.has_error());
+    EXPECT_EQ(ack.error(), RouteMessageError::DUPLICATE);
+    EXPECT_EQ(this->transport.sendCount, 0U);
+    manager->stop();
+}

--- a/packages/streamr-dht/test/unit/RecursiveOperationSessionTest.cpp
+++ b/packages/streamr-dht/test/unit/RecursiveOperationSessionTest.cpp
@@ -1,0 +1,110 @@
+// Ported from packages/dht/test/unit/RecursiveOperationSession.test.ts
+// (v103.8.0-rc.3): the initiator session collects sendResponse reports over
+// a FakeEnvironment network and completes (here via the fallback timeout),
+// exposing the union of the reported closest nodes.
+#include <cstddef>
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+
+#include <coroutine> // IWYU pragma: keep
+
+import streamr.utils.CoroutineHelper;
+import streamr.utils.waitForCondition;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.DhtCallContext;
+import streamr.dht.FakeTransport;
+import streamr.dht.Identifiers;
+import streamr.dht.RecursiveOperationSession;
+import streamr.dht.RecursiveOperationSessionRpcRemote;
+import streamr.dht.RoutingRpcCommunicator;
+import streamr.dht.protos;
+import streamr.dht.TestUtils;
+
+using ::dht::Message;
+using ::dht::PeerDescriptor;
+using ::dht::RecursiveOperation;
+using ::dht::RouteMessageAck;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+using streamr::dht::ServiceID;
+using streamr::dht::recursiveoperation::RecursiveOperationSession;
+using streamr::dht::recursiveoperation::RecursiveOperationSessionOptions;
+using streamr::dht::recursiveoperation::RecursiveOperationSessionRpcRemote;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::dht::transport::FakeEnvironment;
+using streamr::dht::transport::RoutingRpcCommunicator;
+using streamr::dht::transport::SendOptions;
+using streamr::utils::blockingWait;
+using streamr::utils::waitForCondition;
+
+using RecursiveOperationSessionRpcClient =
+    ::dht::RecursiveOperationSessionRpcClient<DhtCallContext>;
+
+namespace {
+constexpr size_t waitedCompletions = 3;
+constexpr size_t responseCount = 3;
+constexpr size_t nodesPerResponse = 2;
+} // namespace
+
+class RecursiveOperationSessionTest : public ::testing::Test {
+protected:
+    FakeEnvironment environment;
+    PeerDescriptor localPeerDescriptor = createMockPeerDescriptor();
+    bool doRouteRequestCalled = false;
+    std::shared_ptr<RecursiveOperationSession> session;
+
+    void sendResponseFrom(const ServiceID& serviceId) {
+        const auto mockPeerDescriptor = createMockPeerDescriptor();
+        auto transport = this->environment.createTransport(mockPeerDescriptor);
+        RoutingRpcCommunicator communicator(
+            ServiceID{serviceId},
+            [transport](const Message& message, const SendOptions& opts) {
+                transport->send(message, opts);
+            });
+        RecursiveOperationSessionRpcRemote remote(
+            mockPeerDescriptor,
+            this->localPeerDescriptor,
+            RecursiveOperationSessionRpcClient(communicator));
+        remote.sendResponse(
+            {createMockPeerDescriptor(), createMockPeerDescriptor()},
+            {createMockPeerDescriptor(), createMockPeerDescriptor()},
+            {},
+            true);
+    }
+
+    void TearDown() override {
+        if (this->session) {
+            this->session->stop();
+        }
+    }
+};
+
+TEST_F(RecursiveOperationSessionTest, HappyPath) {
+    this->session = RecursiveOperationSession::newInstance(
+        RecursiveOperationSessionOptions{
+            .transport =
+                *this->environment.createTransport(localPeerDescriptor),
+            .targetId = Identifiers::createRandomDhtAddress(),
+            .localPeerDescriptor = this->localPeerDescriptor,
+            .waitedRoutingPathCompletions = waitedCompletions,
+            .operation = RecursiveOperation::FIND_CLOSEST_NODES,
+            .doRouteRequest =
+                [this](const ::dht::RouteMessageWrapper& /*message*/) {
+                    this->doRouteRequestCalled = true;
+                    return RouteMessageAck{};
+                }});
+
+    this->session->start(ServiceID{""});
+    EXPECT_TRUE(this->doRouteRequestCalled);
+    for (size_t i = 0; i < responseCount; ++i) {
+        this->sendResponseFrom(ServiceID{this->session->getId()});
+    }
+
+    blockingWait(waitForCondition(
+        [this]() { return this->session->isCompletionEmitted(); }));
+    const auto result = this->session->getResults();
+    EXPECT_EQ(result.closestNodes.size(), responseCount * nodesPerResponse);
+    EXPECT_TRUE(result.dataEntries.empty());
+}

--- a/packages/streamr-utils/modules/MapWithTtl.cppm
+++ b/packages/streamr-utils/modules/MapWithTtl.cppm
@@ -1,0 +1,128 @@
+// Module streamr.utils.MapWithTtl
+// Ported from packages/utils/src/MapWithTtl.ts. A map whose entries expire
+// getTtl(value) milliseconds after they are set.
+//
+// TS removes each entry with its own setTimeout. This C++ port expires
+// lazily — an entry past its deadline is dropped the next time the map is
+// touched — which keeps the same observable behaviour (get/has/values/
+// size/forEach/keys never surface an expired entry) without the lifetime
+// hazard of a per-entry timer callback capturing a map that is not owned
+// through a shared_ptr.
+module;
+
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <utility>
+#include <vector>
+
+export module streamr.utils.MapWithTtl;
+
+export namespace streamr::utils {
+
+template <typename K, typename V>
+class MapWithTtl {
+private:
+    struct ValueWrapper {
+        V value;
+        std::chrono::steady_clock::time_point expiresAt;
+    };
+
+    std::map<K, ValueWrapper> delegate;
+    std::function<std::chrono::milliseconds(const V&)> getTtl;
+
+    [[nodiscard]] static bool expired(
+        const ValueWrapper& wrapper,
+        std::chrono::steady_clock::time_point now) {
+        return now >= wrapper.expiresAt;
+    }
+
+    void purgeExpired() {
+        const auto now = std::chrono::steady_clock::now();
+        for (auto it = this->delegate.begin(); it != this->delegate.end();) {
+            if (expired(it->second, now)) {
+                it = this->delegate.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+public:
+    explicit MapWithTtl(
+        std::function<std::chrono::milliseconds(const V&)> getTtl)
+        : getTtl(std::move(getTtl)) {}
+
+    void set(const K& key, const V& value) {
+        const auto now = std::chrono::steady_clock::now();
+        this->delegate.insert_or_assign(
+            key, ValueWrapper{value, now + this->getTtl(value)});
+    }
+
+    // Returns a pointer to the stored value (so callers can mutate it, as
+    // the TS callers do), or nullptr if the key is absent or expired.
+    [[nodiscard]] V* get(const K& key) {
+        const auto it = this->delegate.find(key);
+        if (it == this->delegate.end()) {
+            return nullptr;
+        }
+        if (expired(it->second, std::chrono::steady_clock::now())) {
+            this->delegate.erase(it);
+            return nullptr;
+        }
+        return &it->second.value;
+    }
+
+    [[nodiscard]] bool has(const K& key) {
+        const auto it = this->delegate.find(key);
+        if (it == this->delegate.end()) {
+            return false;
+        }
+        if (expired(it->second, std::chrono::steady_clock::now())) {
+            this->delegate.erase(it);
+            return false;
+        }
+        return true;
+    }
+
+    // Named remove() rather than delete() (a C++ keyword).
+    void remove(const K& key) { this->delegate.erase(key); }
+
+    void clear() { this->delegate.clear(); }
+
+    [[nodiscard]] size_t size() {
+        this->purgeExpired();
+        return this->delegate.size();
+    }
+
+    [[nodiscard]] std::vector<V> values() {
+        this->purgeExpired();
+        std::vector<V> result;
+        result.reserve(this->delegate.size());
+        for (const auto& [key, wrapper] : this->delegate) {
+            result.push_back(wrapper.value);
+        }
+        return result;
+    }
+
+    [[nodiscard]] std::vector<K> keys() {
+        this->purgeExpired();
+        std::vector<K> result;
+        result.reserve(this->delegate.size());
+        for (const auto& [key, wrapper] : this->delegate) {
+            result.push_back(key);
+        }
+        return result;
+    }
+
+    template <typename Fn>
+    void forEach(Fn callback) {
+        this->purgeExpired();
+        for (auto& [key, wrapper] : this->delegate) {
+            callback(wrapper.value, key);
+        }
+    }
+};
+
+} // namespace streamr::utils


### PR DESCRIPTION
Phase A5 of the trackerless-network completion plan: the recursive-operation cluster, ported from the pinned TS (`v103.8.0-rc.3`).

## What this adds

- **`RecursiveOperationRpcLocal`** — server side of `routeRequest` (drops duplicates, delegates routing to the manager).
- **`RecursiveOperationSessionRpcLocal` / `RecursiveOperationSessionRpcRemote`** — the per-hop `sendResponse` report channel back to the initiator's session.
- **`RecursiveOperationSession`** — the initiator side: starts the routed request, collects the closest-nodes / data reports, and emits `completed` once every routing path has reported (or a fallback timeout fires).
- **`RecursiveOperationManager`** — drives find-closest-nodes / fetch-data / delete-data over the A4 `Router` (RECURSIVE mode), answering with the closest connected nodes and any locally stored data.

(`RecursiveOperationRpcRemote` was already pulled forward in A4.)

## Pulled forward (rest of the cluster lands later)

- **`MapWithTtl`** (streamr-utils) — a map whose entries expire after a per-entry TTL. TS removes each entry with its own `setTimeout`; this port **expires lazily** (an entry past its deadline is dropped the next time the map is touched) to avoid the lifetime hazard of a timer callback capturing a map that is not owned through a `shared_ptr`. Observable behaviour is identical (`get`/`has`/`values`/`size`/`forEach`/`keys` never surface an expired entry). Exercised here via `LocalDataStore`; its own timer-based test is left for the utils/A6 pass.
- **`LocalDataStore`** (streamr-dht `store/`, nominally A6) — one value per `(data key, creator)`; `RecursiveOperationManager` reads it to answer FIND and the unit test constructs a real one. The rest of the store cluster (`StoreManager`, `StoreRpc*`) stays in A6.

## Design notes

- **Import cycle broken**: `RecursiveOperationResult` is defined in `RecursiveOperationSession` (TS keeps it in the manager) so `Session` doesn't import `Manager` while `Manager` imports `Session` — a cycle C++ modules can't express.
- **Router passed as callbacks**: the three Router operations (`doRouteMessage` / `isMostLikelyDuplicate` / `addToDuplicateDetector`) are options callbacks rather than a `Router` handle — matching this package's callback-options style (PeerManager, DhtNodeRpcLocal, RouterRpcLocal) and letting the unit test substitute a mock router (the C++ `Router` is a concrete class). The delivery-thread worker-offload follow-up filed in A4 applies unchanged: the manager routes through the A4 Router's worker, so no new threading decision here.

## Tests (ported from the matching TS tests)

- **`RecursiveOperationSessionTest`** (unit) — collects `sendResponse` reports over a `FakeEnvironment` network and completes via the fallback timeout (~4 s, matching the TS test's `until` on the same timeout).
- **`RecursiveOperationManagerTest`** (unit) — the `routeRequest` server paths (success / no-targets / duplicate / bad-payload) and the no-connections `execute` path, driven through a `FakeRpcCommunicator` plus mock router / transport / connections-view.

`Find.test.ts` is **deferred to A8** — it builds full `DhtNode`s over the Simulator, which aren't assembled until then.

## Verification

- `./test.sh` — **407/407 tests pass** (6 new).
- `./lint.sh` — green across all packages (including streamr-utils with the new `MapWithTtl`).

### Lint note

`RecursiveOperationSessionTest.cpp` is excluded from `clangd-tidy` (still checked by `clang-format`): it trips the known clangd module std-type unification false positive on gtest's own `CodeLocation` / `MakeAndRegisterTestInfo`, following the existing exclusion pattern. `RecursiveOperationManagerTest.cpp` imports the same cluster but does not trip it, so it stays in the clangd-tidy set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)