### PR TITLE
proto-rpc: async server handlers; route off the delivery thread (A4 follow-up)

### DIFF
--- a/packages/streamr-dht/modules/dht/routing/Router.cppm
+++ b/packages/streamr-dht/modules/dht/routing/Router.cppm
@@ -6,18 +6,27 @@
 //
 // C++ threading (the routing operations proved heavy in TS): the Router
 // owns a dedicated single-thread worker executor and runs ALL routing work
-// on it — the RPC handlers hop onto the worker and block for the ack, the
-// session send-completions resume on the worker, and the cross-thread
-// entry points (onNodeConnected/Disconnected, resetCache, stop, the
-// duplicate-detector accessors) dispatch onto it too. Because every access
-// to the routing state (routing-tables cache, ongoing sessions, forwarding
-// table, duplicate detector) happens on that one worker thread, the state
-// needs no additional locks, and the heavy routing computation never runs
-// on the transport/RPC delivery thread. (Server-side RPC handlers run
-// inline on the delivering thread, so this offload is not free — see the
-// worker-thread note in the phase A4 PR.) A single worker serializes
-// routing; scaling it to a pool would require finer-grained locking of the
-// cache and sessions.
+// on it — the routeMessage/forwardMessage RPC handlers co_await onto the
+// worker (async, see below), the session send-completions resume on the
+// worker, and the cross-thread entry points (onNodeConnected/Disconnected,
+// resetCache, stop, the duplicate-detector accessors) dispatch onto it too.
+// Because every access to the routing state (routing-tables cache, ongoing
+// sessions, forwarding table, duplicate detector) happens on that one
+// worker thread, the state needs no additional locks, and the heavy routing
+// computation never runs on the transport/RPC delivery thread. A single
+// worker serializes routing; scaling it to a pool would require finer-
+// grained locking of the cache and sessions.
+//
+// Follow-up to Phase A4 (owner priority model — our own traffic is
+// priority 1, routing is best-effort "whenever we have time"): the
+// routeMessage/forwardMessage handlers are registered as ASYNC proto-rpc
+// handlers (registerRpcMethodAsync) that co_await the routing worker
+// instead of blockingWait-ing on it. The delivery coroutine therefore
+// SUSPENDS (it does not block) and the shared delivery thread returns to
+// our own incoming traffic immediately; the ack is produced on the worker
+// and sent later. The worker is additionally given a low OS thread priority
+// (a positive nice value, best-effort per-platform) so routing yields the
+// CPU to our own work under contention.
 module;
 
 #include <coroutine> // IWYU pragma: keep
@@ -87,6 +96,12 @@ private:
     static constexpr size_t duplicateDetectorSize = 10000;
     static constexpr std::chrono::milliseconds forwardingEntryTtl{10000};
     static constexpr std::chrono::milliseconds sessionTimeout{10000};
+    // Nice value for the routing worker thread: a positive value lowers its
+    // OS priority so routing runs "whenever we have time" relative to our
+    // own traffic. Lowering priority (raising nice) is unprivileged; the
+    // effect is best-effort per platform (honoured on Linux/Android, weaker
+    // on Darwin, where per-thread nice is not fully applied).
+    static constexpr int routingWorkerThreadNice = 10;
 
     struct ForwardingTableEntry {
         std::vector<PeerDescriptor> peerDescriptors;
@@ -94,7 +109,11 @@ private:
     };
 
     RouterOptions options;
-    folly::CPUThreadPoolExecutor routingExecutor{routingWorkerThreadCount};
+    folly::CPUThreadPoolExecutor routingExecutor{
+        routingWorkerThreadCount,
+        std::make_shared<folly::PriorityThreadFactory>(
+            std::make_shared<folly::NamedThreadFactory>("DhtRouting"),
+            routingWorkerThreadNice)};
     AbortController abortController; // cancels the session-cleanup timeouts
     std::map<DhtAddress, ForwardingTableEntry> forwardingTable;
     RoutingTablesCache routingTablesCache;
@@ -143,48 +162,68 @@ private:
                 .localPeerDescriptor = this->options.localPeerDescriptor});
 
         std::weak_ptr<Router> weakSelf = this->sharedFromThis<Router>();
-        this->options.rpcCommunicator
-            .template registerRpcMethod<RouteMessageWrapper, RouteMessageAck>(
-                "routeMessage",
-                [weakSelf](
-                    const RouteMessageWrapper& routedMessage,
-                    const DhtCallContext& callContext) -> RouteMessageAck {
-                    auto self = weakSelf.lock();
-                    if (!self) {
-                        return createRouteMessageAck(
-                            routedMessage, RouteMessageError::STOPPED);
-                    }
-                    return self->runOnWorker(
-                        [&self, &routedMessage, &callContext]() {
+        // routeMessage/forwardMessage are async handlers: they co_await the
+        // routing worker so the delivery coroutine SUSPENDS (does not block
+        // the shared delivery thread) until the ack is ready. `self` (a
+        // shared_ptr held in the coroutine frame) keeps the Router and its
+        // routingExecutor alive across the suspension. The inner worker task
+        // captures its inputs by value, so it is independent of the outer
+        // frame. Wire semantics are unchanged from the previous blocking
+        // handlers (same STOPPED / NO_TARGETS / DUPLICATE acks).
+        this->options.rpcCommunicator.template registerRpcMethodAsync<
+            RouteMessageWrapper,
+            RouteMessageAck>(
+            "routeMessage",
+            [weakSelf](
+                const RouteMessageWrapper& routedMessage,
+                const DhtCallContext& callContext)
+                -> folly::coro::Task<RouteMessageAck> {
+                auto self = weakSelf.lock();
+                if (!self) {
+                    co_return createRouteMessageAck(
+                        routedMessage, RouteMessageError::STOPPED);
+                }
+                co_return co_await streamr::utils::co_withExecutor(
+                    &self->routingExecutor,
+                    folly::coro::co_invoke(
+                        [self,
+                         routedMessage,
+                         callContext]() -> folly::coro::Task<RouteMessageAck> {
                             if (self->stopped) {
-                                return createRouteMessageAck(
+                                co_return createRouteMessageAck(
                                     routedMessage, RouteMessageError::STOPPED);
                             }
-                            return self->routerRpcLocal->routeMessage(
+                            co_return self->routerRpcLocal->routeMessage(
                                 routedMessage, callContext);
-                        });
-                });
-        this->options.rpcCommunicator
-            .template registerRpcMethod<RouteMessageWrapper, RouteMessageAck>(
-                "forwardMessage",
-                [weakSelf](
-                    const RouteMessageWrapper& forwardMessage,
-                    const DhtCallContext& callContext) -> RouteMessageAck {
-                    auto self = weakSelf.lock();
-                    if (!self) {
-                        return createRouteMessageAck(
-                            forwardMessage, RouteMessageError::STOPPED);
-                    }
-                    return self->runOnWorker(
-                        [&self, &forwardMessage, &callContext]() {
+                        }));
+            });
+        this->options.rpcCommunicator.template registerRpcMethodAsync<
+            RouteMessageWrapper,
+            RouteMessageAck>(
+            "forwardMessage",
+            [weakSelf](
+                const RouteMessageWrapper& forwardMessage,
+                const DhtCallContext& callContext)
+                -> folly::coro::Task<RouteMessageAck> {
+                auto self = weakSelf.lock();
+                if (!self) {
+                    co_return createRouteMessageAck(
+                        forwardMessage, RouteMessageError::STOPPED);
+                }
+                co_return co_await streamr::utils::co_withExecutor(
+                    &self->routingExecutor,
+                    folly::coro::co_invoke(
+                        [self,
+                         forwardMessage,
+                         callContext]() -> folly::coro::Task<RouteMessageAck> {
                             if (self->stopped) {
-                                return createRouteMessageAck(
+                                co_return createRouteMessageAck(
                                     forwardMessage, RouteMessageError::STOPPED);
                             }
-                            return self->routerRpcLocal->forwardMessage(
+                            co_return self->routerRpcLocal->forwardMessage(
                                 forwardMessage, callContext);
-                        });
-                });
+                        }));
+            });
     }
 
     // Runs on the routing worker.

--- a/packages/streamr-dht/test/unit/RouterTest.cpp
+++ b/packages/streamr-dht/test/unit/RouterTest.cpp
@@ -5,9 +5,12 @@
 // invokes the registered handler by name (the TS test's FakeRpcCommunicator
 // captures the handler and calls it directly; here it goes through the real
 // server registry via handleIncomingMessage and unpacks the response ack).
+#include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <vector>
@@ -43,9 +46,21 @@ namespace {
 // A real RpcCommunicator (so Router can register on it and build remotes
 // from it) with a helper to invoke a registered handler by name and hand
 // back the unpacked response, standing in for the TS FakeRpcCommunicator.
+//
+// routeMessage/forwardMessage are now ASYNC handlers: handleIncomingMessage
+// schedules the response on a worker and returns immediately, so the ack
+// arrives on another thread. The ack response carries the same requestid as
+// the request, which distinguishes it from the outgoing forward requests the
+// Router itself sends (those have fresh requestids). callRpcMethod waits for
+// the matching ack under a condition variable.
 class FakeRpcCommunicator : public RpcCommunicator<DhtCallContext> {
 private:
-    bool capturing = false;
+    // Upper bound for the async ack to come back; routing acks return in
+    // milliseconds, so this only bounds a hang.
+    static constexpr std::chrono::seconds ackWaitTimeout{5};
+
+    std::mutex mutex;
+    std::condition_variable cv;
     std::string captureRequestId;
     std::optional<RpcMessage> captured;
 
@@ -56,9 +71,10 @@ public:
                 const RpcMessage& message,
                 const std::string& /*requestId*/,
                 const DhtCallContext& /*context*/) {
-                if (this->capturing &&
-                    message.requestid() == this->captureRequestId) {
+                std::lock_guard lock(this->mutex);
+                if (message.requestid() == this->captureRequestId) {
                     this->captured = message;
+                    this->cv.notify_all();
                 }
             });
     }
@@ -71,11 +87,17 @@ public:
         (*requestMessage.mutable_header())["request"] = "request";
         requestMessage.set_requestid(Uuid::v4());
 
-        this->captured.reset();
-        this->captureRequestId = requestMessage.requestid();
-        this->capturing = true;
+        {
+            std::lock_guard lock(this->mutex);
+            this->captured.reset();
+            this->captureRequestId = requestMessage.requestid();
+        }
         this->handleIncomingMessage(requestMessage, DhtCallContext());
-        this->capturing = false;
+
+        std::unique_lock lock(this->mutex);
+        this->cv.wait_for(lock, ackWaitTimeout, [this]() {
+            return this->captured.has_value();
+        });
 
         Resp response;
         if (this->captured.has_value()) {

--- a/packages/streamr-proto-rpc/modules/RpcCommunicator.cppm
+++ b/packages/streamr-proto-rpc/modules/RpcCommunicator.cppm
@@ -165,6 +165,28 @@ public:
     }
 
     /**
+     * @brief Register an async (coroutine) method to be called by remote
+     * clients. `fn` returns folly::coro::Task<ReturnType> and is awaited by
+     * the server layer, so it may co_await a worker executor without blocking
+     * the delivery thread.
+     *
+     * @param name name of the method
+     * @param fn coroutine function to be registered
+     * @param options options for the method
+     */
+
+    template <typename RequestType, typename ReturnType, typename F>
+        requires std::is_assignable_v<
+            std::function<Task<ReturnType>(RequestType, CallContextType)>,
+            F>
+    void registerRpcMethodAsync(
+        const std::string& name, const F& fn, MethodOptions options = {}) {
+        mRpcCommunicatorServerApi
+            .template registerRpcMethodAsync<RequestType, ReturnType, F>(
+                name, fn, options);
+    }
+
+    /**
      * @brief Register a notification to be called by remote clients
      *
      * @param name name of the notification

--- a/packages/streamr-proto-rpc/modules/RpcCommunicatorServerApi.cppm
+++ b/packages/streamr-proto-rpc/modules/RpcCommunicatorServerApi.cppm
@@ -2,7 +2,22 @@
 // CONSOLIDATED from the former header
 // streamr-proto-rpc/RpcCommunicatorServerApi.hpp (MODERNIZATION.md Phase 2.6):
 // this file is now the source of truth.
+//
+// Async request handling (follow-up to Phase A4): incoming requests are
+// handled off the delivery thread. onIncomingMessage() copies everything
+// the response needs (the resolved handler, the outgoing callback, the
+// request message and call context — no `this`), builds a Task<void> that
+// awaits the handler and sends the response, and schedules it on a private
+// worker executor via a CancellableAsyncScope, returning immediately. A
+// handler may therefore co_await a worker (e.g. the DHT routing worker)
+// and SUSPEND the response coroutine instead of blocking the shared
+// delivery thread. Notifications remain synchronous/inline.
 module;
+
+// std::coroutine_traits must be visible in every translation unit that
+// defines OR instantiates a coroutine; it cannot arrive through an
+// imported BMI.
+#include <coroutine> // IWYU pragma: keep
 
 #include <exception>
 #include <functional>
@@ -17,6 +32,8 @@ module;
 
 export module streamr.protorpc.RpcCommunicatorServerApi;
 
+import streamr.utils.CoroutineHelper;
+import streamr.utils.ExecutorHelper;
 import streamr.protorpc.Errors;
 import streamr.protorpc.ServerRegistry;
 export namespace streamr::protorpc {
@@ -26,8 +43,19 @@ using RpcErrorType = ::protorpc::RpcErrorType;
 template <typename CallContextType, typename OutgoingMessageCallbackType>
 class RpcCommunicatorServerApi {
 private:
+    // A single worker thread preserves the previous serial handling of
+    // incoming requests (which all ran on the shared delivery thread), just
+    // moved off that thread. The request coroutines are owned by mScope and
+    // drained in the destructor so none outlives mExecutor.
+    static constexpr size_t serverWorkerThreadCount = 1;
+
+    using AsyncHandler =
+        std::function<folly::coro::Task<Any>(Any, CallContextType)>;
+
     ServerRegistry<CallContextType> mServerRegistry;
     OutgoingMessageCallbackType mOutgoingMessageCallback;
+    folly::CPUThreadPoolExecutor mExecutor{serverWorkerThreadCount};
+    folly::coro::CancellableAsyncScope mScope;
 
     struct RpcResponseParams {
         RpcMessage request;
@@ -73,12 +101,30 @@ private:
         return ret;
     }
 
-    void handleRequest(
-        const RpcMessage& rpcMessage, const CallContextType& callContext) {
+    // Handles one request and sends its response. Runs on mExecutor and may
+    // suspend when the handler co_awaits a worker; every input is held by
+    // value in the coroutine frame, so nothing here depends on the delivery
+    // thread's stack or on `this` staying alive between suspension points.
+    // A detached coroutine must never let an exception escape, so unknown
+    // throws are mapped to SERVER_ERROR just like std::exception.
+    static folly::coro::Task<void> makeResponseTask(
+        std::optional<AsyncHandler> handler,
+        OutgoingMessageCallbackType outgoingMessageCallback,
+        RpcMessage rpcMessage,
+        CallContextType callContext) {
         RpcMessage response;
         try {
             SLogger::trace("handleRequest()");
-            auto bytes = mServerRegistry.handleRequest(rpcMessage, callContext);
+            if (!handler.has_value()) {
+                const auto& header = rpcMessage.header();
+                throw UnknownRpcMethod(
+                    "RPC Method " +
+                    (header.contains("method") ? header.at("method")
+                                               : std::string("<missing>")) +
+                    " is not provided");
+            }
+            Any bytes =
+                co_await handler.value()(rpcMessage.body(), callContext);
             response = createResponseRpcMessage(
                 {.request = rpcMessage, .body = bytes});
         } catch (const Err& err) {
@@ -107,11 +153,18 @@ private:
                 magic_enum::enum_name(ErrorCode::RPC_SERVER_ERROR);
             errorParams.errorMessage = err.what();
             response = createResponseRpcMessage(errorParams);
+        } catch (...) {
+            SLogger::debug("Unknown error when handling request");
+            RpcResponseParams errorParams = {.request = rpcMessage};
+            errorParams.errorType = RpcErrorType::SERVER_ERROR;
+            errorParams.errorCode =
+                magic_enum::enum_name(ErrorCode::RPC_SERVER_ERROR);
+            response = createResponseRpcMessage(errorParams);
         }
 
-        if (mOutgoingMessageCallback) {
+        if (outgoingMessageCallback) {
             try {
-                mOutgoingMessageCallback(
+                outgoingMessageCallback(
                     response, response.requestid(), callContext);
             } catch (const std::exception& clientSideException) {
                 SLogger::debug(
@@ -119,6 +172,23 @@ private:
                     clientSideException.what());
             }
         }
+        co_return;
+    }
+
+    // Resolves the handler on the delivery thread (while `this` is alive),
+    // then schedules the response coroutine on mExecutor and returns
+    // immediately, so the delivery thread is never blocked by handler work.
+    void handleRequest(
+        const RpcMessage& rpcMessage, const CallContextType& callContext) {
+        auto handler = mServerRegistry.getAsyncHandler(rpcMessage);
+        mScope.add(
+            streamr::utils::co_withExecutor(
+                &mExecutor,
+                makeResponseTask(
+                    std::move(handler),
+                    mOutgoingMessageCallback,
+                    rpcMessage,
+                    callContext)));
     }
 
     void handleNotification(
@@ -131,6 +201,26 @@ private:
     }
 
 public:
+    RpcCommunicatorServerApi() = default;
+
+    // Drains any in-flight response coroutines before mExecutor and the
+    // registry are destroyed, so no detached coroutine outlives the state it
+    // uses. Must run on a thread other than mExecutor's worker (it always
+    // does: the communicator is owned and destroyed by the transport/main
+    // thread, never from inside a request handler).
+    ~RpcCommunicatorServerApi() {
+        try {
+            streamr::utils::blockingWait(mScope.cancelAndJoinAsync());
+        } catch (...) { // NOLINT(bugprone-empty-catch) dtor must not throw
+        }
+    }
+
+    RpcCommunicatorServerApi(const RpcCommunicatorServerApi&) = delete;
+    RpcCommunicatorServerApi& operator=(const RpcCommunicatorServerApi&) =
+        delete;
+    RpcCommunicatorServerApi(RpcCommunicatorServerApi&&) = delete;
+    RpcCommunicatorServerApi& operator=(RpcCommunicatorServerApi&&) = delete;
+
     void onIncomingMessage(
         const RpcMessage& rpcMessage, const CallContextType& callContext) {
         const auto& header = rpcMessage.header();
@@ -167,6 +257,18 @@ public:
         const std::string& name, const F& fn, MethodOptions options = {}) {
         mServerRegistry.template registerRpcMethod<RequestType, ReturnType, F>(
             name, fn, options);
+    }
+
+    template <typename RequestType, typename ReturnType, typename F>
+        requires std::is_assignable_v<
+            std::function<
+                folly::coro::Task<ReturnType>(RequestType, CallContextType)>,
+            F>
+    void registerRpcMethodAsync(
+        const std::string& name, const F& fn, MethodOptions options = {}) {
+        mServerRegistry
+            .template registerRpcMethodAsync<RequestType, ReturnType, F>(
+                name, fn, options);
     }
 
     template <typename RequestType, typename F>

--- a/packages/streamr-proto-rpc/modules/ServerRegistry.cppm
+++ b/packages/streamr-proto-rpc/modules/ServerRegistry.cppm
@@ -1,14 +1,31 @@
 // Module streamr.protorpc.ServerRegistry
 // CONSOLIDATED from the former header streamr-proto-rpc/ServerRegistry.hpp
 // (MODERNIZATION.md Phase 2.6): this file is now the source of truth.
+//
+// Async handlers (follow-up to Phase A4): alongside the synchronous
+// std::function<Any(Any, Ctx)> handlers, methods may be registered as
+// folly::coro::Task<Response>-returning coroutines via
+// registerRpcMethodAsync. getAsyncHandler() returns a unified
+// Task<Any>-returning handler for either kind (a sync handler is wrapped
+// in a trivial `co_return syncFn(...)`), so the RPC-communicator server
+// layer can await every handler without blocking the delivery thread.
+// The synchronous handleRequest() / registerRpcMethod() path is kept
+// unchanged for direct callers that still want an inline result.
 module;
 
+// std::coroutine_traits must be visible in every translation unit that
+// defines OR instantiates a coroutine; it cannot arrive through an
+// imported BMI.
+#include <coroutine> // IWYU pragma: keep
+
+#include <optional>
 #include <google/protobuf/any.pb.h>
 #include <google/protobuf/empty.pb.h>
 #include "packages/proto-rpc/protos/ProtoRpc.pb.h"
 
 export module streamr.protorpc.ServerRegistry;
 
+import streamr.utils.CoroutineHelper;
 import streamr.logger.SLogger;
 import streamr.protorpc.Errors;
 export namespace streamr::protorpc {
@@ -29,8 +46,20 @@ private:
 
     using RpcNotificationType =
         std::function<Empty(Any request, CallContextType callContext)>;
+
+    // A coroutine handler that resolves the response Any without blocking
+    // the calling thread. Parameters are taken by value so the coroutine
+    // frame owns them across suspension points.
+    using AsyncRpcMethodType = std::function<folly::coro::Task<Any>(
+        Any request, CallContextType callContext)>;
+
     struct RegisteredMethod {
         RpcMethodType fn;
+        MethodOptions options;
+    };
+
+    struct RegisteredAsyncMethod {
+        AsyncRpcMethodType fn;
         MethodOptions options;
     };
 
@@ -40,6 +69,7 @@ private:
     };
 
     std::map<std::string, RegisteredMethod> mMethods;
+    std::map<std::string, RegisteredAsyncMethod> mAsyncMethods;
     std::map<std::string, RegisteredNotification> mNotifications;
 
     template <typename T>
@@ -75,6 +105,37 @@ public:
         return implementation.fn(rpcMessage.body(), callContext);
     }
 
+    // Returns a unified Task<Any>-returning handler for the method named in
+    // `rpcMessage`, resolving to either a registered async handler or a
+    // synchronous handler wrapped in a trivial coroutine. Returns
+    // std::nullopt when the method is unknown, so the caller can build the
+    // UNKNOWN_RPC_METHOD response itself (the lookup is cheap and happens on
+    // the delivery thread while `this` is guaranteed alive; the returned
+    // handler is self-contained and safe to run on another thread).
+    std::optional<AsyncRpcMethodType> getAsyncHandler(
+        const RpcMessage& rpcMessage) {
+        const auto& header = rpcMessage.header();
+        if (!header.contains("method")) {
+            return std::nullopt;
+        }
+        const auto& method = header.at("method");
+        if (const auto it = mAsyncMethods.find(method);
+            it != mAsyncMethods.end()) {
+            return it->second.fn;
+        }
+        if (const auto it = mMethods.find(method); it != mMethods.end()) {
+            RpcMethodType syncFn = it->second.fn;
+            return AsyncRpcMethodType(
+                [syncFn](
+                    Any request,
+                    CallContextType callContext) -> folly::coro::Task<Any> {
+                    co_return syncFn(
+                        std::move(request), std::move(callContext));
+                });
+        }
+        return std::nullopt;
+    }
+
     Empty handleNotification(
         const RpcMessage& rpcMessage, const CallContextType& callContext) {
         SLogger::trace(
@@ -98,6 +159,28 @@ public:
             },
             .options = options};
         mMethods[name] = method;
+    }
+
+    // Register a coroutine handler. `fn` takes (RequestType, CallContext)
+    // and returns folly::coro::Task<ReturnType>; the wrapper parses the
+    // request, awaits the handler and packs the response. The handler is
+    // awaited by the server layer, so it may co_await a worker executor
+    // without blocking the delivery thread.
+    template <typename RequestType, typename ReturnType, typename F>
+    void registerRpcMethodAsync(
+        const std::string& name, const F& fn, MethodOptions options = {}) {
+        RegisteredAsyncMethod method = {
+            .fn = [fn](Any data, CallContextType callContext)
+                -> folly::coro::Task<Any> {
+                RequestType request;
+                ServerRegistry::wrappedParseAny(request, data);
+                ReturnType response = co_await fn(request, callContext);
+                Any responseAny;
+                responseAny.PackFrom(response);
+                co_return responseAny;
+            },
+            .options = options};
+        mAsyncMethods[name] = method;
     }
 
     template <typename RequestType, typename F>

--- a/packages/streamr-proto-rpc/test/unit/RpcCommunicatorTest.cpp
+++ b/packages/streamr-proto-rpc/test/unit/RpcCommunicatorTest.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <chrono>
 #include <exception>
 #include <thread>
@@ -475,6 +476,118 @@ TEST_F(RpcCommunicatorTest, TestRpcTimeoutOnClientSideForNotification) {
         EXPECT_TRUE(false);
         EXPECT_TRUE(false);
     }
+}
+
+// --- Async server handlers: the delivery thread must not block on the
+// handler (follow-up to Phase A4). ---
+
+namespace {
+RpcMessage makeRequestMessage(
+    const std::string& methodName, const std::string& myname) {
+    static std::atomic<uint64_t> counter = 0;
+    HelloRequest request;
+    request.set_myname(myname);
+    RpcMessage message;
+    message.mutable_body()->PackFrom(request);
+    (*message.mutable_header())["method"] = methodName;
+    (*message.mutable_header())["request"] = "request";
+    message.set_requestid("req-" + std::to_string(counter++));
+    return message;
+}
+} // namespace
+
+// handleIncomingMessage() delivers on the (shared) delivery thread. When a
+// handler is async and slow, the call must return promptly and the response
+// must be produced later, off that thread.
+TEST_F(RpcCommunicatorTest, TestServerAsyncHandlerDoesNotBlockDeliveryThread) {
+    constexpr auto handlerDelay = 500ms;
+    std::atomic<bool> responseSent = false;
+    communicator1.setOutgoingMessageCallback(
+        [&responseSent](
+            const RpcMessage& /* message */,
+            const std::string& /* requestId */,
+            const ProtoCallContext& /* context */) -> void {
+            responseSent = true;
+        });
+    communicator1.registerRpcMethodAsync<HelloRequest, HelloResponse>(
+        "slowFunction",
+        [handlerDelay](
+            const HelloRequest& request, const ProtoCallContext& /* context */)
+            -> folly::coro::Task<HelloResponse> {
+            co_await folly::coro::sleep(handlerDelay);
+            HelloResponse response;
+            response.set_greeting("Hello, " + request.myname());
+            co_return response;
+        });
+
+    const auto start = std::chrono::steady_clock::now();
+    communicator1.handleIncomingMessage(
+        makeRequestMessage("slowFunction", "Test"), ProtoCallContext());
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    // The delivery thread returned well before the handler's delay, and the
+    // response has not been produced yet.
+    EXPECT_LT(elapsed, 200ms);
+    EXPECT_EQ(responseSent.load(), false);
+
+    // After the handler's delay the response is delivered off-thread.
+    std::this_thread::sleep_for(handlerDelay + 400ms);
+    EXPECT_EQ(responseSent.load(), true);
+}
+
+// Our own (fast) incoming traffic must be serviced while a slow handler is
+// still in flight — the priority-1 guarantee the async change restores.
+TEST_F(RpcCommunicatorTest, TestOwnTrafficNotDelayedByInFlightSlowHandler) {
+    const auto t0 = std::chrono::steady_clock::now();
+    std::atomic<int64_t> slowDoneAt = 0;
+    std::atomic<int64_t> fastDoneAt = 0;
+    communicator1.setOutgoingMessageCallback(
+        [&](const RpcMessage& message,
+            const std::string& /* requestId */,
+            const ProtoCallContext& /* context */) -> void {
+            const auto ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - t0)
+                    .count();
+            if (message.header().at("method") == "slow") {
+                slowDoneAt = ms;
+            } else {
+                fastDoneAt = ms;
+            }
+        });
+    // A slow async handler (stands in for routing) ...
+    communicator1.registerRpcMethodAsync<HelloRequest, HelloResponse>(
+        "slow",
+        [](const HelloRequest& request, const ProtoCallContext& /* context */)
+            -> folly::coro::Task<HelloResponse> {
+            co_await folly::coro::sleep(500ms);
+            HelloResponse response;
+            response.set_greeting("Hello, " + request.myname());
+            co_return response;
+        });
+    // ... and a fast synchronous handler (stands in for our own ping).
+    communicator1.registerRpcMethod<HelloRequest, HelloResponse>(
+        "fast",
+        [](const HelloRequest& request,
+           const ProtoCallContext& /* context */) -> HelloResponse {
+            HelloResponse response;
+            response.set_greeting("Hello, " + request.myname());
+            return response;
+        });
+
+    // Deliver the slow request first, then our own fast one right behind it.
+    communicator1.handleIncomingMessage(
+        makeRequestMessage("slow", "A"), ProtoCallContext());
+    communicator1.handleIncomingMessage(
+        makeRequestMessage("fast", "B"), ProtoCallContext());
+
+    std::this_thread::sleep_for(900ms);
+    ASSERT_GT(fastDoneAt.load(), 0);
+    ASSERT_GT(slowDoneAt.load(), 0);
+    // The fast response came back promptly, long before the slow one — the
+    // in-flight slow handler did not delay our own traffic.
+    EXPECT_LT(fastDoneAt.load(), 200);
+    EXPECT_LT(fastDoneAt.load(), slowDoneAt.load());
 }
 
 } // namespace streamr::protorpc

--- a/packages/streamr-proto-rpc/test/unit/RpcCommunicatorTest.cpp
+++ b/packages/streamr-proto-rpc/test/unit/RpcCommunicatorTest.cpp
@@ -1,6 +1,7 @@
 #include <atomic>
 #include <chrono>
 #include <exception>
+#include <memory>
 #include <thread>
 #include <gtest/gtest.h>
 #include "HelloRpc.pb.h"
@@ -537,30 +538,43 @@ TEST_F(RpcCommunicatorTest, TestServerAsyncHandlerDoesNotBlockDeliveryThread) {
 
 // Our own (fast) incoming traffic must be serviced while a slow handler is
 // still in flight — the priority-1 guarantee the async change restores.
+//
+// Deterministic (no wall-clock thresholds, robust under CI load): the slow
+// handler stays gated until the test releases it, so observing the fast
+// response arrive WHILE the slow one is still pending proves our own traffic
+// was not stuck behind the in-flight slow handler. The wait bounds only
+// guard against a hang; they are not part of the timing being asserted.
 TEST_F(RpcCommunicatorTest, TestOwnTrafficNotDelayedByInFlightSlowHandler) {
-    const auto t0 = std::chrono::steady_clock::now();
-    std::atomic<int64_t> slowDoneAt = 0;
-    std::atomic<int64_t> fastDoneAt = 0;
+    constexpr auto pollInterval = 5ms;
+    constexpr auto hangGuard = 5s;
+    auto released = std::make_shared<std::atomic<bool>>(false);
+    std::atomic<int> order = 0;
+    std::atomic<int> slowOrder = 0;
+    std::atomic<int> fastOrder = 0;
+    std::atomic<bool> slowDone = false;
+    std::atomic<bool> fastDone = false;
     communicator1.setOutgoingMessageCallback(
         [&](const RpcMessage& message,
             const std::string& /* requestId */,
             const ProtoCallContext& /* context */) -> void {
-            const auto ms =
-                std::chrono::duration_cast<std::chrono::milliseconds>(
-                    std::chrono::steady_clock::now() - t0)
-                    .count();
             if (message.header().at("method") == "slow") {
-                slowDoneAt = ms;
+                slowOrder = ++order;
+                slowDone = true;
             } else {
-                fastDoneAt = ms;
+                fastOrder = ++order;
+                fastDone = true;
             }
         });
-    // A slow async handler (stands in for routing) ...
+    // A slow async handler (stands in for routing): it stays pending, yielding
+    // the worker thread on each poll, until the test releases it.
     communicator1.registerRpcMethodAsync<HelloRequest, HelloResponse>(
         "slow",
-        [](const HelloRequest& request, const ProtoCallContext& /* context */)
+        [released, pollInterval](
+            const HelloRequest& request, const ProtoCallContext& /* context */)
             -> folly::coro::Task<HelloResponse> {
-            co_await folly::coro::sleep(500ms);
+            while (!released->load()) {
+                co_await folly::coro::sleep(pollInterval);
+            }
             HelloResponse response;
             response.set_greeting("Hello, " + request.myname());
             co_return response;
@@ -581,13 +595,24 @@ TEST_F(RpcCommunicatorTest, TestOwnTrafficNotDelayedByInFlightSlowHandler) {
     communicator1.handleIncomingMessage(
         makeRequestMessage("fast", "B"), ProtoCallContext());
 
-    std::this_thread::sleep_for(900ms);
-    ASSERT_GT(fastDoneAt.load(), 0);
-    ASSERT_GT(slowDoneAt.load(), 0);
-    // The fast response came back promptly, long before the slow one — the
-    // in-flight slow handler did not delay our own traffic.
-    EXPECT_LT(fastDoneAt.load(), 200);
-    EXPECT_LT(fastDoneAt.load(), slowDoneAt.load());
+    // The fast response comes back while the slow handler is still gated.
+    const auto fastDeadline = std::chrono::steady_clock::now() + hangGuard;
+    while (!fastDone.load() &&
+           std::chrono::steady_clock::now() < fastDeadline) {
+        std::this_thread::sleep_for(pollInterval);
+    }
+    EXPECT_EQ(fastDone.load(), true);
+    EXPECT_EQ(slowDone.load(), false);
+
+    // Releasing the slow handler lets it complete; it responded after us.
+    released->store(true);
+    const auto slowDeadline = std::chrono::steady_clock::now() + hangGuard;
+    while (!slowDone.load() &&
+           std::chrono::steady_clock::now() < slowDeadline) {
+        std::this_thread::sleep_for(pollInterval);
+    }
+    EXPECT_EQ(slowDone.load(), true);
+    EXPECT_LT(fastOrder.load(), slowOrder.load());
 }
 
 } // namespace streamr::protorpc

--- a/packages/streamr-utils/modules/CoroutineHelper.cppm
+++ b/packages/streamr-utils/modules/CoroutineHelper.cppm
@@ -22,6 +22,7 @@ module;
 
 #include <folly/CancellationToken.h>
 #include <folly/Unit.h>
+#include <folly/experimental/coro/AsyncScope.h>
 #include <folly/experimental/coro/BlockingWait.h>
 #include <folly/experimental/coro/Collect.h>
 #include <folly/experimental/coro/DetachOnCancel.h>
@@ -37,6 +38,8 @@ export module streamr.utils.CoroutineHelper;
 
 export namespace folly::coro {
 
+using folly::coro::AsyncScope;
+using folly::coro::CancellableAsyncScope;
 using folly::coro::co_invoke;
 using folly::coro::collectAll;
 using folly::coro::collectAllRange;

--- a/packages/streamr-utils/modules/ExecutorHelper.cppm
+++ b/packages/streamr-utils/modules/ExecutorHelper.cppm
@@ -7,6 +7,8 @@ module;
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/executors/FunctionScheduler.h>
+#include <folly/executors/thread_factory/NamedThreadFactory.h>
+#include <folly/executors/thread_factory/PriorityThreadFactory.h>
 
 export module streamr.utils.ExecutorHelper;
 
@@ -14,5 +16,8 @@ export namespace folly {
 
 using folly::CPUThreadPoolExecutor;
 using folly::FunctionScheduler;
+using folly::NamedThreadFactory;
+using folly::PriorityThreadFactory;
+using folly::ThreadFactory;
 
 } // namespace folly


### PR DESCRIPTION
Follow-up to Phase A4 (Router, #60). Tracked in the `router-heavy-ops-worker-thread` design note.

## Problem

Incoming RPC handlers run inline on libdatachannel's (`rtc::WebSocket`) message-delivery thread — a single thread **shared across all peers** that carries both our own incoming traffic (ping/store/find aimed at us) and routed traffic. Because the `routeMessage`/`forwardMessage` ack depends on the routing decision (it may encode `NO_TARGETS`), the Router's handlers `blockingWait`-ed on the routing worker and thereby **blocked that shared delivery thread** until the ack was ready. So in-flight routing could delay our own incoming traffic — violating the owner priority model (our own traffic priority 1, routing best-effort "whenever we have time").

A4 already offloaded routing *computation* onto a dedicated worker, which kept it off the delivery thread's CPU — but the delivery thread still **waited** for the ack. This PR removes the wait.

## Change

Make the proto-rpc server accept **async handlers** so a handler can `co_await` a worker and *suspend* the response coroutine instead of blocking the delivery thread.

- **`ServerRegistry`** — add `registerRpcMethodAsync<Req,Resp>` (a `folly::coro::Task<Resp>`-returning variant) stored alongside the sync handlers, plus `getAsyncHandler()` returning a unified `Task<Any>` handler (a sync handler is wrapped in a trivial `co_return syncFn(...)`). The synchronous `handleRequest`/`registerRpcMethod` path is untouched — every existing sync handler and `ServerRegistryTest` are unaffected.
- **`RpcCommunicatorServerApi`** — the request path is now non-blocking. `onIncomingMessage` resolves the handler on the delivery thread (while `this` is guaranteed alive), then schedules a copy-capturing coroutine (handler + outgoing callback + message + context **by value**, no `this`) on a private single-thread executor via a `CancellableAsyncScope`, and returns immediately. The destructor `blockingWait(scope.cancelAndJoinAsync())` drains in-flight responses before the executor dies. A `catch(...)` maps unknown throws to `SERVER_ERROR` so a detached coroutine can never terminate the process. **Notifications stay synchronous/inline.**
- **`RpcCommunicator`** — `registerRpcMethodAsync` passthrough. `CoroutineHelper` exports `CancellableAsyncScope`; `ExecutorHelper` exports `PriorityThreadFactory`/`NamedThreadFactory`.
- **`Router`** — `routeMessage`/`forwardMessage` now `co_await` the routing worker instead of `blockingWait`-ing on it; the delivery coroutine **suspends** and the shared thread returns to our own traffic immediately, with the ack produced and sent later from the worker. `weakSelf.lock()` held in the coroutine frame keeps the Router (and its executor) alive across the suspension. The routing worker is additionally given a **low OS nice value** via `PriorityThreadFactory` so routing yields the CPU to our own work under contention (best-effort; honoured on Linux/Android, weaker on Darwin). **Wire semantics are unchanged** (`NO_TARGETS`/`DUPLICATE`/`STOPPED` acks identical).

## Behavioural consequence

`handleIncomingMessage` no longer yields the response synchronously — the response is produced off the delivery thread. `RouterTest`'s fake communicator was the one caller relying on the old synchronous contract; it now waits for the ack on a condition variable (matched by request id, distinct from the Router's own outgoing forwards). All its assertions keep their meaning. `RpcCommunicatorTest` round-trip tests already await the **client** future, so they were unaffected.

Two new tests assert the guarantee directly:
- `TestServerAsyncHandlerDoesNotBlockDeliveryThread` — a 500 ms async handler; `handleIncomingMessage` returns in < 200 ms and the response is delivered later.
- `TestOwnTrafficNotDelayedByInFlightSlowHandler` — a fast (sync) request delivered *behind* an in-flight slow async handler returns first.

## Verification (host arm64-osx, Debug)

| Suite | Result |
|---|---|
| proto-rpc unit (incl. 2 new tests) | 24/24 |
| proto-rpc integration | 4/4 |
| dht unit (incl. RouterTest 9/9) | 143/143 |
| dht integration (RouterRpcRemote, DhtNodeRpcRemote) | 12/12 |

`clangd-tidy` and `clang-format` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)