### PR TITLE
Phase A6: data store (StoreManager, StoreRpc client/server)

### DIFF
--- a/packages/streamr-dht/CMakeLists.txt
+++ b/packages/streamr-dht/CMakeLists.txt
@@ -217,6 +217,9 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         test/unit/RouterTest.cpp
         test/unit/RecursiveOperationSessionTest.cpp
         test/unit/RecursiveOperationManagerTest.cpp
+        test/unit/LocalDataStoreTest.cpp
+        test/unit/StoreRpcLocalTest.cpp
+        test/unit/StoreManagerTest.cpp
     )
 
     target_include_directories(streamr-dht-test-unit

--- a/packages/streamr-dht/lint.sh
+++ b/packages/streamr-dht/lint.sh
@@ -46,7 +46,11 @@ echo "Running clangd-tidy on $FILES"
 # through the RecursiveOperationSession coroutine cluster; the compiler
 # builds and runs it, clang-format still checks it. (RecursiveOperation-
 # ManagerTest.cpp imports the same cluster but does NOT trip it.)
-TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/integration/ConnectionLockingTest.cpp' | grep -v 'test/unit/PendingConnectionTest.cpp' | grep -v 'test/unit/SimulatorTest.cpp' | grep -v 'test/integration/SimultaneousConnectionsTest.cpp' | grep -v 'test/integration/ConnectionManagerIntegrationTest.cpp' | grep -v 'test/unit/DhtNodeRpcLocalTest.cpp' | grep -v 'test/integration/DhtNodeRpcRemoteTest.cpp' | grep -v 'test/unit/RoutingSessionTest.cpp' | grep -v 'test/unit/RecursiveOperationSessionTest.cpp' | tr '\n' ' ')
+# StoreRpcLocalTest.cpp and StoreManagerTest.cpp (phase A6) trip the same
+# false positive through the StoreRpcRemote / StoreManager coroutine
+# cluster; the compiler builds and runs both, clang-format still checks
+# them. (LocalDataStoreTest.cpp does NOT trip it.)
+TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/integration/ConnectionLockingTest.cpp' | grep -v 'test/unit/PendingConnectionTest.cpp' | grep -v 'test/unit/SimulatorTest.cpp' | grep -v 'test/integration/SimultaneousConnectionsTest.cpp' | grep -v 'test/integration/ConnectionManagerIntegrationTest.cpp' | grep -v 'test/unit/DhtNodeRpcLocalTest.cpp' | grep -v 'test/integration/DhtNodeRpcRemoteTest.cpp' | grep -v 'test/unit/RoutingSessionTest.cpp' | grep -v 'test/unit/RecursiveOperationSessionTest.cpp' | grep -v 'test/unit/StoreRpcLocalTest.cpp' | grep -v 'test/unit/StoreManagerTest.cpp' | tr '\n' ' ')
 clangd-tidy -p "$COMPILE_DB" $TIDY_FILES
 
 echo "Running clang-format --dry-run on $FILES"

--- a/packages/streamr-dht/modules/dht/store/LocalDataStore.cppm
+++ b/packages/streamr-dht/modules/dht/store/LocalDataStore.cppm
@@ -44,7 +44,15 @@ private:
 public:
     explicit LocalDataStore(uint32_t maxTtl) : maxTtl(maxTtl) {}
 
-    bool storeEntry(const DataEntry& dataEntry) {
+    // Virtual so tests can substitute a mock store (StoreManager /
+    // StoreRpcLocal hold it by reference).
+    virtual ~LocalDataStore() = default;
+    LocalDataStore(const LocalDataStore&) = delete;
+    LocalDataStore& operator=(const LocalDataStore&) = delete;
+    LocalDataStore(LocalDataStore&&) = delete;
+    LocalDataStore& operator=(LocalDataStore&&) = delete;
+
+    virtual bool storeEntry(const DataEntry& dataEntry) {
         const DhtAddress key =
             Identifiers::getDhtAddressFromRaw(DhtAddressRaw{dataEntry.key()});
         const DhtAddress creatorNodeId = Identifiers::getDhtAddressFromRaw(
@@ -73,7 +81,8 @@ public:
         return true;
     }
 
-    bool markAsDeleted(const DhtAddress& key, const DhtAddress& creator) {
+    virtual bool markAsDeleted(
+        const DhtAddress& key, const DhtAddress& creator) {
         const auto it = this->store.find(key);
         if (it == this->store.end() || !it->second.has(creator)) {
             return false;
@@ -82,7 +91,7 @@ public:
         return true;
     }
 
-    [[nodiscard]] std::vector<DataEntry> values(
+    [[nodiscard]] virtual std::vector<DataEntry> values(
         const std::optional<DhtAddress>& key = std::nullopt) {
         std::vector<DataEntry> result;
         if (key.has_value()) {
@@ -100,7 +109,7 @@ public:
         return result;
     }
 
-    [[nodiscard]] std::vector<DhtAddress> keys() {
+    [[nodiscard]] virtual std::vector<DhtAddress> keys() {
         std::vector<DhtAddress> result;
         result.reserve(this->store.size());
         for (const auto& [key, map] : this->store) {
@@ -109,7 +118,7 @@ public:
         return result;
     }
 
-    void setAllEntriesAsStale(const DhtAddress& key) {
+    virtual void setAllEntriesAsStale(const DhtAddress& key) {
         const auto it = this->store.find(key);
         if (it != this->store.end()) {
             it->second.forEach(
@@ -119,7 +128,7 @@ public:
         }
     }
 
-    void deleteEntry(const DhtAddress& key, const DhtAddress& creator) {
+    virtual void deleteEntry(const DhtAddress& key, const DhtAddress& creator) {
         const auto it = this->store.find(key);
         if (it != this->store.end() && it->second.get(creator) != nullptr) {
             it->second.remove(creator);
@@ -129,7 +138,7 @@ public:
         }
     }
 
-    void clear() {
+    virtual void clear() {
         for (auto& [key, map] : this->store) {
             map.clear();
         }

--- a/packages/streamr-dht/modules/dht/store/StoreManager.cppm
+++ b/packages/streamr-dht/modules/dht/store/StoreManager.cppm
@@ -1,0 +1,320 @@
+// Module streamr.dht.StoreManager
+// Ported from packages/dht/src/dht/store/StoreManager.ts (v103.8.0-rc.3).
+// Owns the store side of a DHT node: registers the StoreRpc handlers, stores
+// data to the k closest nodes (storeDataToDht), and keeps replicas in sync
+// as the neighbourhood changes (onContactAdded / replicateDataToClosestNodes).
+//
+// C++ notes: the recursive-find and per-contact remote creation are options
+// callbacks (matching this package's callback-options style, and letting the
+// unit test mock them); the fire-and-forget replications TS runs via
+// setImmediate are dispatched onto a small worker executor here, so
+// StoreManager is owned through a shared_ptr.
+module;
+
+#include <coroutine> // IWYU pragma: keep
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.StoreManager;
+
+import streamr.utils.CoroutineHelper;
+import streamr.utils.EnableSharedFromThis;
+import streamr.utils.ExecutorHelper;
+import streamr.logger.SLogger;
+import streamr.protorpc.RpcCommunicator;
+import streamr.dht.DhtCallContext;
+import streamr.dht.getClosestNodes;
+import streamr.dht.Identifiers;
+import streamr.dht.LocalDataStore;
+import streamr.dht.RecursiveOperationSession;
+import streamr.dht.StoreRpcLocal;
+import streamr.dht.StoreRpcRemote;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+using streamr::utils::EnableSharedFromThis;
+
+export namespace streamr::dht::store {
+
+using ::dht::DataEntry;
+using ::dht::PeerDescriptor;
+using ::dht::RecursiveOperation;
+using ::dht::ReplicateDataRequest;
+using ::dht::StoreDataRequest;
+using ::dht::StoreDataResponse;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+using streamr::dht::ServiceID;
+using streamr::dht::contact::getClosestNodes;
+using streamr::dht::contact::GetClosestNodesOptions;
+using streamr::dht::recursiveoperation::RecursiveOperationResult;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::protorpc::RpcCommunicator;
+
+struct StoreManagerOptions {
+    RpcCommunicator<DhtCallContext>& rpcCommunicator;
+    PeerDescriptor localPeerDescriptor;
+    LocalDataStore& localDataStore;
+    ServiceID serviceId;
+    uint32_t highestTtl;
+    size_t redundancyFactor;
+    std::function<std::vector<PeerDescriptor>()> getNeighbors;
+    std::function<std::shared_ptr<StoreRpcRemote>(const PeerDescriptor&)>
+        createRpcRemote;
+    // recursiveOperationManager.execute(key, FIND_CLOSEST_NODES)
+    std::function<folly::coro::Task<RecursiveOperationResult>(
+        const DhtAddress&, RecursiveOperation)>
+        executeRecursiveOperation;
+};
+
+class StoreManager : public EnableSharedFromThis {
+private:
+    static constexpr size_t replicationWorkerThreads = 1;
+
+    StoreManagerOptions options;
+    folly::CPUThreadPoolExecutor replicationExecutor{replicationWorkerThreads};
+    std::unique_ptr<StoreRpcLocal> rpcLocal;
+
+    explicit StoreManager(StoreManagerOptions options)
+        : options(std::move(options)) {}
+
+    [[nodiscard]] bool equalsLocal(const PeerDescriptor& peer) const {
+        return Identifiers::areEqualPeerDescriptors(
+            peer, this->options.localPeerDescriptor);
+    }
+
+    // The actual async replication of one entry to one contact.
+    folly::coro::Task<void> doReplicate(
+        DataEntry dataEntry, PeerDescriptor contact) {
+        auto rpcRemote = this->options.createRpcRemote(contact);
+        ReplicateDataRequest request;
+        *request.mutable_entry() = std::move(dataEntry);
+        try {
+            co_await rpcRemote->replicateData(std::move(request), true);
+        } catch (const std::exception& err) {
+            SLogger::trace(
+                "replicateData() threw an exception " +
+                std::string(err.what()));
+        }
+    }
+
+    // Fire-and-forget the async replication onto the worker executor.
+    void replicateDataToContact(
+        const DataEntry& dataEntry, const PeerDescriptor& contact) {
+        auto self = this->sharedFromThis<StoreManager>();
+        DataEntry entry = dataEntry;
+        PeerDescriptor target = contact;
+        streamr::utils::co_withExecutor(
+            &this->replicationExecutor,
+            folly::coro::co_invoke(
+                [self, entry, target]() -> folly::coro::Task<void> {
+                    co_await self->doReplicate(entry, target);
+                }))
+            .start();
+    }
+
+    void registerLocalRpcMethods() {
+        auto self = this->sharedFromThis<StoreManager>();
+        this->rpcLocal = std::make_unique<StoreRpcLocal>(StoreRpcLocalOptions{
+            .localDataStore = this->options.localDataStore,
+            .localPeerDescriptor = this->options.localPeerDescriptor,
+            .replicateDataToContact =
+                [this](
+                    const DataEntry& dataEntry, const PeerDescriptor& contact) {
+                    this->replicateDataToContact(dataEntry, contact);
+                },
+            .getStorers =
+                [this](const DhtAddress& dataKey) {
+                    return this->getStorers(dataKey, std::nullopt);
+                }});
+        std::weak_ptr<StoreManager> weakSelf = self;
+        this->options.rpcCommunicator
+            .template registerRpcMethod<StoreDataRequest, StoreDataResponse>(
+                "storeData",
+                [weakSelf](
+                    const StoreDataRequest& request,
+                    const DhtCallContext& callContext) -> StoreDataResponse {
+                    auto locked = weakSelf.lock();
+                    if (!locked) {
+                        return StoreDataResponse{};
+                    }
+                    return locked->rpcLocal->storeData(request, callContext);
+                });
+        this->options.rpcCommunicator
+            .template registerRpcNotification<ReplicateDataRequest>(
+                "replicateData",
+                [weakSelf](
+                    const ReplicateDataRequest& request,
+                    const DhtCallContext& callContext) {
+                    auto locked = weakSelf.lock();
+                    if (locked) {
+                        locked->rpcLocal->replicateData(request, callContext);
+                    }
+                });
+    }
+
+    void replicateAndUpdateStaleState(
+        const DhtAddress& dataKey, const PeerDescriptor& newNode) {
+        const auto storers = this->getStorers(dataKey, std::nullopt);
+        std::vector<PeerDescriptor> storersBeforeContactAdded;
+        for (const auto& peer : storers) {
+            if (!Identifiers::areEqualPeerDescriptors(peer, newNode)) {
+                storersBeforeContactAdded.push_back(peer);
+            }
+        }
+        const bool selfWasPrimaryStorer = !storersBeforeContactAdded.empty() &&
+            this->equalsLocal(storersBeforeContactAdded[0]);
+        const bool newNodeIsStorer = std::ranges::any_of(
+            storers, [&newNode](const PeerDescriptor& peer) {
+                return Identifiers::areEqualPeerDescriptors(peer, newNode);
+            });
+        if (selfWasPrimaryStorer) {
+            if (newNodeIsStorer) {
+                auto self = this->sharedFromThis<StoreManager>();
+                DhtAddress key = dataKey;
+                PeerDescriptor node = newNode;
+                streamr::utils::co_withExecutor(
+                    &this->replicationExecutor,
+                    folly::coro::co_invoke(
+                        [self, key, node]() -> folly::coro::Task<void> {
+                            const auto dataEntries =
+                                self->options.localDataStore.values(key);
+                            for (const auto& dataEntry : dataEntries) {
+                                co_await self->doReplicate(dataEntry, node);
+                            }
+                        }))
+                    .start();
+            }
+        } else if (!std::ranges::any_of(
+                       storers, [this](const PeerDescriptor& peer) {
+                           return this->equalsLocal(peer);
+                       })) {
+            this->options.localDataStore.setAllEntriesAsStale(dataKey);
+        }
+    }
+
+    [[nodiscard]] std::vector<PeerDescriptor> getStorers(
+        const DhtAddress& dataKey, std::optional<PeerDescriptor> excludedNode) {
+        std::vector<PeerDescriptor> nodes = this->options.getNeighbors();
+        nodes.push_back(this->options.localPeerDescriptor);
+        GetClosestNodesOptions opts;
+        opts.maxCount = this->options.redundancyFactor;
+        if (excludedNode.has_value()) {
+            opts.excludedNodeIds = std::set<DhtAddress>{
+                Identifiers::getNodeIdFromPeerDescriptor(excludedNode.value())};
+        }
+        return getClosestNodes(dataKey, nodes, opts);
+    }
+
+    folly::coro::Task<void> replicateDataToClosestNodes() {
+        const auto dataEntries = this->options.localDataStore.values();
+        for (const auto& dataEntry : dataEntries) {
+            const DhtAddress dataKey = Identifiers::getDhtAddressFromRaw(
+                DhtAddressRaw{dataEntry.key()});
+            const auto neighbors = getClosestNodes(
+                dataKey,
+                this->options.getNeighbors(),
+                GetClosestNodesOptions{
+                    .maxCount = this->options.redundancyFactor});
+            for (const auto& neighbor : neighbors) {
+                auto rpcRemote = this->options.createRpcRemote(neighbor);
+                ReplicateDataRequest request;
+                *request.mutable_entry() = dataEntry;
+                try {
+                    co_await rpcRemote->replicateData(
+                        std::move(request), false);
+                } catch (const std::exception& err) {
+                    SLogger::trace(
+                        "Failed to replicate in replicateDataToClosestNodes " +
+                        std::string(err.what()));
+                }
+            }
+        }
+    }
+
+public:
+    [[nodiscard]] static std::shared_ptr<StoreManager> newInstance(
+        StoreManagerOptions options) {
+        struct MakeSharedEnabler : public StoreManager {
+            explicit MakeSharedEnabler(StoreManagerOptions options)
+                : StoreManager(std::move(options)) {}
+        };
+        auto instance = std::make_shared<MakeSharedEnabler>(std::move(options));
+        instance->registerLocalRpcMethods();
+        return instance;
+    }
+
+    ~StoreManager() override = default;
+
+    void onContactAdded(const PeerDescriptor& peerDescriptor) {
+        for (const auto& key : this->options.localDataStore.keys()) {
+            this->replicateAndUpdateStaleState(key, peerDescriptor);
+        }
+    }
+
+    folly::coro::Task<std::vector<PeerDescriptor>> storeDataToDht(
+        DhtAddress key, ::google::protobuf::Any data, DhtAddress creator) {
+        auto self = this->sharedFromThis<StoreManager>();
+        SLogger::debug("Storing data to DHT");
+        const auto result = co_await this->options.executeRecursiveOperation(
+            key, RecursiveOperation::FIND_CLOSEST_NODES);
+        const auto& closestNodes = result.closestNodes;
+        std::vector<PeerDescriptor> successfulNodes;
+        const uint32_t ttl = this->options.highestTtl;
+        const auto createdAt = nowTimestamp();
+        const DhtAddressRaw keyRaw = Identifiers::getRawFromDhtAddress(key);
+        const DhtAddressRaw creatorRaw =
+            Identifiers::getRawFromDhtAddress(creator);
+        for (size_t i = 0; i < closestNodes.size() &&
+             successfulNodes.size() < this->options.redundancyFactor;
+             ++i) {
+            if (this->equalsLocal(closestNodes[i])) {
+                DataEntry entry;
+                entry.set_key(keyRaw);
+                *entry.mutable_data() = data;
+                entry.set_creator(creatorRaw);
+                *entry.mutable_createdat() = createdAt;
+                *entry.mutable_storedat() = nowTimestamp();
+                entry.set_ttl(ttl);
+                entry.set_stale(false);
+                entry.set_deleted(false);
+                this->options.localDataStore.storeEntry(entry);
+                successfulNodes.push_back(closestNodes[i]);
+                continue;
+            }
+            auto rpcRemote = this->options.createRpcRemote(closestNodes[i]);
+            StoreDataRequest request;
+            request.set_key(keyRaw);
+            *request.mutable_data() = data;
+            request.set_creator(creatorRaw);
+            *request.mutable_createdat() = createdAt;
+            request.set_ttl(ttl);
+            try {
+                co_await rpcRemote->storeData(std::move(request));
+                successfulNodes.push_back(closestNodes[i]);
+            } catch (const std::exception& err) {
+                SLogger::trace(
+                    "remote.storeData() threw an exception " +
+                    std::string(err.what()));
+            }
+        }
+        co_return successfulNodes;
+    }
+
+    folly::coro::Task<void> destroy() {
+        co_await this->replicateDataToClosestNodes();
+    }
+};
+
+} // namespace streamr::dht::store

--- a/packages/streamr-dht/modules/dht/store/StoreRpcLocal.cppm
+++ b/packages/streamr-dht/modules/dht/store/StoreRpcLocal.cppm
@@ -1,0 +1,151 @@
+// Module streamr.dht.StoreRpcLocal
+// Ported from packages/dht/src/dht/store/StoreRpcLocal.ts (v103.8.0-rc.3).
+// The server side of the StoreRpc service: storeData writes an entry (stale
+// unless this node is a storer of the key); replicateData writes a
+// replicated entry and, if newly stored, fans it out to the neighbouring
+// storers.
+//
+// TS defers each fan-out replication with setImmediate + executeSafePromise
+// (fire and forget). Here replicateDataToContact is a synchronous void
+// callback that the manager wires to kick off the async replication itself,
+// so the local side calls it directly.
+module;
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.StoreRpcLocal;
+
+import streamr.logger.SLogger;
+import streamr.dht.DhtRpcServer;
+import streamr.dht.DhtCallContext;
+import streamr.dht.Identifiers;
+import streamr.dht.LocalDataStore;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+
+export namespace streamr::dht::store {
+
+using ::dht::DataEntry;
+using ::dht::PeerDescriptor;
+using ::dht::ReplicateDataRequest;
+using ::dht::StoreDataRequest;
+using ::dht::StoreDataResponse;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+using streamr::dht::rpcprotocol::DhtCallContext;
+
+using StoreRpc = ::dht::StoreRpc<DhtCallContext>;
+
+// Timestamp for "now" (protobuf has no Timestamp::now() in C++).
+inline ::google::protobuf::Timestamp nowTimestamp() {
+    const auto sinceEpoch = std::chrono::system_clock::now().time_since_epoch();
+    const auto seconds =
+        std::chrono::duration_cast<std::chrono::seconds>(sinceEpoch);
+    const auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        sinceEpoch - seconds);
+    ::google::protobuf::Timestamp timestamp;
+    timestamp.set_seconds(seconds.count());
+    timestamp.set_nanos(static_cast<int32_t>(nanos.count()));
+    return timestamp;
+}
+
+struct StoreRpcLocalOptions {
+    LocalDataStore& localDataStore;
+    PeerDescriptor localPeerDescriptor;
+    std::function<void(const DataEntry&, const PeerDescriptor&)>
+        replicateDataToContact;
+    std::function<std::vector<PeerDescriptor>(const DhtAddress&)> getStorers;
+};
+
+class StoreRpcLocal : public StoreRpc {
+private:
+    StoreRpcLocalOptions options;
+
+    [[nodiscard]] bool isLocalNodeStorer(const DhtAddress& dataKey) {
+        const auto storers = this->options.getStorers(dataKey);
+        return std::ranges::any_of(storers, [this](const PeerDescriptor& peer) {
+            return Identifiers::areEqualPeerDescriptors(
+                peer, this->options.localPeerDescriptor);
+        });
+    }
+
+    void replicateDataToNeighbors(
+        const PeerDescriptor& requestor, const DataEntry& dataEntry) {
+        const DhtAddress dataKey =
+            Identifiers::getDhtAddressFromRaw(DhtAddressRaw{dataEntry.key()});
+        const auto storers = this->options.getStorers(dataKey);
+        if (storers.empty()) {
+            return;
+        }
+        const bool isLocalNodePrimaryStorer =
+            Identifiers::areEqualPeerDescriptors(
+                storers[0], this->options.localPeerDescriptor);
+        // If we are the closest to the data, replicate to all storers;
+        // otherwise only to the closest one. Never to the requestor or self.
+        const std::vector<PeerDescriptor> candidates = isLocalNodePrimaryStorer
+            ? storers
+            : std::vector<PeerDescriptor>{storers[0]};
+        for (const auto& target : candidates) {
+            if (!Identifiers::areEqualPeerDescriptors(target, requestor) &&
+                !Identifiers::areEqualPeerDescriptors(
+                    target, this->options.localPeerDescriptor)) {
+                this->options.replicateDataToContact(dataEntry, target);
+            }
+        }
+    }
+
+public:
+    explicit StoreRpcLocal(StoreRpcLocalOptions options)
+        : options(std::move(options)) {}
+
+    ~StoreRpcLocal() override = default;
+
+    StoreDataResponse storeData(
+        const StoreDataRequest& request,
+        const DhtCallContext& /*callContext*/) override {
+        SLogger::trace("storeData()");
+        const DhtAddress key =
+            Identifiers::getDhtAddressFromRaw(DhtAddressRaw{request.key()});
+        const bool isLocalNodeStorer = this->isLocalNodeStorer(key);
+        DataEntry entry;
+        entry.set_key(request.key());
+        *entry.mutable_data() = request.data();
+        entry.set_creator(request.creator());
+        *entry.mutable_createdat() = request.createdat();
+        *entry.mutable_storedat() = nowTimestamp();
+        entry.set_ttl(request.ttl());
+        entry.set_stale(!isLocalNodeStorer);
+        entry.set_deleted(false);
+        this->options.localDataStore.storeEntry(entry);
+        if (!isLocalNodeStorer) {
+            this->options.localDataStore.setAllEntriesAsStale(key);
+        }
+        return StoreDataResponse{};
+    }
+
+    void replicateData(
+        const ReplicateDataRequest& request,
+        const DhtCallContext& callContext) override {
+        SLogger::trace("server-side replicateData()");
+        const DataEntry& dataEntry = request.entry();
+        const bool wasStored =
+            this->options.localDataStore.storeEntry(dataEntry);
+        if (wasStored) {
+            this->replicateDataToNeighbors(
+                callContext.incomingSourceDescriptor.value(), request.entry());
+        }
+        const DhtAddress key =
+            Identifiers::getDhtAddressFromRaw(DhtAddressRaw{dataEntry.key()});
+        if (!this->isLocalNodeStorer(key)) {
+            this->options.localDataStore.setAllEntriesAsStale(key);
+        }
+    }
+};
+
+} // namespace streamr::dht::store

--- a/packages/streamr-dht/modules/dht/store/StoreRpcRemote.cppm
+++ b/packages/streamr-dht/modules/dht/store/StoreRpcRemote.cppm
@@ -1,0 +1,87 @@
+// Module streamr.dht.StoreRpcRemote
+// Ported from packages/dht/src/dht/store/StoreRpcRemote.ts
+// (v103.8.0-rc.3). The client used to store data on, and replicate data to,
+// a peer. storeData/replicateData are virtual so a test can substitute a
+// counting mock.
+module;
+
+#include <coroutine> // IWYU pragma: keep
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <utility>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+export module streamr.dht.StoreRpcRemote;
+
+import streamr.utils.CoroutineHelper;
+import streamr.logger.SLogger;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.DhtCallContext;
+import streamr.dht.Identifiers;
+import streamr.dht.RpcRemote;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+
+export namespace streamr::dht::store {
+
+using ::dht::PeerDescriptor;
+using ::dht::ReplicateDataRequest;
+using ::dht::StoreDataRequest;
+using streamr::dht::Identifiers;
+using streamr::dht::contact::RpcRemote;
+using streamr::dht::rpcprotocol::DhtCallContext;
+
+using StoreRpcClient = ::dht::StoreRpcClient<DhtCallContext>;
+
+class StoreRpcRemote : public RpcRemote<StoreRpcClient> {
+public:
+    StoreRpcRemote(
+        PeerDescriptor localPeerDescriptor, // NOLINT
+        PeerDescriptor remotePeerDescriptor,
+        StoreRpcClient client,
+        std::optional<std::chrono::milliseconds> timeout = std::nullopt)
+        : RpcRemote<StoreRpcClient>(
+              std::move(localPeerDescriptor),
+              std::move(remotePeerDescriptor),
+              std::move(client),
+              timeout) {}
+
+    virtual ~StoreRpcRemote() = default;
+    StoreRpcRemote(const StoreRpcRemote&) = delete;
+    StoreRpcRemote& operator=(const StoreRpcRemote&) = delete;
+    StoreRpcRemote(StoreRpcRemote&&) = delete;
+    StoreRpcRemote& operator=(StoreRpcRemote&&) = delete;
+
+    virtual folly::coro::Task<void> storeData(StoreDataRequest request) {
+        auto options = this->formDhtRpcOptions();
+        try {
+            co_await this->getClient().storeData(
+                std::move(request), std::move(options), this->getTimeout());
+        } catch (const std::exception& err) {
+            const DhtAddress to = Identifiers::getNodeIdFromPeerDescriptor(
+                this->getPeerDescriptor());
+            const DhtAddress from = Identifiers::getNodeIdFromPeerDescriptor(
+                this->getLocalPeerDescriptor());
+            throw std::runtime_error(
+                "Could not store data to " + to + " from " + from + " " +
+                std::string(err.what()));
+        }
+    }
+
+    virtual folly::coro::Task<void> replicateData(
+        ReplicateDataRequest request, bool connect) {
+        DhtCallContext context;
+        context.connect = connect;
+        context.sendIfStopped = true;
+        auto options = this->formDhtRpcOptions(context);
+        co_await this->getClient().replicateData(
+            std::move(request),
+            std::move(options),
+            RpcRemote<StoreRpcClient>::existingConnectionTimeout);
+    }
+};
+
+} // namespace streamr::dht::store

--- a/packages/streamr-dht/test/unit/LocalDataStoreTest.cpp
+++ b/packages/streamr-dht/test/unit/LocalDataStoreTest.cpp
@@ -1,0 +1,141 @@
+// Ported from packages/dht/test/unit/LocalDataStore.test.ts
+// (v103.8.0-rc.3). Also validates the A5 MapWithTtl lazy-expiry adaptation:
+// the "deleted after TTL" case waits real time and expects the entry gone on
+// the next access.
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <thread>
+#include <vector>
+#include <gtest/gtest.h>
+
+import streamr.dht.Identifiers;
+import streamr.dht.LocalDataStore;
+import streamr.dht.protos;
+import streamr.dht.TestUtils;
+
+using ::dht::DataEntry;
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtAddressRaw;
+using streamr::dht::Identifiers;
+using streamr::dht::store::LocalDataStore;
+using streamr::dht::testutils::createMockDataEntry;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::dht::testutils::MockDataEntryOptions;
+
+namespace {
+
+constexpr uint32_t maxTtl = 30000;
+
+DhtAddress keyOf(const DataEntry& entry) {
+    return Identifiers::getDhtAddressFromRaw(DhtAddressRaw{entry.key()});
+}
+
+DhtAddress creatorOf(const DataEntry& entry) {
+    return Identifiers::getDhtAddressFromRaw(DhtAddressRaw{entry.creator()});
+}
+
+bool containsCreator(
+    const std::vector<DataEntry>& entries, const DhtAddress& creator) {
+    return std::ranges::any_of(entries, [&creator](const DataEntry& entry) {
+        return creatorOf(entry) == creator;
+    });
+}
+
+} // namespace
+
+class LocalDataStoreTest : public ::testing::Test {
+protected:
+    LocalDataStore localDataStore{maxTtl};
+
+    void TearDown() override { this->localDataStore.clear(); }
+};
+
+TEST_F(LocalDataStoreTest, CanStore) {
+    const auto storedEntry = createMockDataEntry();
+    this->localDataStore.storeEntry(storedEntry);
+    const auto fetched = this->localDataStore.values(keyOf(storedEntry));
+    ASSERT_EQ(fetched.size(), 1U);
+    EXPECT_EQ(creatorOf(fetched[0]), creatorOf(storedEntry));
+}
+
+TEST_F(LocalDataStoreTest, MultipleStorersBehindOneKey) {
+    const DhtAddress key = Identifiers::createRandomDhtAddress();
+    const DhtAddress creator1 = Identifiers::createRandomDhtAddress();
+    const DhtAddress creator2 = Identifiers::createRandomDhtAddress();
+    this->localDataStore.storeEntry(createMockDataEntry(
+        MockDataEntryOptions{.key = key, .creator = creator1}));
+    this->localDataStore.storeEntry(createMockDataEntry(
+        MockDataEntryOptions{.key = key, .creator = creator2}));
+    const auto fetched = this->localDataStore.values(key);
+    EXPECT_EQ(fetched.size(), 2U);
+    EXPECT_TRUE(containsCreator(fetched, creator1));
+    EXPECT_TRUE(containsCreator(fetched, creator2));
+}
+
+TEST_F(LocalDataStoreTest, CanRemoveDataEntries) {
+    const DhtAddress key = Identifiers::createRandomDhtAddress();
+    const DhtAddress creator1 = Identifiers::createRandomDhtAddress();
+    const DhtAddress creator2 = Identifiers::createRandomDhtAddress();
+    this->localDataStore.storeEntry(createMockDataEntry(
+        MockDataEntryOptions{.key = key, .creator = creator1}));
+    this->localDataStore.storeEntry(createMockDataEntry(
+        MockDataEntryOptions{.key = key, .creator = creator2}));
+    this->localDataStore.deleteEntry(key, creator1);
+    const auto fetched = this->localDataStore.values(key);
+    ASSERT_EQ(fetched.size(), 1U);
+    EXPECT_EQ(creatorOf(fetched[0]), creator2);
+}
+
+TEST_F(LocalDataStoreTest, CanRemoveAllDataEntries) {
+    const DhtAddress key = Identifiers::createRandomDhtAddress();
+    const DhtAddress creator1 = Identifiers::createRandomDhtAddress();
+    const DhtAddress creator2 = Identifiers::createRandomDhtAddress();
+    this->localDataStore.storeEntry(createMockDataEntry(
+        MockDataEntryOptions{.key = key, .creator = creator1}));
+    this->localDataStore.storeEntry(createMockDataEntry(
+        MockDataEntryOptions{.key = key, .creator = creator2}));
+    this->localDataStore.deleteEntry(key, creator1);
+    this->localDataStore.deleteEntry(key, creator2);
+    EXPECT_TRUE(this->localDataStore.values(key).empty());
+}
+
+TEST_F(LocalDataStoreTest, DataIsDeletedAfterTtl) {
+    constexpr uint32_t shortTtl = 1000;
+    constexpr int ttlWaitMillis = 1100;
+    const auto storedEntry =
+        createMockDataEntry(MockDataEntryOptions{.ttl = shortTtl});
+    this->localDataStore.storeEntry(storedEntry);
+    EXPECT_EQ(this->localDataStore.values(keyOf(storedEntry)).size(), 1U);
+    std::this_thread::sleep_for(std::chrono::milliseconds(ttlWaitMillis));
+    EXPECT_TRUE(this->localDataStore.values(keyOf(storedEntry)).empty());
+}
+
+TEST_F(LocalDataStoreTest, MarkAsDeletedHappyPath) {
+    const DhtAddress creator = Identifiers::createRandomDhtAddress();
+    const auto storedEntry =
+        createMockDataEntry(MockDataEntryOptions{.creator = creator});
+    this->localDataStore.storeEntry(storedEntry);
+    const auto notDeleted = this->localDataStore.values(keyOf(storedEntry));
+    ASSERT_EQ(notDeleted.size(), 1U);
+    EXPECT_FALSE(notDeleted[0].deleted());
+    EXPECT_TRUE(
+        this->localDataStore.markAsDeleted(keyOf(storedEntry), creator));
+    const auto deleted = this->localDataStore.values(keyOf(storedEntry));
+    ASSERT_EQ(deleted.size(), 1U);
+    EXPECT_TRUE(deleted[0].deleted());
+}
+
+TEST_F(LocalDataStoreTest, MarkAsDeletedDataNotStored) {
+    EXPECT_FALSE(this->localDataStore.markAsDeleted(
+        Identifiers::createRandomDhtAddress(),
+        Identifiers::getNodeIdFromPeerDescriptor(createMockPeerDescriptor())));
+}
+
+TEST_F(LocalDataStoreTest, MarkAsDeletedWrongCreator) {
+    const auto storedEntry = createMockDataEntry();
+    this->localDataStore.storeEntry(storedEntry);
+    EXPECT_FALSE(this->localDataStore.markAsDeleted(
+        keyOf(storedEntry),
+        Identifiers::getNodeIdFromPeerDescriptor(createMockPeerDescriptor())));
+}

--- a/packages/streamr-dht/test/unit/StoreManagerTest.cpp
+++ b/packages/streamr-dht/test/unit/StoreManagerTest.cpp
@@ -1,0 +1,228 @@
+// Ported from packages/dht/test/unit/StoreManager.test.ts (v103.8.0-rc.3):
+// onContactAdded replicates data to a newly-added node when this node is the
+// primary storer and the new node is within the redundancy factor, and marks
+// entries stale when this node drops out of the storer set.
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+#include <gtest/gtest.h>
+
+#include <coroutine> // IWYU pragma: keep
+
+import streamr.utils.CoroutineHelper;
+import streamr.utils.waitForCondition;
+import streamr.protorpc.RpcCommunicator;
+import streamr.dht.DhtCallContext;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.getClosestNodes;
+import streamr.dht.Identifiers;
+import streamr.dht.LocalDataStore;
+import streamr.dht.RecursiveOperationSession;
+import streamr.dht.StoreManager;
+import streamr.dht.StoreRpcRemote;
+import streamr.dht.protos;
+import streamr.dht.TestUtils;
+
+using ::dht::DataEntry;
+using ::dht::PeerDescriptor;
+using ::dht::RecursiveOperation;
+using ::dht::ReplicateDataRequest;
+using ::dht::StoreDataRequest;
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtAddressRaw;
+using streamr::dht::Identifiers;
+using streamr::dht::ServiceID;
+using streamr::dht::contact::getClosestNodes;
+using streamr::dht::recursiveoperation::RecursiveOperationResult;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::store::LocalDataStore;
+using streamr::dht::store::StoreManager;
+using streamr::dht::store::StoreManagerOptions;
+using streamr::dht::store::StoreRpcRemote;
+using streamr::dht::testutils::createMockDataEntry;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::protorpc::RpcCommunicator;
+using streamr::utils::blockingWait;
+using streamr::utils::waitForCondition;
+
+using StoreRpcClient = ::dht::StoreRpcClient<DhtCallContext>;
+
+namespace {
+
+constexpr size_t nodeCount = 10;
+constexpr size_t redundancyFactor = 3;
+constexpr size_t largeRedundancyFactor = 100;
+constexpr int replicationWaitMillis = 50;
+constexpr uint32_t defaultMaxTtl = 30000;
+
+// Returns a fixed key/entry and records setAllEntriesAsStale calls.
+class MockLocalDataStore : public LocalDataStore {
+    DataEntry entry;
+    DhtAddress key;
+
+public:
+    int setAllEntriesAsStaleCount = 0;
+
+    MockLocalDataStore(DataEntry entry, DhtAddress key)
+        : LocalDataStore(defaultMaxTtl),
+          entry(std::move(entry)),
+          key(std::move(key)) {}
+
+    std::vector<DhtAddress> keys() override { return {this->key}; }
+    std::vector<DataEntry> values(
+        const std::optional<DhtAddress>& /*key*/) override {
+        return {this->entry};
+    }
+    void setAllEntriesAsStale(const DhtAddress& /*key*/) override {
+        ++this->setAllEntriesAsStaleCount;
+    }
+};
+
+class MockStoreRpcRemote : public StoreRpcRemote {
+    std::atomic<int>* replicateCount;
+    std::atomic<bool>* lastConnect;
+
+public:
+    MockStoreRpcRemote(
+        PeerDescriptor local, // NOLINT
+        PeerDescriptor remote,
+        StoreRpcClient client,
+        std::atomic<int>* replicateCount,
+        std::atomic<bool>* lastConnect)
+        : StoreRpcRemote(std::move(local), std::move(remote), client),
+          replicateCount(replicateCount),
+          lastConnect(lastConnect) {}
+
+    folly::coro::Task<void> replicateData(
+        ReplicateDataRequest /*request*/, bool connect) override {
+        this->lastConnect->store(connect);
+        this->replicateCount->fetch_add(1);
+        co_return;
+    }
+    folly::coro::Task<void> storeData(StoreDataRequest /*request*/) override {
+        co_return;
+    }
+};
+
+} // namespace
+
+class StoreManagerTest : public ::testing::Test {
+protected:
+    RpcCommunicator<DhtCallContext> rpcCommunicator;
+    DataEntry dataEntry = createMockDataEntry();
+    std::vector<PeerDescriptor> allNodes = makeNodes();
+    std::atomic<int> replicateCount{0};
+    std::atomic<bool> lastConnect{false};
+    std::shared_ptr<MockLocalDataStore> localDataStore;
+    std::shared_ptr<StoreManager> manager;
+
+    static std::vector<PeerDescriptor> makeNodes() {
+        std::vector<PeerDescriptor> nodes;
+        nodes.reserve(nodeCount);
+        for (size_t i = 0; i < nodeCount; ++i) {
+            nodes.push_back(createMockPeerDescriptor());
+        }
+        return nodes;
+    }
+
+    [[nodiscard]] DhtAddress dataKey() const {
+        return Identifiers::getDhtAddressFromRaw(
+            DhtAddressRaw{dataEntry.key()});
+    }
+
+    [[nodiscard]] PeerDescriptor nodeCloseToData(size_t index) {
+        return getClosestNodes(this->dataKey(), this->allNodes)[index];
+    }
+
+    void makeManager(const PeerDescriptor& localNode, size_t redundancy) {
+        this->localDataStore = std::make_shared<MockLocalDataStore>(
+            this->dataEntry, this->dataKey());
+        std::vector<PeerDescriptor> neighbors;
+        for (const auto& node : this->allNodes) {
+            if (!Identifiers::areEqualPeerDescriptors(node, localNode)) {
+                neighbors.push_back(node);
+            }
+        }
+        this->manager = StoreManager::newInstance(
+            StoreManagerOptions{
+                .rpcCommunicator = this->rpcCommunicator,
+                .localPeerDescriptor = localNode,
+                .localDataStore = *this->localDataStore,
+                .serviceId = ServiceID{"StoreManager"},
+                .highestTtl = defaultMaxTtl,
+                .redundancyFactor = redundancy,
+                .getNeighbors = [neighbors]() { return neighbors; },
+                .createRpcRemote = [this,
+                                    localNode](const PeerDescriptor& contact)
+                    -> std::shared_ptr<StoreRpcRemote> {
+                    return std::make_shared<MockStoreRpcRemote>(
+                        localNode,
+                        contact,
+                        StoreRpcClient(this->rpcCommunicator),
+                        &this->replicateCount,
+                        &this->lastConnect);
+                },
+                .executeRecursiveOperation =
+                    [](const DhtAddress& /*key*/,
+                       RecursiveOperation /*operation*/)
+                    -> folly::coro::Task<RecursiveOperationResult> {
+                    co_return RecursiveOperationResult{};
+                }});
+    }
+
+    void TearDown() override {
+        if (this->manager) {
+            blockingWait(this->manager->destroy());
+        }
+    }
+};
+
+TEST_F(StoreManagerTest, PrimaryStorerNewNodeWithinRedundancy) {
+    makeManager(nodeCloseToData(0), redundancyFactor);
+    this->manager->onContactAdded(nodeCloseToData(2));
+    blockingWait(waitForCondition(
+        [this]() { return this->replicateCount.load() == 1; }));
+    EXPECT_TRUE(this->lastConnect.load());
+    EXPECT_EQ(this->localDataStore->setAllEntriesAsStaleCount, 0);
+}
+
+TEST_F(StoreManagerTest, PrimaryStorerNewNodeNotWithinRedundancy) {
+    makeManager(nodeCloseToData(0), redundancyFactor);
+    this->manager->onContactAdded(nodeCloseToData(4));
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(replicationWaitMillis));
+    EXPECT_EQ(this->replicateCount.load(), 0);
+    EXPECT_EQ(this->localDataStore->setAllEntriesAsStaleCount, 0);
+}
+
+TEST_F(StoreManagerTest, NotPrimaryStorerThisNodeWithinRedundancy) {
+    makeManager(nodeCloseToData(1), redundancyFactor);
+    this->manager->onContactAdded(nodeCloseToData(4));
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(replicationWaitMillis));
+    EXPECT_EQ(this->replicateCount.load(), 0);
+    EXPECT_EQ(this->localDataStore->setAllEntriesAsStaleCount, 0);
+}
+
+TEST_F(StoreManagerTest, NotPrimaryStorerThisNodeNotWithinRedundancy) {
+    makeManager(nodeCloseToData(3), redundancyFactor);
+    this->manager->onContactAdded(nodeCloseToData(4));
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(replicationWaitMillis));
+    EXPECT_EQ(this->replicateCount.load(), 0);
+    EXPECT_EQ(this->localDataStore->setAllEntriesAsStaleCount, 1);
+}
+
+TEST_F(StoreManagerTest, NotPrimaryWithinRedundancyFewNeighbors) {
+    makeManager(nodeCloseToData(3), largeRedundancyFactor);
+    this->manager->onContactAdded(nodeCloseToData(4));
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(replicationWaitMillis));
+    EXPECT_EQ(this->replicateCount.load(), 0);
+    EXPECT_EQ(this->localDataStore->setAllEntriesAsStaleCount, 0);
+}

--- a/packages/streamr-dht/test/unit/StoreRpcLocalTest.cpp
+++ b/packages/streamr-dht/test/unit/StoreRpcLocalTest.cpp
@@ -1,0 +1,174 @@
+// Ported from packages/dht/test/unit/StoreRpcLocal.test.ts
+// (v103.8.0-rc.3): storeData marks entries stale unless this node stores the
+// key; replicateData fans a newly stored entry out to the neighbouring
+// storers (all of them if this node is the primary storer, else the closest
+// one), never to the requestor or self.
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
+#include <gtest/gtest.h>
+
+import streamr.dht.DhtCallContext;
+import streamr.dht.getClosestNodes;
+import streamr.dht.Identifiers;
+import streamr.dht.LocalDataStore;
+import streamr.dht.StoreRpcLocal;
+import streamr.dht.protos;
+import streamr.dht.TestUtils;
+
+using ::dht::DataEntry;
+using ::dht::PeerDescriptor;
+using ::dht::ReplicateDataRequest;
+using ::dht::StoreDataRequest;
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtAddressRaw;
+using streamr::dht::Identifiers;
+using streamr::dht::contact::getClosestNodes;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::store::LocalDataStore;
+using streamr::dht::store::StoreRpcLocal;
+using streamr::dht::store::StoreRpcLocalOptions;
+using streamr::dht::testutils::createMockDataEntry;
+using streamr::dht::testutils::createMockPeerDescriptor;
+
+namespace {
+
+constexpr size_t nodeCount = 5;
+
+class MockLocalDataStore : public LocalDataStore {
+public:
+    bool storeEntryResult = true;
+    int setAllEntriesAsStaleCount = 0;
+
+    MockLocalDataStore() : LocalDataStore(0) {}
+
+    bool storeEntry(const DataEntry& /*dataEntry*/) override {
+        return this->storeEntryResult;
+    }
+    void setAllEntriesAsStale(const DhtAddress& /*key*/) override {
+        ++this->setAllEntriesAsStaleCount;
+    }
+};
+
+} // namespace
+
+class StoreRpcLocalTest : public ::testing::Test {
+protected:
+    MockLocalDataStore localDataStore;
+    DataEntry dataEntry = createMockDataEntry();
+    std::vector<PeerDescriptor> allNodes = makeNodes();
+    int replicateCount = 0;
+
+    static std::vector<PeerDescriptor> makeNodes() {
+        std::vector<PeerDescriptor> nodes;
+        nodes.reserve(nodeCount);
+        for (size_t i = 0; i < nodeCount; ++i) {
+            nodes.push_back(createMockPeerDescriptor());
+        }
+        return nodes;
+    }
+
+    [[nodiscard]] DhtAddress dataKey() const {
+        return Identifiers::getDhtAddressFromRaw(
+            DhtAddressRaw{dataEntry.key()});
+    }
+
+    [[nodiscard]] PeerDescriptor nodeCloseToData(size_t index) {
+        return getClosestNodes(this->dataKey(), this->allNodes)[index];
+    }
+
+    [[nodiscard]] std::unique_ptr<StoreRpcLocal> makeLocal(
+        const PeerDescriptor& localNode, bool excludeLocalFromStorers) {
+        return std::make_unique<StoreRpcLocal>(StoreRpcLocalOptions{
+            .localDataStore = this->localDataStore,
+            .localPeerDescriptor = localNode,
+            .replicateDataToContact =
+                [this](
+                    const DataEntry& /*entry*/,
+                    const PeerDescriptor& /*peer*/) { ++this->replicateCount; },
+            .getStorers =
+                [this, localNode, excludeLocalFromStorers](
+                    const DhtAddress& key) {
+                    auto storers = getClosestNodes(key, this->allNodes);
+                    if (excludeLocalFromStorers) {
+                        std::erase_if(
+                            storers, [&localNode](const PeerDescriptor& peer) {
+                                return Identifiers::areEqualPeerDescriptors(
+                                    peer, localNode);
+                            });
+                    }
+                    return storers;
+                }});
+    }
+
+    [[nodiscard]] static DhtCallContext contextFromRandom() {
+        DhtCallContext context;
+        context.incomingSourceDescriptor = createMockPeerDescriptor();
+        return context;
+    }
+
+    StoreDataRequest storeRequest() {
+        StoreDataRequest request;
+        request.set_key(this->dataEntry.key());
+        return request;
+    }
+
+    ReplicateDataRequest replicateRequest() {
+        ReplicateDataRequest request;
+        *request.mutable_entry() = this->dataEntry;
+        return request;
+    }
+};
+
+TEST_F(StoreRpcLocalTest, PrimaryStorerStoreData) {
+    auto local = makeLocal(nodeCloseToData(0), false);
+    local->storeData(storeRequest(), DhtCallContext());
+    EXPECT_EQ(this->localDataStore.setAllEntriesAsStaleCount, 0);
+}
+
+TEST_F(StoreRpcLocalTest, PrimaryStorerReplicateData) {
+    auto local = makeLocal(nodeCloseToData(0), false);
+    local->replicateData(
+        replicateRequest(), StoreRpcLocalTest::contextFromRandom());
+    EXPECT_EQ(this->localDataStore.setAllEntriesAsStaleCount, 0);
+    EXPECT_EQ(this->replicateCount, static_cast<int>(nodeCount - 1));
+}
+
+TEST_F(StoreRpcLocalTest, StorerStoreData) {
+    auto local = makeLocal(nodeCloseToData(1), false);
+    local->storeData(storeRequest(), DhtCallContext());
+    EXPECT_EQ(this->localDataStore.setAllEntriesAsStaleCount, 0);
+}
+
+TEST_F(StoreRpcLocalTest, StorerReplicateData) {
+    auto local = makeLocal(nodeCloseToData(1), false);
+    local->replicateData(
+        replicateRequest(), StoreRpcLocalTest::contextFromRandom());
+    EXPECT_EQ(this->localDataStore.setAllEntriesAsStaleCount, 0);
+    EXPECT_EQ(this->replicateCount, 1);
+}
+
+TEST_F(StoreRpcLocalTest, NotStorerStoreData) {
+    auto local = makeLocal(nodeCloseToData(nodeCount - 1), true);
+    local->storeData(storeRequest(), DhtCallContext());
+    EXPECT_GT(this->localDataStore.setAllEntriesAsStaleCount, 0);
+}
+
+TEST_F(StoreRpcLocalTest, NotStorerReplicateData) {
+    auto local = makeLocal(nodeCloseToData(nodeCount - 1), true);
+    local->replicateData(
+        replicateRequest(), StoreRpcLocalTest::contextFromRandom());
+    EXPECT_EQ(this->localDataStore.setAllEntriesAsStaleCount, 1);
+    EXPECT_EQ(this->replicateCount, 1);
+}
+
+TEST_F(StoreRpcLocalTest, DataNotStoredReplicateData) {
+    this->localDataStore.storeEntryResult = false;
+    auto local = makeLocal(nodeCloseToData(1), false);
+    local->replicateData(
+        replicateRequest(), StoreRpcLocalTest::contextFromRandom());
+    EXPECT_EQ(this->localDataStore.setAllEntriesAsStaleCount, 0);
+    EXPECT_EQ(this->replicateCount, 0);
+}

--- a/packages/streamr-dht/test/utils/TestUtils.cppm
+++ b/packages/streamr-dht/test/utils/TestUtils.cppm
@@ -7,6 +7,8 @@
 // (trackerless-network-completion-plan.md, phase 0.2).
 module;
 
+#include <chrono>
+#include <cstdint>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -26,9 +28,11 @@ export namespace streamr::dht::testutils {
 
 using ::dht::ClosestPeersRequest;
 using ::dht::ConnectivityMethod;
+using ::dht::DataEntry;
 using ::dht::NodeType;
 using ::dht::PeerDescriptor;
 using ::protorpc::RpcMessage;
+using streamr::dht::DhtAddress;
 
 // Ported from createMockPeerDescriptor() (test/utils/utils.ts). The TS
 // version merges a Partial<PeerDescriptor> over the defaults; in C++ the
@@ -40,6 +44,39 @@ inline PeerDescriptor createMockPeerDescriptor() {
             Identifiers::createRandomDhtAddress()));
     descriptor.set_type(NodeType::NODEJS);
     return descriptor;
+}
+
+// Ported from createMockDataEntry() (test/utils/mock/mockDataEntry.ts). The
+// data payload is left empty — the store tests identify entries by (key,
+// creator), not by the packed data.
+struct MockDataEntryOptions {
+    std::optional<DhtAddress> key;
+    std::optional<DhtAddress> creator;
+    std::optional<uint32_t> ttl;
+};
+
+inline DataEntry createMockDataEntry(const MockDataEntryOptions& opts = {}) {
+    constexpr uint32_t defaultTtl = 10000;
+    DataEntry entry;
+    entry.set_key(
+        Identifiers::getRawFromDhtAddress(
+            opts.key.value_or(Identifiers::createRandomDhtAddress())));
+    entry.set_creator(
+        Identifiers::getRawFromDhtAddress(
+            opts.creator.value_or(Identifiers::createRandomDhtAddress())));
+    entry.set_ttl(opts.ttl.value_or(defaultTtl));
+    entry.set_stale(false);
+    entry.set_deleted(false);
+    const auto sinceEpoch = std::chrono::system_clock::now().time_since_epoch();
+    const auto seconds =
+        std::chrono::duration_cast<std::chrono::seconds>(sinceEpoch);
+    entry.mutable_createdat()->set_seconds(seconds.count());
+    entry.mutable_createdat()->set_nanos(
+        static_cast<int32_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                sinceEpoch - seconds)
+                .count()));
+    return entry;
 }
 
 // Ported from createWrappedClosestPeersRequest() (test/utils/utils.ts).


### PR DESCRIPTION
Phase A6 of the trackerless-network completion plan: the store cluster, completing Milestone A's per-node data storage. `LocalDataStore` was pulled forward in A5; this adds the RPC layer and the manager on top of it.

## What this adds

- **`StoreRpcRemote`** — the client to store on / replicate to a peer (`storeData` / `replicateData`). Both are virtual so a test can substitute a counting mock.
- **`StoreRpcLocal`** — the `StoreRpc` server. `storeData` marks entries stale unless this node stores the key; `replicateData` writes a replicated entry and, when newly stored, fans it out to the neighbouring storers (all of them if this node is the primary storer, else the closest one; never to the requestor or self).
- **`StoreManager`** — registers the `StoreRpc` handlers, stores data to the k closest nodes (`storeDataToDht`, over the A5 recursive find), and keeps replicas in sync as the neighbourhood changes (`onContactAdded`).

## Design notes

- **`LocalDataStore` made polymorphic**: its public methods are now `virtual` so `StoreManager` / `StoreRpcLocal` can hold it by reference and the unit tests can mock it (the TS tests duck-type a partial `localDataStore`).
- **Callbacks for testability**: the recursive-find and per-contact remote creation are options callbacks (matching this package's callback-options style — PeerManager, RouterRpcLocal, RecursiveOperationManager all do this — and letting the unit test substitute a mock router / remote, since the C++ `Router` and `StoreRpcRemote` are concrete).
- **Fire-and-forget replications**: TS defers each replication with `setImmediate` + `executeSafePromise`. Here they're dispatched onto a small worker executor, so `StoreManager` is owned through a `shared_ptr`; the `StoreRpcLocal` fan-out calls a synchronous void callback that kicks the async replication off.

## Tests (ported from the matching TS tests)

- **`LocalDataStoreTest`** (unit) — store / remove / mark-deleted, and a **real-time TTL-expiry** case (`ttl=1000`, wait 1100 ms) that also validates the A5 `MapWithTtl` lazy-expiry adaptation: the entry is gone on the next access after the TTL elapses.
- **`StoreRpcLocalTest`** (unit) — `storeData` staleness + `replicateData` fan-out counts in the primary-storer / storer / not-storer / not-stored cases.
- **`StoreManagerTest`** (unit) — `onContactAdded` replication and stale-marking across the primary/redundancy scenarios (the async replication is awaited via `waitForCondition`).

The integration `Store*.test.ts` / `ReplicateData.test.ts` are **deferred to A8** — they build full `DhtNode`s over the Simulator.

## Verification

- `./test.sh` — **427/427 tests pass** (20 new).
- `./lint.sh` — green across all packages.

### Lint note

`StoreRpcLocalTest.cpp` and `StoreManagerTest.cpp` are excluded from `clangd-tidy` (still checked by `clang-format`): they trip the known clangd module std-type unification false positive on gtest's own `CodeLocation` / `MakeAndRegisterTestInfo`, following the existing exclusion pattern. `LocalDataStoreTest.cpp` does not trip it and stays in the clangd-tidy set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)