### PR TITLE
Fix RecursiveOperationManagerTest against the async RPC server

### DIFF
--- a/packages/streamr-dht/test/unit/RecursiveOperationManagerTest.cpp
+++ b/packages/streamr-dht/test/unit/RecursiveOperationManagerTest.cpp
@@ -3,9 +3,12 @@
 // no-targets, duplicate, bad-payload) and the no-connections execute path.
 // The Router is substituted by callbacks (the C++ Router is concrete);
 // MockTransport / MockConnectionsView stand in for the transport.
+#include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -62,9 +65,18 @@ constexpr uint32_t maxTtl = 3000;
 // A real RpcCommunicator with a helper to invoke a registered handler by
 // name; surfaces a handler exception as a thrown error (the response
 // carries errorType).
+//
+// The server now responds ASYNCHRONOUSLY (handleIncomingMessage schedules
+// the response on a worker and returns immediately), so the ack arrives on
+// another thread. The ack response carries the same requestid as the
+// request, so callRpcMethod waits for the matching response under a
+// condition variable.
 class FakeRpcCommunicator : public RpcCommunicator<DhtCallContext> {
 private:
-    bool capturing = false;
+    static constexpr std::chrono::seconds ackWaitTimeout{5};
+
+    std::mutex mutex;
+    std::condition_variable cv;
     std::string captureRequestId;
     std::optional<RpcMessage> captured;
 
@@ -75,9 +87,10 @@ public:
                 const RpcMessage& message,
                 const std::string& /*requestId*/,
                 const DhtCallContext& /*context*/) {
-                if (this->capturing &&
-                    message.requestid() == this->captureRequestId) {
+                std::lock_guard lock(this->mutex);
+                if (message.requestid() == this->captureRequestId) {
                     this->captured = message;
+                    this->cv.notify_all();
                 }
             });
     }
@@ -89,11 +102,17 @@ public:
         (*requestMessage.mutable_header())["method"] = methodName;
         (*requestMessage.mutable_header())["request"] = "request";
         requestMessage.set_requestid(Uuid::v4());
-        this->captured.reset();
-        this->captureRequestId = requestMessage.requestid();
-        this->capturing = true;
+        {
+            std::lock_guard lock(this->mutex);
+            this->captured.reset();
+            this->captureRequestId = requestMessage.requestid();
+        }
         this->handleIncomingMessage(requestMessage, DhtCallContext());
-        this->capturing = false;
+
+        std::unique_lock lock(this->mutex);
+        this->cv.wait_for(lock, ackWaitTimeout, [this]() {
+            return this->captured.has_value();
+        });
         Resp response;
         if (this->captured.has_value()) {
             if (this->captured->has_errortype()) {


### PR DESCRIPTION
`main` is currently red: three `RecursiveOperationManagerTest` cases fail (`ServerThrowsIfPayloadNotRecursive`, `NoTargets`, `Error`).

## Cause

The proto-rpc async-server change (#62) made `handleIncomingMessage` schedule the RPC response on a worker and return immediately, so an ack now arrives on **another thread**. #62 updated `RouterTest`'s `FakeRpcCommunicator` to wait for the ack under a condition variable — but `RecursiveOperationManagerTest` (merged earlier, in #61) kept its **synchronous** capture, so `callRpcMethod` read an empty ack and the assertions failed. (#62 branched off A4, before that test existed, so it couldn't have updated it; the two just missed each other across the merge order A5 → #62 → A6.)

## Fix

Apply the same async-aware pattern `RouterTest` already uses: the outgoing callback captures the response (matched by requestid) under a mutex and notifies a condition variable; `callRpcMethod` waits for it. Test-only change — no production code touched.

## Verification

- The full dht unit suite is green again (169/169), dht integration 12/12.
- `RecursiveOperationManagerTest` run at `--gtest_repeat=10` — no failures.
- clangd-tidy + clang-format clean on the changed file.

(The local pre-push hook hit an unrelated transient clangd-tidy LSP crash while linting `streamr-proto-rpc`, which this PR does not touch; CI runs the full lint.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)