### PR TITLE
Phase A7: discovery and join (PeerDiscovery, DiscoverySession, RingDiscoverySession)

### DIFF
--- a/packages/streamr-dht/CMakeLists.txt
+++ b/packages/streamr-dht/CMakeLists.txt
@@ -220,6 +220,7 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         test/unit/LocalDataStoreTest.cpp
         test/unit/StoreRpcLocalTest.cpp
         test/unit/StoreManagerTest.cpp
+        test/unit/DiscoverySessionTest.cpp
     )
 
     target_include_directories(streamr-dht-test-unit

--- a/packages/streamr-dht/modules/dht/DhtNodeRpcRemote.cppm
+++ b/packages/streamr-dht/modules/dht/DhtNodeRpcRemote.cppm
@@ -95,7 +95,8 @@ public:
             this->getPeerDescriptor());
     }
 
-    folly::coro::Task<std::vector<PeerDescriptor>> getClosestPeers(
+    // Virtual (like ping()) so tests can substitute a deterministic result.
+    virtual folly::coro::Task<std::vector<PeerDescriptor>> getClosestPeers(
         const DhtAddress& nodeId) {
         ClosestPeersRequest request;
         request.set_nodeid(Identifiers::getRawFromDhtAddress(nodeId));
@@ -112,7 +113,8 @@ public:
         co_return peers;
     }
 
-    folly::coro::Task<ClosestRingPeerDescriptors> getClosestRingPeers(
+    // Virtual (like ping()) so tests can substitute a deterministic result.
+    virtual folly::coro::Task<ClosestRingPeerDescriptors> getClosestRingPeers(
         const RingIdRaw& ringIdRaw) {
         ClosestRingPeersRequest request;
         request.set_ringid(ringIdRaw);

--- a/packages/streamr-dht/modules/dht/PeerManager.cppm
+++ b/packages/streamr-dht/modules/dht/PeerManager.cppm
@@ -429,6 +429,21 @@ public:
         return this->nearbyContacts->getSize(excludedNodeIds);
     }
 
+    // TS returns the SortedContactList itself; the only consumer
+    // (DiscoverySession) maps it straight to peer descriptors, so this returns
+    // the descriptors directly and keeps the list access under the mutex.
+    [[nodiscard]] std::vector<PeerDescriptor> getNearbyContacts() {
+        std::scoped_lock lock(this->mutex);
+        const auto contacts =
+            this->nearbyContacts->getAllContactsInUndefinedOrder();
+        std::vector<PeerDescriptor> result;
+        result.reserve(contacts.size());
+        for (const auto& contact : contacts) {
+            result.push_back(contact->getPeerDescriptor());
+        }
+        return result;
+    }
+
     [[nodiscard]] size_t getNeighborCount() {
         std::scoped_lock lock(this->mutex);
         return this->neighbors->count();

--- a/packages/streamr-dht/modules/dht/consts.cppm
+++ b/packages/streamr-dht/modules/dht/consts.cppm
@@ -1,0 +1,17 @@
+// Module streamr.dht.consts
+// Ported from packages/dht/src/dht/consts.ts (v103.8.0-rc.3).
+module;
+
+#include <string>
+
+export module streamr.dht.consts;
+
+import streamr.dht.Identifiers;
+
+export namespace streamr::dht {
+
+// TODO (from TS): move this to the trackerless-network package and make the
+// serviceId a required parameter.
+inline const ServiceID CONTROL_LAYER_NODE_SERVICE_ID{"layer0"};
+
+} // namespace streamr::dht

--- a/packages/streamr-dht/modules/dht/discovery/DiscoverySession.cppm
+++ b/packages/streamr-dht/modules/dht/discovery/DiscoverySession.cppm
@@ -1,0 +1,262 @@
+// Module streamr.dht.DiscoverySession
+// Ported from packages/dht/src/dht/discovery/DiscoverySession.ts
+// (v103.8.0-rc.3). One Kademlia-style lookup toward a target id: it keeps
+// up to `parallelism` getClosestPeers requests in flight against the closest
+// uncontacted nearby contacts, feeds the returned peers back into the
+// PeerManager, and finishes once the frontier is exhausted or `noProgressLimit`
+// consecutive requests fail to bring a closer neighbour.
+//
+// TS drives the fan-out through promise continuations: each request's
+// `.finally` re-invokes findMoreContacts, which tops the in-flight set back up
+// to `parallelism`. This port expresses the identical rolling concurrency as
+// `parallelism` worker coroutines that each pull the next-closest uncontacted
+// node from the shared frontier under the session mutex, so at most
+// `parallelism` requests run at once and each completion immediately refills.
+// The TS Gate/withTimeout pair becomes structured concurrency: findClosestNodes
+// awaits every worker under a single folly timeout (a `done` flag, guarded by
+// the mutex, stands in for the single-shot Gate). Because the workers are
+// awaited rather than detached, `this` outlives them and no self-pin is needed.
+//
+// Discovery is I/O-bound (it spends its time awaiting RPC responses, not
+// computing), so unlike the Router's routing-table work it is not offloaded to
+// a dedicated worker executor; the fan-out runs on whatever executor drives the
+// join and yields at every RPC await.
+module;
+
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+#include <coroutine> // IWYU pragma: keep
+
+export module streamr.dht.DiscoverySession;
+
+import streamr.utils.AbortController;
+import streamr.utils.CoroutineHelper;
+import streamr.utils.Uuid;
+import streamr.logger.SLogger;
+import streamr.dht.DhtNodeRpcRemote;
+import streamr.dht.getClosestNodes;
+import streamr.dht.getPeerDistance;
+import streamr.dht.Identifiers;
+import streamr.dht.PeerManager;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+using streamr::utils::AbortSignal;
+using streamr::utils::Uuid;
+
+export namespace streamr::dht::discovery {
+
+using ::dht::PeerDescriptor;
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtAddressRaw;
+using streamr::dht::DhtNodeRpcRemote;
+using streamr::dht::Identifiers;
+using streamr::dht::PeerManager;
+using streamr::dht::contact::getClosestNodes;
+using streamr::dht::contact::GetClosestNodesOptions;
+using streamr::dht::helpers::getPeerDistance;
+
+struct DiscoverySessionOptions {
+    DhtAddress targetId;
+    size_t parallelism;
+    size_t noProgressLimit;
+    PeerManager& peerManager;
+    // Mutated by this session (and, when several entry points are joined at
+    // once, by the sibling sessions that share the same set). Owned by the
+    // caller; it outlives findClosestNodes.
+    std::set<DhtAddress>& contactedPeers;
+    AbortSignal& abortSignal;
+    std::function<std::shared_ptr<DhtNodeRpcRemote>(const PeerDescriptor&)>
+        createDhtNodeRpcRemote;
+};
+
+class DiscoverySession {
+private:
+    std::string id = Uuid::v4();
+    size_t noProgressCounter = 0;
+    std::set<DhtAddress> ongoingRequests;
+    bool done = false; // the single-shot Gate, guarded by the mutex
+    std::recursive_mutex mutex;
+    DiscoverySessionOptions options;
+
+    void addContacts(const std::vector<PeerDescriptor>& contacts) {
+        std::scoped_lock lock(this->mutex);
+        if (this->options.abortSignal.aborted || this->done) {
+            return;
+        }
+        for (const auto& contact : contacts) {
+            this->options.peerManager.addContact(contact);
+        }
+    }
+
+    folly::coro::Task<std::vector<PeerDescriptor>>
+    fetchClosestNeighborsFromRemote(PeerDescriptor peerDescriptor) {
+        {
+            std::scoped_lock lock(this->mutex);
+            if (this->options.abortSignal.aborted || this->done) {
+                co_return std::vector<PeerDescriptor>{};
+            }
+        }
+        const auto nodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor);
+        SLogger::trace("Getting closest neighbors from remote: " + nodeId);
+        const auto remote =
+            this->options.createDhtNodeRpcRemote(peerDescriptor);
+        auto returnedContacts =
+            co_await remote->getClosestPeers(this->options.targetId);
+        {
+            std::scoped_lock lock(this->mutex);
+            this->options.peerManager.setContactActive(nodeId);
+        }
+        co_return returnedContacts;
+    }
+
+    // Returns nullopt when there are no neighbours yet (TS would index [0] of
+    // an empty array; guarding avoids the undefined access).
+    [[nodiscard]] std::optional<PeerDescriptor> getClosestNeighbor() {
+        std::vector<PeerDescriptor> neighborDescriptors;
+        const auto neighbors = this->options.peerManager.getNeighbors();
+        neighborDescriptors.reserve(neighbors.size());
+        for (const auto& neighbor : neighbors) {
+            neighborDescriptors.push_back(neighbor->getPeerDescriptor());
+        }
+        const auto closest = getClosestNodes(
+            this->options.targetId,
+            neighborDescriptors,
+            GetClosestNodesOptions{.maxCount = 1});
+        if (closest.empty()) {
+            return std::nullopt;
+        }
+        return closest.front();
+    }
+
+    void onRequestSucceeded(
+        const DhtAddress& nodeId, const std::vector<PeerDescriptor>& contacts) {
+        std::scoped_lock lock(this->mutex);
+        if (!this->ongoingRequests.contains(nodeId)) {
+            return;
+        }
+        this->ongoingRequests.erase(nodeId);
+        const auto targetIdRaw =
+            Identifiers::getRawFromDhtAddress(this->options.targetId);
+        const auto oldClosestNeighbor = this->getClosestNeighbor();
+        this->addContacts(contacts);
+        const auto newClosestNeighbor = this->getClosestNeighbor();
+        // No prior neighbour means the newly added contacts are progress; a
+        // new closest that is not nearer than the old one is not.
+        if (oldClosestNeighbor.has_value() && newClosestNeighbor.has_value()) {
+            const auto oldClosestDistance = getPeerDistance(
+                targetIdRaw, DhtAddressRaw{oldClosestNeighbor->nodeid()});
+            const auto newClosestDistance = getPeerDistance(
+                targetIdRaw, DhtAddressRaw{newClosestNeighbor->nodeid()});
+            if (newClosestDistance >= oldClosestDistance) {
+                this->noProgressCounter++;
+            }
+        } else if (!newClosestNeighbor.has_value()) {
+            this->noProgressCounter++;
+        }
+    }
+
+    void onRequestFailed(const DhtAddress& nodeId) {
+        std::scoped_lock lock(this->mutex);
+        if (!this->ongoingRequests.contains(nodeId)) {
+            return;
+        }
+        this->ongoingRequests.erase(nodeId);
+        this->options.peerManager.removeContact(nodeId);
+    }
+
+    // One worker of the rolling fan-out: repeatedly claim the closest
+    // uncontacted node and query it, until the session is done.
+    folly::coro::Task<void> worker() {
+        while (true) {
+            std::optional<PeerDescriptor> node;
+            {
+                std::scoped_lock lock(this->mutex);
+                if (this->options.abortSignal.aborted || this->done) {
+                    co_return;
+                }
+                if (this->noProgressCounter >= this->options.noProgressLimit) {
+                    this->done = true;
+                    co_return;
+                }
+                const auto uncontacted = getClosestNodes(
+                    this->options.targetId,
+                    this->options.peerManager.getNearbyContacts(),
+                    GetClosestNodesOptions{
+                        .maxCount = this->options.parallelism,
+                        .excludedNodeIds = this->options.contactedPeers});
+                for (const auto& candidate : uncontacted) {
+                    const auto candidateId =
+                        Identifiers::getNodeIdFromPeerDescriptor(candidate);
+                    if (!this->ongoingRequests.contains(candidateId)) {
+                        node = candidate;
+                        break;
+                    }
+                }
+                if (!node.has_value()) {
+                    if (this->ongoingRequests.empty()) {
+                        this->done = true;
+                    }
+                    co_return;
+                }
+                const auto nodeId =
+                    Identifiers::getNodeIdFromPeerDescriptor(*node);
+                this->ongoingRequests.insert(nodeId);
+                // TS adds to contactedPeers synchronously at the start of
+                // fetchClosestNeighborsFromRemote, before the await; claiming
+                // it here (under the lock) keeps sibling workers from picking
+                // the same node.
+                this->options.contactedPeers.insert(nodeId);
+            }
+            const auto nodeId = Identifiers::getNodeIdFromPeerDescriptor(*node);
+            try {
+                const auto contacts =
+                    co_await this->fetchClosestNeighborsFromRemote(*node);
+                this->onRequestSucceeded(nodeId, contacts);
+            } catch (const std::exception& e) {
+                SLogger::trace(
+                    "getClosestPeers failed: " + std::string(e.what()));
+                this->onRequestFailed(nodeId);
+            }
+        }
+    }
+
+public:
+    explicit DiscoverySession(DiscoverySessionOptions options)
+        : options(std::move(options)) {}
+
+    [[nodiscard]] const std::string& getId() const { return this->id; }
+
+    folly::coro::Task<void> findClosestNodes(
+        std::chrono::milliseconds timeout) {
+        {
+            std::scoped_lock lock(this->mutex);
+            if (this->options.peerManager.getNearbyContactCount(
+                    this->options.contactedPeers) == 0) {
+                co_return;
+            }
+        }
+        std::vector<folly::coro::Task<void>> workers;
+        workers.reserve(this->options.parallelism);
+        for (size_t i = 0; i < this->options.parallelism; ++i) {
+            workers.push_back(this->worker());
+        }
+        co_await streamr::utils::co_withCancellation(
+            this->options.abortSignal.getCancellationToken(),
+            folly::coro::timeout(
+                folly::coro::collectAllRange(std::move(workers)), timeout));
+    }
+};
+
+} // namespace streamr::dht::discovery

--- a/packages/streamr-dht/modules/dht/discovery/PeerDiscovery.cppm
+++ b/packages/streamr-dht/modules/dht/discovery/PeerDiscovery.cppm
@@ -1,0 +1,473 @@
+// Module streamr.dht.PeerDiscovery
+// Ported from packages/dht/src/dht/discovery/PeerDiscovery.ts
+// (v103.8.0-rc.3). Orchestrates joining the DHT: for each entry point it runs
+// a DiscoverySession toward the local id (plus, optionally, a second session
+// toward the bit-flipped "distant" id), retries the join when no neighbours
+// are found, and once joined keeps a periodic recovery task refreshing the
+// neighbour set. joinRing does the same over the ring topology.
+//
+// PeerDiscovery is shared_ptr-owned (EnableSharedFromThis): the retry timeout
+// and the recovery interval are detached and pin `self` for their lifetime,
+// and they run on a dedicated worker executor so this 2nd-class maintenance
+// work never occupies a caller/delivery thread. Both are torn down by the
+// join abort signal (the same one DhtNode aborts on stop).
+//
+// The join fans out over entry points with collectAllRange; the shared
+// contactedPeers sets are mutated across those sibling sessions. That is safe
+// under cooperative (single-driver) execution, which is how the join is
+// driven; running the fan-out on a multi-threaded executor would need the
+// shared sets synchronised. This is exercised by the phase A8 integration
+// tests (DhtJoinPeerDiscovery, MultipleEntryPointJoining).
+module;
+
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+#include <coroutine> // IWYU pragma: keep
+
+export module streamr.dht.PeerDiscovery;
+
+import streamr.utils.AbortableTimers;
+import streamr.utils.AbortController;
+import streamr.utils.CoroutineHelper;
+import streamr.utils.EnableSharedFromThis;
+import streamr.utils.ExecutorHelper;
+import streamr.utils.scheduleAtInterval;
+import streamr.logger.SLogger;
+import streamr.dht.ConnectionLocker;
+import streamr.dht.ConnectionLockStates;
+import streamr.dht.consts;
+import streamr.dht.DhtNodeRpcRemote;
+import streamr.dht.DiscoverySession;
+import streamr.dht.getClosestNodes;
+import streamr.dht.Identifiers;
+import streamr.dht.PeerManager;
+import streamr.dht.RingDiscoverySession;
+import streamr.dht.ringIdentifiers;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+using streamr::utils::AbortableTimers;
+using streamr::utils::AbortSignal;
+using streamr::utils::EnableSharedFromThis;
+using streamr::utils::scheduleAtInterval;
+
+export namespace streamr::dht::discovery {
+
+using ::dht::PeerDescriptor;
+using streamr::dht::CONTROL_LAYER_NODE_SERVICE_ID;
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtAddressRaw;
+using streamr::dht::DhtNodeRpcRemote;
+using streamr::dht::Identifiers;
+using streamr::dht::PeerManager;
+using streamr::dht::ServiceID;
+using streamr::dht::connection::ConnectionLocker;
+using streamr::dht::connection::LockID;
+using streamr::dht::contact::getClosestNodes;
+using streamr::dht::contact::GetClosestNodesOptions;
+using streamr::dht::contact::getRingIdRawFromPeerDescriptor;
+using streamr::dht::contact::RingIdRaw;
+
+// The bit-flipped id: seeds a discovery session far across the keyspace so the
+// join learns about distant parts of the network, not just the local vicinity.
+inline DhtAddress createDistantDhtAddress(const DhtAddress& address) {
+    const auto raw = Identifiers::getRawFromDhtAddress(address);
+    std::string flipped;
+    flipped.reserve(raw.size());
+    for (const char byte : raw) {
+        flipped.push_back(static_cast<char>(~static_cast<unsigned char>(byte)));
+    }
+    return Identifiers::getDhtAddressFromRaw(DhtAddressRaw{flipped});
+}
+
+struct PeerDiscoveryOptions {
+    PeerDescriptor localPeerDescriptor;
+    size_t joinNoProgressLimit;
+    ServiceID serviceId;
+    size_t parallelism;
+    std::chrono::milliseconds joinTimeout;
+    std::shared_ptr<ConnectionLocker> connectionLocker; // may be null
+    PeerManager& peerManager;
+    AbortSignal& abortSignal;
+    std::function<std::shared_ptr<DhtNodeRpcRemote>(const PeerDescriptor&)>
+        createDhtNodeRpcRemote;
+};
+
+// The distant-join arm of joinDht (TS models it as a discriminated union).
+struct DistantJoinConfig {
+    bool enabled;
+    std::set<DhtAddress> contactedPeers; // meaningful only when enabled
+};
+
+class PeerDiscovery : public EnableSharedFromThis {
+private:
+    // TS uses these literals inline (with TODOs to name them); named here.
+    static constexpr std::chrono::milliseconds rejoinDelay{1000};
+    static constexpr std::chrono::milliseconds rejoinRetryDelay{5000};
+    static constexpr std::chrono::milliseconds recoveryInterval{60000};
+
+    std::map<std::string, std::shared_ptr<DiscoverySession>>
+        ongoingDiscoverySessions;
+    std::map<std::string, std::shared_ptr<RingDiscoverySession>>
+        ongoingRingDiscoverySessions;
+    bool rejoinOngoing = false;
+    bool joinCalled = false;
+    bool recoveryIntervalStarted = false;
+    std::recursive_mutex mutex;
+    // Recovery / rejoin maintenance runs here — 2nd-class work kept off the
+    // caller/delivery threads.
+    folly::CPUThreadPoolExecutor recoveryExecutor{1};
+    PeerDiscoveryOptions options;
+
+    explicit PeerDiscovery(PeerDiscoveryOptions options)
+        : options(std::move(options)) {}
+
+    [[nodiscard]] bool isStopped() const {
+        return this->options.abortSignal.aborted;
+    }
+
+    [[nodiscard]] LockID joinLockId() const {
+        return LockID{
+            static_cast<std::string>(this->options.serviceId) + "::joinDht"};
+    }
+
+    [[nodiscard]] std::shared_ptr<DiscoverySession> createSession(
+        const DhtAddress& targetId, std::set<DhtAddress>& contactedPeers) {
+        return std::make_shared<DiscoverySession>(DiscoverySessionOptions{
+            .targetId = targetId,
+            .parallelism = this->options.parallelism,
+            .noProgressLimit = this->options.joinNoProgressLimit,
+            .peerManager = this->options.peerManager,
+            .contactedPeers = contactedPeers,
+            .abortSignal = this->options.abortSignal,
+            .createDhtNodeRpcRemote = this->options.createDhtNodeRpcRemote});
+    }
+
+    [[nodiscard]] std::shared_ptr<RingDiscoverySession> createRingSession(
+        const RingIdRaw& targetId, std::set<DhtAddress>& contactedPeers) {
+        return std::make_shared<RingDiscoverySession>(
+            RingDiscoverySessionOptions{
+                .targetId = targetId,
+                .parallelism = this->options.parallelism,
+                .noProgressLimit = this->options.joinNoProgressLimit,
+                .peerManager = this->options.peerManager,
+                .contactedPeers = contactedPeers,
+                .abortSignal = this->options.abortSignal});
+    }
+
+    folly::coro::Task<void> runSessions(
+        std::vector<std::shared_ptr<DiscoverySession>> sessions,
+        PeerDescriptor entryPointDescriptor,
+        bool retry) {
+        try {
+            for (const auto& session : sessions) {
+                {
+                    std::scoped_lock lock(this->mutex);
+                    this->ongoingDiscoverySessions[session->getId()] = session;
+                }
+                co_await session->findClosestNodes(this->options.joinTimeout);
+            }
+        } catch (const std::exception&) {
+            SLogger::debug("DHT join timed out");
+        }
+        if (!this->isStopped()) {
+            if (this->options.peerManager.getNeighborCount() == 0) {
+                if (retry) {
+                    this->scheduleRejoin(entryPointDescriptor, rejoinDelay);
+                }
+            } else {
+                co_await this->ensureRecoveryIntervalIsRunning();
+            }
+        }
+        {
+            std::scoped_lock lock(this->mutex);
+            for (const auto& session : sessions) {
+                this->ongoingDiscoverySessions.erase(session->getId());
+            }
+        }
+    }
+
+    folly::coro::Task<void> runRingSessions(
+        std::vector<std::shared_ptr<RingDiscoverySession>> sessions) {
+        try {
+            for (const auto& session : sessions) {
+                {
+                    std::scoped_lock lock(this->mutex);
+                    this->ongoingRingDiscoverySessions[session->getId()] =
+                        session;
+                }
+                co_await session->findClosestNodes(this->options.joinTimeout);
+            }
+        } catch (const std::exception&) {
+            SLogger::debug("Ring join timed out");
+        }
+        {
+            std::scoped_lock lock(this->mutex);
+            for (const auto& session : sessions) {
+                this->ongoingRingDiscoverySessions.erase(session->getId());
+            }
+        }
+    }
+
+    // Detaches a rejoin attempt onto the worker executor after `delay`,
+    // cancelled by the abort signal (TS: setAbortableTimeout(() =>
+    // rejoinDht(...), delay, signal)).
+    void scheduleRejoin(
+        const PeerDescriptor& entryPoint, std::chrono::milliseconds delay) {
+        auto self = this->sharedFromThis<PeerDiscovery>();
+        auto entryPointCopy = entryPoint;
+        AbortableTimers::setAbortableTimeout(
+            [self, entryPointCopy]() {
+                streamr::utils::co_withExecutor(
+                    &self->recoveryExecutor,
+                    folly::coro::co_invoke(
+                        [self, entryPointCopy]() -> folly::coro::Task<void> {
+                            co_await self->rejoinDht(entryPointCopy);
+                        }))
+                    .start();
+            },
+            delay,
+            this->options.abortSignal);
+    }
+
+    folly::coro::Task<void> ensureRecoveryIntervalIsRunning() {
+        bool shouldStart = false;
+        {
+            std::scoped_lock lock(this->mutex);
+            if (!this->recoveryIntervalStarted) {
+                this->recoveryIntervalStarted = true;
+                shouldStart = true;
+            }
+        }
+        if (shouldStart) {
+            auto self = this->sharedFromThis<PeerDiscovery>();
+            co_await scheduleAtInterval(
+                [self]() -> folly::coro::Task<void> {
+                    co_await self->fetchClosestAndRandomNeighbors();
+                },
+                recoveryInterval,
+                true,
+                this->options.abortSignal,
+                &this->recoveryExecutor);
+        }
+    }
+
+    [[nodiscard]] std::vector<PeerDescriptor> getClosestNeighbors(
+        const DhtAddress& referenceId, size_t maxCount) {
+        std::vector<PeerDescriptor> neighborDescriptors;
+        const auto neighbors = this->options.peerManager.getNeighbors();
+        neighborDescriptors.reserve(neighbors.size());
+        for (const auto& neighbor : neighbors) {
+            neighborDescriptors.push_back(neighbor->getPeerDescriptor());
+        }
+        return getClosestNodes(
+            referenceId,
+            neighborDescriptors,
+            GetClosestNodesOptions{.maxCount = maxCount});
+    }
+
+    folly::coro::Task<void> fetchClosestAndRandomNeighbors() {
+        if (this->isStopped()) {
+            co_return;
+        }
+        const auto localNodeId = Identifiers::getNodeIdFromPeerDescriptor(
+            this->options.localPeerDescriptor);
+        const auto nodes =
+            this->getClosestNeighbors(localNodeId, this->options.parallelism);
+        const auto randomNodes =
+            this->getClosestNeighbors(Identifiers::createRandomDhtAddress(), 1);
+        auto self = this->sharedFromThis<PeerDiscovery>();
+        std::vector<folly::coro::Task<void>> fetches;
+        fetches.reserve(nodes.size() + randomNodes.size());
+        for (const auto& node : nodes) {
+            fetches.push_back(
+                folly::coro::co_invoke(
+                    [self, node, localNodeId]() -> folly::coro::Task<void> {
+                        co_await self->fetchAndAddContacts(node, localNodeId);
+                    }));
+        }
+        for (const auto& node : randomNodes) {
+            fetches.push_back(
+                folly::coro::co_invoke(
+                    [self, node]() -> folly::coro::Task<void> {
+                        co_await self->fetchAndAddContacts(
+                            node, Identifiers::createRandomDhtAddress());
+                    }));
+        }
+        // collectAllRange, but each fetch swallows its own failure — the TS
+        // uses Promise.allSettled, so one failed remote does not abort the
+        // rest.
+        co_await folly::coro::collectAllRange(std::move(fetches));
+    }
+
+    folly::coro::Task<void> fetchAndAddContacts(
+        PeerDescriptor node, DhtAddress referenceId) {
+        try {
+            const auto remote = this->options.createDhtNodeRpcRemote(node);
+            const auto contacts = co_await remote->getClosestPeers(referenceId);
+            for (const auto& contact : contacts) {
+                this->options.peerManager.addContact(contact);
+            }
+        } catch (const std::exception& e) {
+            SLogger::trace(
+                "recovery getClosestPeers failed: " + std::string(e.what()));
+        }
+    }
+
+public:
+    [[nodiscard]] static std::shared_ptr<PeerDiscovery> newInstance(
+        PeerDiscoveryOptions options) {
+        struct MakeSharedEnabler : public PeerDiscovery {
+            explicit MakeSharedEnabler(PeerDiscoveryOptions options)
+                : PeerDiscovery(std::move(options)) {}
+        };
+        return std::make_shared<MakeSharedEnabler>(std::move(options));
+    }
+
+    ~PeerDiscovery() override = default;
+
+    PeerDiscovery(const PeerDiscovery&) = delete;
+    PeerDiscovery& operator=(const PeerDiscovery&) = delete;
+    PeerDiscovery(PeerDiscovery&&) = delete;
+    PeerDiscovery& operator=(PeerDiscovery&&) = delete;
+
+    folly::coro::Task<void> joinDht(
+        std::vector<PeerDescriptor> entryPoints,
+        // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+        bool doAdditionalDistantPeerDiscovery = true,
+        bool retry = true) {
+        std::set<DhtAddress> contactedPeers;
+        DistantJoinConfig distantJoinOptions{
+            .enabled = doAdditionalDistantPeerDiscovery, .contactedPeers = {}};
+        auto self = this->sharedFromThis<PeerDiscovery>();
+        std::vector<folly::coro::Task<void>> joins;
+        joins.reserve(entryPoints.size());
+        for (const auto& entryPoint : entryPoints) {
+            joins.push_back(
+                folly::coro::co_invoke(
+                    [self,
+                     entryPoint,
+                     &contactedPeers,
+                     &distantJoinOptions,
+                     retry]() -> folly::coro::Task<void> {
+                        co_await self->joinThroughEntryPoint(
+                            entryPoint,
+                            contactedPeers,
+                            distantJoinOptions,
+                            retry);
+                    }));
+        }
+        co_await folly::coro::collectAllRange(std::move(joins));
+    }
+
+    folly::coro::Task<void> joinThroughEntryPoint(
+        PeerDescriptor entryPointDescriptor,
+        std::set<DhtAddress>& contactedPeers,
+        DistantJoinConfig& additionalDistantJoin,
+        bool retry = true) {
+        if (this->isStopped()) {
+            co_return;
+        }
+        {
+            std::scoped_lock lock(this->mutex);
+            this->joinCalled = true;
+        }
+        SLogger::debug(
+            "Joining DHT via entrypoint " +
+            Identifiers::getNodeIdFromPeerDescriptor(entryPointDescriptor));
+        if (Identifiers::areEqualPeerDescriptors(
+                entryPointDescriptor, this->options.localPeerDescriptor)) {
+            co_return;
+        }
+        if (this->options.connectionLocker != nullptr) {
+            this->options.connectionLocker->lockConnection(
+                entryPointDescriptor, this->joinLockId());
+        }
+        this->options.peerManager.addContact(entryPointDescriptor);
+        const auto targetId = Identifiers::getNodeIdFromPeerDescriptor(
+            this->options.localPeerDescriptor);
+        std::vector<std::shared_ptr<DiscoverySession>> sessions;
+        sessions.push_back(this->createSession(targetId, contactedPeers));
+        if (additionalDistantJoin.enabled) {
+            sessions.push_back(this->createSession(
+                createDistantDhtAddress(targetId),
+                additionalDistantJoin.contactedPeers));
+        }
+        co_await this->runSessions(
+            std::move(sessions), entryPointDescriptor, retry);
+        if (this->options.connectionLocker != nullptr) {
+            this->options.connectionLocker->unlockConnection(
+                entryPointDescriptor, this->joinLockId());
+        }
+    }
+
+    folly::coro::Task<void> joinRing() {
+        std::set<DhtAddress> contactedPeers;
+        std::vector<std::shared_ptr<RingDiscoverySession>> sessions;
+        sessions.push_back(this->createRingSession(
+            getRingIdRawFromPeerDescriptor(this->options.localPeerDescriptor),
+            contactedPeers));
+        co_await this->runRingSessions(std::move(sessions));
+    }
+
+    folly::coro::Task<void> rejoinDht(
+        PeerDescriptor entryPoint,
+        // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+        std::set<DhtAddress> contactedPeers = {},
+        std::set<DhtAddress> distantJoinContactPeers = {}) {
+        {
+            std::scoped_lock lock(this->mutex);
+            if (this->isStopped() || this->rejoinOngoing) {
+                co_return;
+            }
+            this->rejoinOngoing = true;
+        }
+        SLogger::debug(
+            "Rejoining DHT " +
+            static_cast<std::string>(this->options.serviceId));
+        DistantJoinConfig additionalDistantJoin{
+            .enabled = true,
+            .contactedPeers = std::move(distantJoinContactPeers)};
+        try {
+            co_await this->joinThroughEntryPoint(
+                entryPoint, contactedPeers, additionalDistantJoin, true);
+            SLogger::debug(
+                "Rejoined DHT successfully " +
+                static_cast<std::string>(this->options.serviceId));
+        } catch (const std::exception&) {
+            SLogger::warn(
+                "Rejoining DHT failed " +
+                static_cast<std::string>(this->options.serviceId));
+            if (!this->isStopped()) {
+                this->scheduleRejoin(entryPoint, rejoinRetryDelay);
+            }
+        }
+        {
+            std::scoped_lock lock(this->mutex);
+            this->rejoinOngoing = false;
+        }
+    }
+
+    [[nodiscard]] bool isJoinOngoing() {
+        std::scoped_lock lock(this->mutex);
+        return !this->joinCalled ? true
+                                 : !this->ongoingDiscoverySessions.empty();
+    }
+
+    [[nodiscard]] bool isJoinCalled() {
+        std::scoped_lock lock(this->mutex);
+        return this->joinCalled;
+    }
+};
+
+} // namespace streamr::dht::discovery

--- a/packages/streamr-dht/modules/dht/discovery/RingDiscoverySession.cppm
+++ b/packages/streamr-dht/modules/dht/discovery/RingDiscoverySession.cppm
@@ -1,0 +1,279 @@
+// Module streamr.dht.RingDiscoverySession
+// Ported from packages/dht/src/dht/discovery/RingDiscoverySession.ts
+// (v103.8.0-rc.3). The ring-topology counterpart of DiscoverySession: it walks
+// toward a target ring id by querying getClosestRingPeers on the closest
+// uncontacted ring contacts, asking both sides (left/right) of the ring
+// equally, and stops when the ring frontier is exhausted or `noProgressLimit`
+// consecutive requests bring no closer contact on either side.
+//
+// The concurrency model is identical to DiscoverySession's: `parallelism`
+// worker coroutines pull from the shared ring frontier under the session mutex
+// (the faithful realisation of TS's `.finally`-recursion fan-out), and
+// findClosestNodes awaits them under one folly timeout with a `done` flag
+// standing in for the TS Gate. See DiscoverySession for the rationale.
+module;
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+#include <coroutine> // IWYU pragma: keep
+
+export module streamr.dht.RingDiscoverySession;
+
+import streamr.utils.AbortController;
+import streamr.utils.CoroutineHelper;
+import streamr.utils.Uuid;
+import streamr.logger.SLogger;
+import streamr.dht.DhtNodeRpcRemote;
+import streamr.dht.Identifiers;
+import streamr.dht.PeerManager;
+import streamr.dht.RingContactList;
+import streamr.dht.ringIdentifiers;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+using streamr::utils::AbortSignal;
+using streamr::utils::Uuid;
+
+export namespace streamr::dht::discovery {
+
+using ::dht::PeerDescriptor;
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtNodeRpcRemote;
+using streamr::dht::Identifiers;
+using streamr::dht::PeerManager;
+using streamr::dht::contact::getLeftDistance;
+using streamr::dht::contact::getRingIdFromPeerDescriptor;
+using streamr::dht::contact::getRingIdFromRaw;
+using streamr::dht::contact::RingContacts;
+using streamr::dht::contact::RingId;
+using streamr::dht::contact::RingIdRaw;
+
+struct RingDiscoverySessionOptions {
+    RingIdRaw targetId;
+    size_t parallelism;
+    size_t noProgressLimit;
+    PeerManager& peerManager;
+    // Mutated by this session (and sibling sessions that share the set); owned
+    // by the caller and outlives findClosestNodes.
+    std::set<DhtAddress>& contactedPeers;
+    AbortSignal& abortSignal;
+};
+
+class RingDiscoverySession {
+private:
+    std::string id = Uuid::v4();
+    size_t noProgressCounter = 0;
+    std::set<DhtAddress> ongoingRequests;
+    bool done = false; // the single-shot Gate, guarded by the mutex
+    std::recursive_mutex mutex;
+    RingDiscoverySessionOptions options;
+    RingId targetIdAsRingId;
+
+    void addContacts(const std::vector<PeerDescriptor>& contacts) {
+        std::scoped_lock lock(this->mutex);
+        if (this->options.abortSignal.aborted || this->done) {
+            return;
+        }
+        for (const auto& contact : contacts) {
+            this->options.peerManager.addContact(contact);
+        }
+    }
+
+    folly::coro::Task<std::vector<PeerDescriptor>>
+    fetchClosestContactsFromRemote(std::shared_ptr<DhtNodeRpcRemote> contact) {
+        {
+            std::scoped_lock lock(this->mutex);
+            if (this->options.abortSignal.aborted || this->done) {
+                co_return std::vector<PeerDescriptor>{};
+            }
+        }
+        SLogger::trace(
+            "Getting closest ring peers from contact: " + contact->getNodeId());
+        auto returnedContacts =
+            co_await contact->getClosestRingPeers(this->options.targetId);
+        {
+            std::scoped_lock lock(this->mutex);
+            this->options.peerManager.setContactActive(contact->getNodeId());
+        }
+        // Merge the wire response's left/right peer lists into a single set of
+        // contacts to feed back (TS concatenates them before addContacts).
+        std::vector<PeerDescriptor> merged;
+        merged.reserve(
+            returnedContacts.left.size() + returnedContacts.right.size());
+        merged.insert(
+            merged.end(),
+            returnedContacts.left.begin(),
+            returnedContacts.left.end());
+        merged.insert(
+            merged.end(),
+            returnedContacts.right.begin(),
+            returnedContacts.right.end());
+        co_return merged;
+    }
+
+    // The left/right distance of the closest current ring contact to the
+    // target, or nullopt when that side has no contact (TS indexes [0] of a
+    // possibly empty array; guarding avoids the undefined access).
+    [[nodiscard]] std::optional<RingId> closestSideDistance(bool leftSide) {
+        const auto closest = this->options.peerManager.getClosestRingContactsTo(
+            this->options.targetId, 1);
+        const auto& side = leftSide ? closest.left : closest.right;
+        if (side.empty()) {
+            return std::nullopt;
+        }
+        return getLeftDistance(
+            this->targetIdAsRingId,
+            getRingIdFromPeerDescriptor(side.front()->getPeerDescriptor()));
+    }
+
+    static bool sideMadeNoProgress(
+        // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+        std::optional<RingId> oldDistance,
+        std::optional<RingId> newDistance) {
+        if (oldDistance.has_value() && newDistance.has_value()) {
+            return *newDistance >= *oldDistance;
+        }
+        // Gaining a contact where there was none is progress; anything else
+        // (no contact on this side) counts as no progress.
+        return !(!oldDistance.has_value() && newDistance.has_value());
+    }
+
+    void onRequestSucceeded(
+        const DhtAddress& nodeId, const std::vector<PeerDescriptor>& contacts) {
+        std::scoped_lock lock(this->mutex);
+        if (!this->ongoingRequests.contains(nodeId)) {
+            return;
+        }
+        this->ongoingRequests.erase(nodeId);
+        const auto oldLeft = this->closestSideDistance(true);
+        const auto oldRight = this->closestSideDistance(false);
+        this->addContacts(contacts);
+        const auto newLeft = this->closestSideDistance(true);
+        const auto newRight = this->closestSideDistance(false);
+        if (sideMadeNoProgress(oldLeft, newLeft) &&
+            sideMadeNoProgress(oldRight, newRight)) {
+            this->noProgressCounter++;
+        }
+    }
+
+    void onRequestFailed(const DhtAddress& nodeId) {
+        std::scoped_lock lock(this->mutex);
+        if (!this->ongoingRequests.contains(nodeId)) {
+            return;
+        }
+        this->ongoingRequests.erase(nodeId);
+        this->options.peerManager.removeContact(nodeId);
+    }
+
+    // Ask from both sides of the ring equally, dropping duplicates (TS
+    // interleaves left[i]/right[i]).
+    [[nodiscard]] static std::vector<std::shared_ptr<DhtNodeRpcRemote>>
+    mergeSides(const RingContacts<DhtNodeRpcRemote>& uncontacted) {
+        std::vector<std::shared_ptr<DhtNodeRpcRemote>> merged;
+        std::set<DhtAddress> alreadyInMerged;
+        const size_t length =
+            std::max(uncontacted.left.size(), uncontacted.right.size());
+        for (size_t i = 0; i < length; ++i) {
+            if (i < uncontacted.left.size() &&
+                alreadyInMerged.insert(uncontacted.left[i]->getNodeId())
+                    .second) {
+                merged.push_back(uncontacted.left[i]);
+            }
+            if (i < uncontacted.right.size() &&
+                alreadyInMerged.insert(uncontacted.right[i]->getNodeId())
+                    .second) {
+                merged.push_back(uncontacted.right[i]);
+            }
+        }
+        return merged;
+    }
+
+    folly::coro::Task<void> worker() {
+        while (true) {
+            std::shared_ptr<DhtNodeRpcRemote> contact;
+            {
+                std::scoped_lock lock(this->mutex);
+                if (this->options.abortSignal.aborted || this->done) {
+                    co_return;
+                }
+                if (this->noProgressCounter >= this->options.noProgressLimit) {
+                    this->done = true;
+                    co_return;
+                }
+                const auto uncontacted =
+                    this->options.peerManager.getClosestRingContactsTo(
+                        this->options.targetId,
+                        this->options.parallelism,
+                        this->options.contactedPeers);
+                if (uncontacted.left.empty() && uncontacted.right.empty()) {
+                    this->done = true;
+                    co_return;
+                }
+                for (const auto& candidate : mergeSides(uncontacted)) {
+                    if (!this->ongoingRequests.contains(
+                            candidate->getNodeId())) {
+                        contact = candidate;
+                        break;
+                    }
+                }
+                if (contact == nullptr) {
+                    co_return;
+                }
+                const auto nodeId = contact->getNodeId();
+                this->ongoingRequests.insert(nodeId);
+                // TS adds to contactedPeers synchronously at the start of the
+                // fetch; claiming it here keeps sibling workers off this node.
+                this->options.contactedPeers.insert(nodeId);
+            }
+            const auto nodeId = contact->getNodeId();
+            try {
+                const auto contacts =
+                    co_await this->fetchClosestContactsFromRemote(contact);
+                this->onRequestSucceeded(nodeId, contacts);
+            } catch (const std::exception& e) {
+                SLogger::trace(
+                    "getClosestRingPeers failed: " + std::string(e.what()));
+                this->onRequestFailed(nodeId);
+            }
+        }
+    }
+
+public:
+    explicit RingDiscoverySession(RingDiscoverySessionOptions options)
+        : options(std::move(options)),
+          targetIdAsRingId(getRingIdFromRaw(this->options.targetId)) {}
+
+    [[nodiscard]] const std::string& getId() const { return this->id; }
+
+    folly::coro::Task<void> findClosestNodes(
+        std::chrono::milliseconds timeout) {
+        {
+            std::scoped_lock lock(this->mutex);
+            if (this->options.peerManager.getNearbyContactCount(
+                    this->options.contactedPeers) == 0) {
+                co_return;
+            }
+        }
+        std::vector<folly::coro::Task<void>> workers;
+        workers.reserve(this->options.parallelism);
+        for (size_t i = 0; i < this->options.parallelism; ++i) {
+            workers.push_back(this->worker());
+        }
+        co_await streamr::utils::co_withCancellation(
+            this->options.abortSignal.getCancellationToken(),
+            folly::coro::timeout(
+                folly::coro::collectAllRange(std::move(workers)), timeout));
+    }
+};
+
+} // namespace streamr::dht::discovery

--- a/packages/streamr-dht/test/unit/DiscoverySessionTest.cpp
+++ b/packages/streamr-dht/test/unit/DiscoverySessionTest.cpp
@@ -1,0 +1,355 @@
+// Ported from packages/dht/test/unit/DiscoverySession.test.ts
+// (v103.8.0-rc.3): builds a connected 40-node test topology, then runs one
+// DiscoverySession from a random node toward a random target with
+// parallelism 1 and noProgressLimit 1, and checks that the sequence of queried
+// nodes moves monotonically closer to the target.
+//
+// The mock DhtNodeRpcRemote (a subclass, since getClosestPeers/ping are
+// virtual) answers getClosestPeers by rebuilding that node's PeerManager from
+// the topology and returning its closest neighbours — exactly as the TS
+// Partial<DhtNodeRpcRemote> mock does. createTestTopology is ported here from
+// test/utils/topology.ts.
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <list>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+
+#include <coroutine> // IWYU pragma: keep
+
+import streamr.utils.AbortController;
+import streamr.utils.CoroutineHelper;
+import streamr.protorpc.RpcCommunicator;
+import streamr.protorpc.protos;
+import streamr.dht.ConnectionLockStates;
+import streamr.dht.DhtCallContext;
+import streamr.dht.DhtNodeRpcRemote;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.DiscoverySession;
+import streamr.dht.getClosestNodes;
+import streamr.dht.getPeerDistance;
+import streamr.dht.Identifiers;
+import streamr.dht.PeerManager;
+import streamr.dht.protos;
+import streamr.dht.TestUtils;
+
+using ::dht::NodeType;
+using ::dht::PeerDescriptor;
+using streamr::dht::DhtAddress;
+using streamr::dht::DhtAddressRaw;
+using streamr::dht::DhtNodeRpcRemote;
+using streamr::dht::Identifiers;
+using streamr::dht::PeerManager;
+using streamr::dht::PeerManagerOptions;
+using streamr::dht::ServiceID;
+using streamr::dht::connection::LockID;
+using streamr::dht::contact::getClosestNodes;
+using streamr::dht::contact::GetClosestNodesOptions;
+using streamr::dht::discovery::DiscoverySession;
+using streamr::dht::discovery::DiscoverySessionOptions;
+using streamr::dht::helpers::getPeerDistance;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::protorpc::RpcCommunicator;
+using streamr::utils::AbortController;
+using streamr::utils::blockingWait;
+
+using DhtNodeRpcClient = ::dht::DhtNodeRpcClient<DhtCallContext>;
+
+namespace {
+
+constexpr size_t nodeCount = 40;
+constexpr size_t minNeighborCount = 2;
+constexpr size_t parallelism = 1;
+constexpr size_t noProgressLimit = 1;
+constexpr size_t queryBatchSize = 5;
+constexpr size_t numberOfNodesPerKBucket = 8;
+constexpr size_t maxContactCount = 200;
+constexpr std::chrono::milliseconds queryDelay{10};
+constexpr std::chrono::milliseconds discoverySessionTimeout{1000};
+
+// A Multimap<DhtAddress, DhtAddress> from the TS test: node id -> its
+// neighbours (a set, so edges are naturally deduplicated).
+using Topology = std::map<DhtAddress, std::set<DhtAddress>>;
+
+PeerDescriptor createPeerDescriptor(const DhtAddress& nodeId) {
+    PeerDescriptor descriptor;
+    descriptor.set_nodeid(Identifiers::getRawFromDhtAddress(nodeId));
+    descriptor.set_type(NodeType::NODEJS);
+    return descriptor;
+}
+
+// The `count` node ids closest to referenceId, excluding referenceId itself
+// (TS's local getClosestNodes with allowToContainReferenceId=false).
+std::vector<DhtAddress> getClosestNodeIds(
+    const DhtAddress& referenceId,
+    const std::vector<DhtAddress>& candidates,
+    size_t count) {
+    std::vector<PeerDescriptor> descriptors;
+    descriptors.reserve(candidates.size());
+    for (const auto& id : candidates) {
+        descriptors.push_back(createPeerDescriptor(id));
+    }
+    const auto closest = getClosestNodes(
+        referenceId,
+        descriptors,
+        GetClosestNodesOptions{
+            .maxCount = count,
+            .excludedNodeIds = std::set<DhtAddress>{referenceId}});
+    std::vector<DhtAddress> result;
+    result.reserve(closest.size());
+    for (const auto& descriptor : closest) {
+        result.push_back(Identifiers::getNodeIdFromPeerDescriptor(descriptor));
+    }
+    return result;
+}
+
+// The connected components of the topology (TS getTopologyPartitions). A
+// std::list keeps partition pointers stable across the merge/erase.
+std::vector<std::set<DhtAddress>> getTopologyPartitions(
+    const Topology& topology) {
+    std::list<std::set<DhtAddress>> partitions;
+    const auto findPartition = [&partitions](const DhtAddress& nodeId) {
+        return std::ranges::find_if(
+            partitions, [&nodeId](const std::set<DhtAddress>& partition) {
+                return partition.contains(nodeId);
+            });
+    };
+    for (const auto& [nodeId, neighbors] : topology) {
+        const auto existing = findPartition(nodeId);
+        if (existing != partitions.end()) {
+            for (const auto& neighbor : neighbors) {
+                if (existing->contains(neighbor)) {
+                    continue;
+                }
+                const auto other = findPartition(neighbor);
+                if (other != partitions.end()) {
+                    existing->insert(other->begin(), other->end());
+                    partitions.erase(other);
+                } else {
+                    existing->insert(neighbor);
+                }
+            }
+        } else {
+            std::set<DhtAddress> partition{nodeId};
+            partition.insert(neighbors.begin(), neighbors.end());
+            partitions.push_back(std::move(partition));
+        }
+    }
+    return {partitions.begin(), partitions.end()};
+}
+
+// Builds a topology with no network splits, where each node's neighbours are
+// globally closest to it (TS createTestTopology).
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+Topology createTestTopology(size_t count, size_t minNeighbors) {
+    std::vector<DhtAddress> nodeIds;
+    nodeIds.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        nodeIds.push_back(Identifiers::createRandomDhtAddress());
+    }
+    Topology topology;
+    for (const auto& nodeId : nodeIds) {
+        for (const auto& closestNode :
+             getClosestNodeIds(nodeId, nodeIds, minNeighbors)) {
+            topology[nodeId].insert(closestNode);
+            topology[closestNode].insert(nodeId);
+        }
+    }
+    // Merge partitions by repeatedly joining the globally closest cross-
+    // partition pair until a single component remains.
+    while (true) {
+        const auto partitions = getTopologyPartitions(topology);
+        if (partitions.size() <= 1) {
+            break;
+        }
+        std::optional<DhtAddress> mergeFrom;
+        std::optional<DhtAddress> mergeTo;
+        double bestDistance = 0;
+        for (const auto& nodeId : nodeIds) {
+            const auto& ownPartition = *std::ranges::find_if(
+                partitions, [&nodeId](const std::set<DhtAddress>& partition) {
+                    return partition.contains(nodeId);
+                });
+            std::vector<DhtAddress> otherNodes;
+            for (const auto& candidate : nodeIds) {
+                if (!ownPartition.contains(candidate)) {
+                    otherNodes.push_back(candidate);
+                }
+            }
+            const auto closestOther = getClosestNodeIds(nodeId, otherNodes, 1);
+            if (closestOther.empty()) {
+                continue;
+            }
+            const double distance = getPeerDistance(
+                Identifiers::getRawFromDhtAddress(nodeId),
+                Identifiers::getRawFromDhtAddress(closestOther.front()));
+            if (!mergeFrom.has_value() || distance < bestDistance) {
+                bestDistance = distance;
+                mergeFrom = nodeId;
+                mergeTo = closestOther.front();
+            }
+        }
+        topology[*mergeFrom].insert(*mergeTo);
+        topology[*mergeTo].insert(*mergeFrom);
+    }
+    return topology;
+}
+
+} // namespace
+
+class DiscoverySessionTest : public ::testing::Test {
+protected:
+    RpcCommunicator<DhtCallContext> mockCommunicator;
+    Topology topology;
+    std::shared_ptr<std::vector<DhtAddress>> queriedNodes =
+        std::make_shared<std::vector<DhtAddress>>();
+
+    void SetUp() override {
+        this->mockCommunicator.setOutgoingMessageCallback(
+            [](const ::protorpc::RpcMessage& /*message*/,
+               const std::string& /*requestId*/,
+               const DhtCallContext& /*context*/) {});
+        this->topology = createTestTopology(nodeCount, minNeighborCount);
+    }
+
+    // The mock: getClosestPeers rebuilds this node's PeerManager and returns
+    // its closest neighbours; ping never touches the network.
+    class MockDhtNodeRpcRemote : public DhtNodeRpcRemote {
+    private:
+        std::shared_ptr<std::vector<DhtAddress>> queriedNodes;
+        std::function<std::vector<PeerDescriptor>(const DhtAddress&)>
+            getClosest;
+
+    public:
+        MockDhtNodeRpcRemote(
+            PeerDescriptor localPeerDescriptor, // NOLINT
+            PeerDescriptor remotePeerDescriptor,
+            DhtNodeRpcClient client,
+            std::shared_ptr<std::vector<DhtAddress>> queriedNodes,
+            std::function<std::vector<PeerDescriptor>(const DhtAddress&)>
+                getClosest)
+            : DhtNodeRpcRemote(
+                  std::move(localPeerDescriptor),
+                  std::move(remotePeerDescriptor),
+                  ServiceID{"mock"},
+                  client),
+              queriedNodes(std::move(queriedNodes)),
+              getClosest(std::move(getClosest)) {}
+
+        folly::coro::Task<std::vector<PeerDescriptor>> getClosestPeers(
+            const DhtAddress& referenceId) override {
+            this->queriedNodes->push_back(this->getNodeId());
+            co_await folly::coro::sleep(queryDelay);
+            co_return this->getClosest(referenceId);
+        }
+
+        folly::coro::Task<bool> ping() override { co_return true; }
+    };
+
+    std::shared_ptr<DhtNodeRpcRemote> createMockRpcRemote(
+        const PeerDescriptor& peerDescriptor) {
+        const auto nodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(peerDescriptor);
+        // The callback rebuilds a PeerManager and may throw (allocation); it
+        // runs inside the getClosestPeers coroutine, which handles exceptions,
+        // and in this test any throw simply fails the test.
+        // NOLINTBEGIN(bugprone-exception-escape)
+        auto getClosest =
+            [this, nodeId](
+                const DhtAddress& referenceId) -> std::vector<PeerDescriptor> {
+            const auto peerManager = this->createPeerManager(nodeId);
+            std::vector<PeerDescriptor> neighborDescriptors;
+            for (const auto& neighbor : peerManager->getNeighbors()) {
+                neighborDescriptors.push_back(neighbor->getPeerDescriptor());
+            }
+            auto result = getClosestNodes(
+                referenceId,
+                neighborDescriptors,
+                GetClosestNodesOptions{.maxCount = queryBatchSize});
+            peerManager->stop();
+            return result;
+        };
+        // NOLINTEND(bugprone-exception-escape)
+        return std::make_shared<MockDhtNodeRpcRemote>(
+            createMockPeerDescriptor(),
+            peerDescriptor,
+            DhtNodeRpcClient(this->mockCommunicator),
+            this->queriedNodes,
+            std::move(getClosest));
+    }
+
+    std::shared_ptr<PeerManager> createPeerManager(
+        const DhtAddress& localNodeId) {
+        auto peerManager = PeerManager::newInstance(
+            PeerManagerOptions{
+                .numberOfNodesPerKBucket = numberOfNodesPerKBucket,
+                .maxContactCount = maxContactCount,
+                .localNodeId = localNodeId,
+                .localPeerDescriptor = createPeerDescriptor(localNodeId),
+                .connectionLocker = nullptr,
+                .neighborPingLimit = std::nullopt,
+                .lockId = LockID{"discovery-test"},
+                .createDhtNodeRpcRemote =
+                    [this](const PeerDescriptor& peerDescriptor) {
+                        return this->createMockRpcRemote(peerDescriptor);
+                    },
+                .hasConnection =
+                    [](const DhtAddress& /*nodeId*/) { return true; }});
+        for (const auto& neighbor : this->topology[localNodeId]) {
+            peerManager->addContact(createPeerDescriptor(neighbor));
+        }
+        return peerManager;
+    }
+};
+
+TEST_F(DiscoverySessionTest, HappyPath) {
+    std::vector<DhtAddress> nodeIds;
+    nodeIds.reserve(this->topology.size());
+    for (const auto& [nodeId, neighbors] : this->topology) {
+        nodeIds.push_back(nodeId);
+    }
+    ASSERT_GE(nodeIds.size(), 2U);
+    const auto localNodeId = nodeIds.front();
+    const auto targetId = nodeIds.at(nodeIds.size() / 2);
+
+    std::set<DhtAddress> contactedPeers;
+    const auto peerManager = this->createPeerManager(localNodeId);
+    AbortController abortController;
+    DiscoverySession session(
+        DiscoverySessionOptions{
+            .targetId = targetId,
+            .parallelism = parallelism,
+            .noProgressLimit = noProgressLimit,
+            .peerManager = *peerManager,
+            .contactedPeers = contactedPeers,
+            .abortSignal = abortController.getSignal(),
+            .createDhtNodeRpcRemote =
+                [this](const PeerDescriptor& peerDescriptor) {
+                    return this->createMockRpcRemote(peerDescriptor);
+                }});
+
+    blockingWait(session.findClosestNodes(discoverySessionTimeout));
+
+    ASSERT_FALSE(this->queriedNodes->empty());
+    // Each queried node is strictly closer to the target than the previous one
+    // (parallelism 1, noProgressLimit 1 make the walk monotonic).
+    const auto targetRaw = Identifiers::getRawFromDhtAddress(targetId);
+    std::vector<double> distances;
+    distances.reserve(this->queriedNodes->size());
+    for (const auto& queried : *this->queriedNodes) {
+        distances.push_back(getPeerDistance(
+            Identifiers::getRawFromDhtAddress(queried), targetRaw));
+    }
+    for (size_t i = 1; i < distances.size(); ++i) {
+        EXPECT_LT(distances[i], distances[i - 1]);
+    }
+    peerManager->stop();
+}

--- a/packages/streamr-utils/modules/ExecutorHelper.cppm
+++ b/packages/streamr-utils/modules/ExecutorHelper.cppm
@@ -5,6 +5,7 @@
 // re-exported in their original namespace.
 module;
 
+#include <folly/Executor.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/executors/FunctionScheduler.h>
 #include <folly/executors/thread_factory/NamedThreadFactory.h>
@@ -15,6 +16,7 @@ export module streamr.utils.ExecutorHelper;
 export namespace folly {
 
 using folly::CPUThreadPoolExecutor;
+using folly::Executor;
 using folly::FunctionScheduler;
 using folly::NamedThreadFactory;
 using folly::PriorityThreadFactory;

--- a/packages/streamr-utils/modules/scheduleAtInterval.cppm
+++ b/packages/streamr-utils/modules/scheduleAtInterval.cppm
@@ -1,0 +1,62 @@
+// Module streamr.utils.scheduleAtInterval
+// Ported from packages/utils/src/scheduleAtInterval.ts (v103.8.0-rc.3).
+// Runs `task` once immediately (when executeAtStart) and then repeatedly,
+// waiting `interval` after each completion, until `abortSignal` fires.
+//
+// TS schedules the recurring runs with setTimeout and the returned promise
+// resolves after the first (executeAtStart) run. This port mirrors that: the
+// returned Task completes after the executeAtStart run, and the recurring
+// `sleep(interval)` then `task()` loop is detached onto `executor` — a worker
+// pool, so this maintenance work never runs on a caller/delivery thread —
+// stopping as soon as the abort signal requests cancellation.
+module;
+
+#include <chrono>
+#include <functional>
+#include <utility>
+
+#include <coroutine> // IWYU pragma: keep
+
+export module streamr.utils.scheduleAtInterval;
+
+import streamr.utils.AbortController;
+import streamr.utils.CoroutineHelper;
+import streamr.utils.ExecutorHelper;
+
+export namespace streamr::utils {
+
+using streamr::utils::AbortSignal;
+
+inline folly::coro::Task<void> scheduleAtInterval(
+    std::function<folly::coro::Task<void>()> task,
+    std::chrono::milliseconds interval,
+    bool executeAtStart,
+    AbortSignal& abortSignal,
+    folly::Executor* executor) {
+    if (abortSignal.aborted) {
+        co_return;
+    }
+    if (executeAtStart) {
+        co_await task();
+    }
+    const auto cancellationToken = abortSignal.getCancellationToken();
+    streamr::utils::co_withExecutor(
+        executor,
+        streamr::utils::co_withCancellation(
+            cancellationToken,
+            folly::coro::co_invoke(
+                [task = std::move(task), interval, cancellationToken]()
+                    -> folly::coro::Task<void> {
+                    while (!cancellationToken.isCancellationRequested()) {
+                        co_await folly::coro::sleep(interval);
+                        if (cancellationToken.isCancellationRequested()) {
+                            co_return;
+                        }
+                        co_await task();
+                    }
+                })))
+        .start();
+    co_return;
+}
+
+} // namespace streamr::utils


### PR DESCRIPTION
## Phase A7 — Discovery and join

Ports the DHT discovery/join layer from the pinned TypeScript
(`streamr/network` `af966cf03`, v103.8.0-rc.3):

- **`DiscoverySession`** — one Kademlia lookup toward a target id. TS drives the
  fan-out through promise `.finally`-recursion that keeps `parallelism` requests
  in flight; this port expresses the identical rolling concurrency as
  `parallelism` worker coroutines pulling from the shared frontier under the
  session mutex, awaited under one `folly::coro::timeout` (a `done` flag stands
  in for the TS `Gate`). Discovery is I/O-bound, so — unlike the Router's
  routing-table work — it is not offloaded to a dedicated executor.
- **`RingDiscoverySession`** — the ring-topology counterpart (queries both sides
  of the ring equally).
- **`PeerDiscovery`** — join orchestration: per entry point a discovery session
  toward the local id plus an optional distant (bit-flipped) session, retry when
  no neighbours are found, and a periodic recovery task once joined. It is
  `shared_ptr`-owned; the retry/recovery work is detached onto a dedicated
  worker executor (2nd-class maintenance kept off caller/delivery threads) and
  torn down by the join abort signal.

Supporting changes:
- `streamr.utils.scheduleAtInterval` (new): the recurring-task util the recovery
  loop needs; `ExecutorHelper` now also exports `folly::Executor`.
- `DhtNodeRpcRemote::getClosestPeers` / `getClosestRingPeers` made `virtual`
  (like `ping`) so the discovery test can substitute them.
- `PeerManager::getNearbyContacts()` accessor; `streamr.dht.consts`
  (`CONTROL_LAYER_NODE_SERVICE_ID`).

Tests: ports `unit/DiscoverySession.test.ts` (+ the `createTestTopology`
partition-merge helper). The two integration tests
(`DhtJoinPeerDiscovery`, `MultipleEntryPointJoining`) build full DhtNodes over
the Simulator and are deferred to phase A8 (DhtNode assembly).

Verified: 170/170 dht unit, 12/12 dht integration, 51/51 utils unit;
`lint.sh` green for streamr-dht and streamr-utils.

🤖 Generated with [Claude Code](https://claude.com/claude-code)