### PR TITLE
Fix PendingConnection connect-timeout use-after-free

### DIFF
--- a/packages/streamr-dht/modules/connection/IncomingHandshaker.cppm
+++ b/packages/streamr-dht/modules/connection/IncomingHandshaker.cppm
@@ -158,7 +158,7 @@ protected:
 
         if (!this->pendingConnection) {
             this->pendingConnection =
-                std::make_shared<PendingConnection>(source);
+                PendingConnection::newInstance(source);
             if (this->onNewConnectionCallback) {
                 if (!this->onNewConnectionCallback.value()(
                         this->pendingConnection)) {

--- a/packages/streamr-dht/modules/connection/PendingConnection.cppm
+++ b/packages/streamr-dht/modules/connection/PendingConnection.cppm
@@ -17,6 +17,7 @@ import streamr.dht.protos;
 
 import streamr.utils.AbortController;
 import streamr.utils.AbortableTimers;
+import streamr.utils.EnableSharedFromThis;
 import streamr.logger.SLogger;
 import streamr.dht.Connection;
 import streamr.dht.IPendingConnection;
@@ -27,6 +28,7 @@ import streamr.dht.Identifiers;
 // at file scope than inside the package namespace.
 using streamr::utils::AbortableTimers;
 using streamr::utils::AbortController;
+using streamr::utils::EnableSharedFromThis;
 // Self-sufficient shorthand (was inherited textually from a
 // neighboring header before consolidation).
 using streamr::logger::SLogger;
@@ -37,7 +39,8 @@ using ::dht::PeerDescriptor;
 using streamr::dht::Identifiers;
 using streamr::dht::connection::Connection;
 
-class PendingConnection : public IPendingConnection {
+class PendingConnection : public IPendingConnection,
+                          public EnableSharedFromThis {
 private:
     AbortController connectingAbortController;
     PeerDescriptor remotePeerDescriptor;
@@ -46,20 +49,54 @@ private:
     bool replacedAsDuplicate = false;
     bool stopped = false;
 
-public:
+protected:
     explicit PendingConnection(
+        PeerDescriptor remotePeerDescriptor,
+        std::optional<std::function<void(std::exception_ptr)>> errorCallback =
+            std::nullopt)
+        : errorCallback(std::move(errorCallback)),
+          remotePeerDescriptor(std::move(remotePeerDescriptor)) {}
+
+    // The connect-timeout timer must capture a WEAK self, not `this`: the
+    // timer can outlive the PendingConnection (a connect that never completes,
+    // e.g. to an offline peer, is torn down while its timeout is still
+    // pending), and firing on a freed object would emit Disconnected on a
+    // destroyed EventEmitter. Scheduled from newInstance (after make_shared, so
+    // sharedFromThis works); the destructor aborts the timer as a backstop.
+    void scheduleConnectingTimeout(std::chrono::milliseconds timeout) {
+        std::weak_ptr<PendingConnection> weakSelf =
+            this->sharedFromThis<PendingConnection>();
+        AbortableTimers::setAbortableTimeout(
+            [weakSelf]() {
+                if (auto self = weakSelf.lock()) {
+                    self->close(false);
+                }
+            },
+            timeout,
+            this->connectingAbortController.getSignal());
+    }
+
+public:
+    [[nodiscard]] static std::shared_ptr<PendingConnection> newInstance(
         PeerDescriptor remotePeerDescriptor,
         std::optional<std::function<void(std::exception_ptr)>> errorCallback =
             std::nullopt,
         std::chrono::milliseconds timeout =
-            std::chrono::milliseconds(15 * 1000)) // NOLINT
-        : errorCallback(std::move(errorCallback)),
-          remotePeerDescriptor(std::move(remotePeerDescriptor)) {
-        AbortableTimers::setAbortableTimeout(
-            [this]() { this->close(false); },
-            timeout,
-            this->connectingAbortController.getSignal());
+            std::chrono::milliseconds(15 * 1000)) { // NOLINT
+        struct MakeSharedEnabler : public PendingConnection {
+            MakeSharedEnabler(
+                PeerDescriptor descriptor,
+                std::optional<std::function<void(std::exception_ptr)>> callback)
+                : PendingConnection(
+                      std::move(descriptor), std::move(callback)) {}
+        };
+        auto instance = std::make_shared<MakeSharedEnabler>(
+            std::move(remotePeerDescriptor), std::move(errorCallback));
+        instance->scheduleConnectingTimeout(timeout);
+        return instance;
     }
+
+    ~PendingConnection() override { this->connectingAbortController.abort(); }
 
     void replaceAsDuplicate() override {
         SLogger::trace(

--- a/packages/streamr-dht/modules/connection/simulator/SimulatorConnector.cppm
+++ b/packages/streamr-dht/modules/connection/simulator/SimulatorConnector.cppm
@@ -95,7 +95,7 @@ public:
             ConnectionType::SIMULATOR_CLIENT,
             this->simulator);
 
-        auto pendingConnection = std::make_shared<PendingConnection>(
+        auto pendingConnection = PendingConnection::newInstance(
             targetPeerDescriptor, std::move(errorCallback));
 
         auto outgoingHandshaker = OutgoingHandshaker::newInstance(

--- a/packages/streamr-dht/modules/connection/websocket/WebsocketClientConnector.cppm
+++ b/packages/streamr-dht/modules/connection/websocket/WebsocketClientConnector.cppm
@@ -126,7 +126,7 @@ public:
         const auto url = Connectivity::connectivityMethodToWebsocketUrl(
             targetPeerDescriptor.websocket());
 
-        auto pendingConnection = std::make_shared<PendingConnection>(
+        auto pendingConnection = PendingConnection::newInstance(
             targetPeerDescriptor, std::move(errorCallback));
 
         std::shared_ptr<OutgoingHandshaker> outgoingHandshaker =

--- a/packages/streamr-dht/test/unit/PendingConnectionTest.cpp
+++ b/packages/streamr-dht/test/unit/PendingConnectionTest.cpp
@@ -39,13 +39,13 @@ public:
 class PendingConnectionTest : public ::testing::Test {
 protected:
     PeerDescriptor mockPeerDescriptor;
-    std::unique_ptr<PendingConnection> pendingConnection;
+    std::shared_ptr<PendingConnection> pendingConnection;
     static constexpr auto timeout = std::chrono::seconds(5);
     static constexpr auto retryInternal = std::chrono::milliseconds(100);
 
     void SetUp() override {
         mockPeerDescriptor = createMockPeerDescriptor();
-        pendingConnection = std::make_unique<PendingConnection>(
+        pendingConnection = PendingConnection::newInstance(
             mockPeerDescriptor,
             std::nullopt,
             std::chrono::milliseconds(500)); // NOLINT
@@ -126,6 +126,29 @@ TEST_F(PendingConnectionTest, ReplaysDisconnectedToLateListener) {
     pendingConnection->once<Disconnected>(
         [&](bool /* gracefulLeave */) { isEmitted = true; });
     EXPECT_TRUE(isEmitted);
+}
+
+// Regression test for the connect-timeout use-after-free: if the
+// PendingConnection is dropped (without close()/destroy()) before its timeout
+// fires, the timer must not touch the freed object. Before the weak-self fix,
+// the timer captured raw `this` and fired close() on freed memory, emitting
+// Disconnected on a destroyed EventEmitter ("mutex lock failed").
+TEST_F(PendingConnectionTest, DoesNotCrashIfDroppedBeforeTimeout) {
+    auto shortLived = PendingConnection::newInstance(
+        createMockPeerDescriptor(),
+        std::nullopt,
+        std::chrono::milliseconds(50)); // NOLINT
+    shortLived.reset(); // drop it with the timeout still pending
+    // Wait well past the timeout; the timer must be a no-op, not a UAF.
+    std::function<bool()> never = []() { return false; };
+    try {
+        streamr::utils::blockingWait(waitForCondition(
+            std::move(never), std::chrono::milliseconds(300), retryInternal));
+    } catch (...) {
+        // waitForCondition times out (the condition never becomes true); that
+        // is expected — we only care that no crash occurred meanwhile.
+    }
+    SUCCEED();
 }
 
 TEST_F(PendingConnectionTest, DoesNotEmitConnectedIfReplaced) {

--- a/packages/streamr-dht/test/unit/WebsocketClientConnectorRpcLocalTest.cpp
+++ b/packages/streamr-dht/test/unit/WebsocketClientConnectorRpcLocalTest.cpp
@@ -21,7 +21,7 @@ TEST(WebsocketClientConnectorRpcLocal, TestCanBeCreated) {
     WebsocketClientConnectorRpcLocalOptions options{
         .connect =
             [](const PeerDescriptor& peer) {
-                return std::make_shared<PendingConnection>(peer);
+                return PendingConnection::newInstance(peer);
             },
         .hasConnection = [](const DhtAddress& /*nodeId*/) { return false; },
         .onNewConnection =


### PR DESCRIPTION
## Fix PendingConnection connect-timeout use-after-free

> Stacked on #66 (module-sloc-dedup) — review/merge that first; this diff shows only the UAF fix.

### The bug

`PendingConnection` scheduled its connect-timeout in the constructor capturing **raw `this`**, with no destructor to cancel it:

```cpp
AbortableTimers::setAbortableTimeout(
    [this]() { this->close(false); },     // raw this
    timeout, this->connectingAbortController.getSignal());
```

`PendingConnection` is `make_shared`-owned, but when a connect never completes — e.g. to an **offline peer** — the object can be torn down while its timeout is still pending. The timer then fires on freed memory: `close()` → `emit<Disconnected>` on a destroyed EventEmitter, surfacing as `std::system_error: mutex lock failed: Invalid argument` on the FunctionScheduler thread. Online connections never hit it because `onHandshakeCompleted` aborts the timer first.

This was found via a full-node integration test (a node joining through an offline entry point); an lldb backtrace pinned it to `PendingConnection::close` → EventEmitter emit on an invalid mutex.

### The fix

Following the same pattern phase 0.3 used for the handshaker's raw-`this` captures:

- `PendingConnection` is now `EnableSharedFromThis`;
- the connect timeout is scheduled from a **`newInstance`** factory (after `make_shared`, so `sharedFromThis` works), capturing a **weak self** and re-validating on fire (`if (auto self = weak.lock()) self->close(false)`);
- a destructor aborts the timer as a backstop;
- the ctor is `protected` so the timer can't be skipped by a raw `make_shared`.

The three creation sites (`SimulatorConnector`, `WebsocketClientConnector`, `IncomingHandshaker`) and two tests move to `newInstance`.

### Tests

- New `PendingConnectionTest.DoesNotCrashIfDroppedBeforeTimeout`: drops a `PendingConnection` with its timeout pending — no UAF (was a crash before).
- Existing `EmitsDisconnectedAfterTimedOut` confirms the timeout still fires and emits `Disconnected`.
- Full `PendingConnectionTest` suite green under `--gtest_repeat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)