### PR TITLE
Phase B2: WebRTC connector over libdatachannel

### DIFF
--- a/packages/streamr-dht/CMakeLists.txt
+++ b/packages/streamr-dht/CMakeLists.txt
@@ -172,6 +172,8 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         test/unit/WebsocketClientConnectorRpcRemoteTest.cpp
         test/unit/IdentifiersTest.cpp
         test/unit/CreatePeerDescriptorTest.cpp
+        test/unit/WebrtcConnectionTest.cpp
+        test/unit/WebrtcConnectorTest.cpp
         test/unit/ConnectivityRequestHandlerTest.cpp
         test/unit/ConnectionLockRpcRemoteTest.cpp
         test/unit/ConnectorFacadeTest.cpp
@@ -264,6 +266,9 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         test/integration/KademliaCorrectnessTest.cpp
         test/integration/ConnectivityCheckingTest.cpp
         test/integration/WebsocketConnectionManagementTest.cpp
+        test/integration/WebrtcConnectorRpcTest.cpp
+        test/integration/WebrtcConnectionManagementTest.cpp
+        test/integration/RpcConnectionsOverWebrtcTest.cpp
     )
 
     target_include_directories(streamr-dht-test-integration

--- a/packages/streamr-dht/lint.sh
+++ b/packages/streamr-dht/lint.sh
@@ -75,6 +75,13 @@ echo "Running clangd-tidy on $FILES"
 # CodeLocation/MakeAndRegisterTestInfo reported ambiguous — like the other
 # excluded files; the compiler builds and runs it on every platform and
 # clang-format still checks it.)
+# WebrtcConnectionTest.cpp, WebrtcConnectorTest.cpp and
+# RpcConnectionsOverWebrtcTest.cpp (phase B2) trip the same std-type
+# unification false positive (gtest CodeLocation/MakeAndRegisterTestInfo
+# ambiguous, protobuf member calls ambiguous) through the WebrtcConnection /
+# ConnectionManager import sets; the compiler builds and runs all three
+# (unit 181/181, integration green). The other two B2 tests
+# (all five B2 test files trip it via the protobuf/gtest ambiguity.)
 # CreatePeerDescriptorTest.cpp, ConnectivityRequestHandlerTest.cpp and
 # WebsocketConnectionManagementTest.cpp (phase B1) trip the same std-type
 # unification false positive (std::string method calls on protobuf getters
@@ -84,7 +91,7 @@ echo "Running clangd-tidy on $FILES"
 # clang-format still checks them. (ConnectivityCheckingTest.cpp imports
 # the same cluster but does NOT trip it.)
 HEAVY_TIDY_FILES='./test/integration/MockLayer1Layer0Test.cpp ./test/integration/Layer1ScaleTest.cpp ./test/integration/DhtNodeExternalApiTest.cpp ./test/integration/KademliaCorrectnessTest.cpp'
-TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/integration/ConnectionLockingTest.cpp' | grep -v 'test/unit/PendingConnectionTest.cpp' | grep -v 'test/unit/SimulatorTest.cpp' | grep -v 'test/integration/SimultaneousConnectionsTest.cpp' | grep -v 'test/integration/ConnectionManagerIntegrationTest.cpp' | grep -v 'test/unit/DhtNodeRpcLocalTest.cpp' | grep -v 'test/integration/DhtNodeRpcRemoteTest.cpp' | grep -v 'test/unit/RoutingSessionTest.cpp' | grep -v 'test/unit/RecursiveOperationSessionTest.cpp' | grep -v 'test/unit/StoreRpcLocalTest.cpp' | grep -v 'test/unit/StoreManagerTest.cpp' | grep -v 'test/integration/MultipleEntryPointJoiningTest.cpp' | grep -v 'test/utils/DhtNodeTestUtils.hpp' | grep -v 'test/integration/DhtNodeTest.cpp' | grep -v 'test/integration/MockLayer1Layer0Test.cpp' | grep -v 'test/integration/Layer1ScaleTest.cpp' | grep -v 'test/integration/DhtNodeExternalApiTest.cpp' | grep -v 'test/integration/KademliaCorrectnessTest.cpp' | grep -v 'test/unit/CreatePeerDescriptorTest.cpp' | grep -v 'test/unit/ConnectivityRequestHandlerTest.cpp' | grep -v 'test/integration/WebsocketConnectionManagementTest.cpp' | tr '\n' ' ')
+TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/integration/ConnectionLockingTest.cpp' | grep -v 'test/unit/PendingConnectionTest.cpp' | grep -v 'test/unit/SimulatorTest.cpp' | grep -v 'test/integration/SimultaneousConnectionsTest.cpp' | grep -v 'test/integration/ConnectionManagerIntegrationTest.cpp' | grep -v 'test/unit/DhtNodeRpcLocalTest.cpp' | grep -v 'test/integration/DhtNodeRpcRemoteTest.cpp' | grep -v 'test/unit/RoutingSessionTest.cpp' | grep -v 'test/unit/RecursiveOperationSessionTest.cpp' | grep -v 'test/unit/StoreRpcLocalTest.cpp' | grep -v 'test/unit/StoreManagerTest.cpp' | grep -v 'test/integration/MultipleEntryPointJoiningTest.cpp' | grep -v 'test/utils/DhtNodeTestUtils.hpp' | grep -v 'test/integration/DhtNodeTest.cpp' | grep -v 'test/integration/MockLayer1Layer0Test.cpp' | grep -v 'test/integration/Layer1ScaleTest.cpp' | grep -v 'test/integration/DhtNodeExternalApiTest.cpp' | grep -v 'test/integration/KademliaCorrectnessTest.cpp' | grep -v 'test/unit/CreatePeerDescriptorTest.cpp' | grep -v 'test/unit/ConnectivityRequestHandlerTest.cpp' | grep -v 'test/integration/WebsocketConnectionManagementTest.cpp' | grep -v 'test/unit/WebrtcConnectionTest.cpp' | grep -v 'test/unit/WebrtcConnectorTest.cpp' | grep -v 'test/integration/RpcConnectionsOverWebrtcTest.cpp' | grep -v 'test/integration/WebrtcConnectorRpcTest.cpp' | grep -v 'test/integration/WebrtcConnectionManagementTest.cpp' | tr '\n' ' ')
 # Chunked: one clangd process accumulates source-location space across the
 # files it serves and never releases it; with the phase-A8 module graph a
 # single process no longer survives the whole list (mid-batch the affected

--- a/packages/streamr-dht/modules/connection/Connection.cppm
+++ b/packages/streamr-dht/modules/connection/Connection.cppm
@@ -76,6 +76,13 @@ public:
     ~Connection() override { SLogger::trace("~Connection()"); }
 
     [[nodiscard]] ConnectionID getConnectionID() const { return mID; }
+
+    // TS IConnection.connectionId is publicly assignable; used by the WebRTC
+    // answerer to adopt the offerer's connection id (WebrtcConnectorRpcLocal
+    // rtcOffer).
+    void setConnectionId(ConnectionID connectionId) {
+        this->mID = std::move(connectionId);
+    }
     [[nodiscard]] ConnectionType getConnectionType() const { return mType; }
     [[nodiscard]] std::string getConnectionTypeString() const {
         return std::string(magic_enum::enum_name(mType));

--- a/packages/streamr-dht/modules/connection/ConnectorFacade.cppm
+++ b/packages/streamr-dht/modules/connection/ConnectorFacade.cppm
@@ -24,6 +24,8 @@ import streamr.dht.ListeningRpcCommunicator;
 import streamr.dht.PendingConnection;
 import streamr.dht.PortRange;
 import streamr.dht.Transport;
+import streamr.dht.WebrtcConnector;
+import streamr.dht.webrtcTypes;
 import streamr.dht.WebsocketClientConnector;
 import streamr.dht.WebsocketServerConnector;
 
@@ -40,6 +42,9 @@ using namespace std::chrono_literals;
 using ::dht::ConnectivityResponse;
 using streamr::dht::connection::IPendingConnection;
 using streamr::dht::connection::PendingConnection;
+using streamr::dht::connection::webrtc::IceServer;
+using streamr::dht::connection::webrtc::WebrtcConnector;
+using streamr::dht::connection::webrtc::WebrtcConnectorOptions;
 using streamr::dht::connection::websocket::WebsocketClientConnector;
 using streamr::dht::connection::websocket::WebsocketClientConnectorOptions;
 using streamr::dht::connection::websocket::WebsocketServerConnector;
@@ -71,12 +76,12 @@ struct DefaultConnectorFacadeOptions {
     std::optional<std::string> websocketHost = std::nullopt;
     std::optional<PortRange> websocketPortRange = std::nullopt;
     std::optional<std::vector<PeerDescriptor>> entryPoints = std::nullopt;
-    // std::vector<IceServer> iceServers;
-    // bool webrtcAllowPrivateAddresses;
-    // int webrtcDatachannelBufferThresholdLow;
-    // int webrtcDatachannelBufferThresholdHigh;
-    // std::optional<std::string> externalIp;
-    // PortRange webrtcPortRange;
+    std::vector<IceServer> iceServers = {};
+    std::optional<bool> webrtcAllowPrivateAddresses = std::nullopt;
+    std::optional<size_t> webrtcDatachannelBufferThresholdLow = std::nullopt;
+    std::optional<size_t> webrtcDatachannelBufferThresholdHigh = std::nullopt;
+    std::optional<std::string> externalIp = std::nullopt;
+    std::optional<PortRange> webrtcPortRange = std::nullopt;
     std::optional<size_t> maxMessageSize;
     // TlsCertificate tlsCertificate;
     // bool websocketServerEnableTls;
@@ -97,11 +102,13 @@ private:
     ListeningRpcCommunicator websocketConnectorRpcCommunicator;
     std::unique_ptr<WebsocketClientConnector> websocketClientConnector;
     std::unique_ptr<WebsocketServerConnector> websocketServerConnector;
+    std::unique_ptr<WebrtcConnector> webrtcConnector;
 
     void setLocalPeerDescriptor(const PeerDescriptor& peerDescriptor) {
         this->localPeerDescriptor = peerDescriptor;
         this->websocketClientConnector->setLocalPeerDescriptor(peerDescriptor);
         this->websocketServerConnector->setLocalPeerDescriptor(peerDescriptor);
+        this->webrtcConnector->setLocalPeerDescriptor(peerDescriptor);
     }
 
 public:
@@ -151,6 +158,21 @@ public:
             std::make_unique<WebsocketServerConnector>(
                 std::move(webSocketServerConnectorOptions));
 
+        this->webrtcConnector =
+            std::make_unique<WebrtcConnector>(WebrtcConnectorOptions{
+                .onNewConnection = onNewConnection,
+                .transport = this->options.transport,
+                .iceServers = this->options.iceServers,
+                .allowPrivateAddresses =
+                    this->options.webrtcAllowPrivateAddresses,
+                .bufferThresholdLow =
+                    this->options.webrtcDatachannelBufferThresholdLow,
+                .bufferThresholdHigh =
+                    this->options.webrtcDatachannelBufferThresholdHigh,
+                .maxMessageSize = this->options.maxMessageSize,
+                .externalIp = this->options.externalIp,
+                .portRange = this->options.webrtcPortRange});
+
         this->websocketServerConnector->start();
         const auto connectivityResponse =
             this->websocketServerConnector->checkConnectivity(false);
@@ -178,8 +200,7 @@ public:
                 peerDescriptor)) {
             return this->websocketServerConnector->connect(peerDescriptor);
         }
-        // TS falls through to the WebrtcConnector here (milestone B2).
-        return nullptr;
+        return this->webrtcConnector->connect(peerDescriptor, false);
     }
 
     std::shared_ptr<IPendingConnection> createConnection(
@@ -194,8 +215,9 @@ public:
                 peerDescriptor)) {
             return this->websocketServerConnector->connect(peerDescriptor);
         }
-        // TS falls through to the WebrtcConnector here (milestone B2).
-        return nullptr;
+        // The TS PendingConnection carries no per-call error callback on the
+        // WebRTC path either.
+        return this->webrtcConnector->connect(peerDescriptor, false);
     }
 
     PeerDescriptor getLocalPeerDescriptor() const override {
@@ -205,8 +227,9 @@ public:
     void stop() override {
         SLogger::info("DefaultConnectorFacade::stop start");
         this->websocketConnectorRpcCommunicator.destroy();
-        this->websocketClientConnector->destroy();
         this->websocketServerConnector->destroy();
+        this->websocketClientConnector->destroy();
+        this->webrtcConnector->stop();
         SLogger::info("DefaultConnectorFacade::stop end");
     }
 };

--- a/packages/streamr-dht/modules/connection/webrtc/WebrtcConnection.cppm
+++ b/packages/streamr-dht/modules/connection/webrtc/WebrtcConnection.cppm
@@ -1,0 +1,437 @@
+// Module streamr.dht.WebrtcConnection
+// Ported from packages/dht/src/nodejs/WebrtcConnection.ts (v103.8.0-rc.3):
+// one WebRTC data-channel connection over libdatachannel's
+// rtc::PeerConnection/rtc::DataChannel — the TS node-datachannel binding
+// wraps the exact same library, so the callback semantics match closely.
+// Adaptations from the TS original:
+//  - the localDescription/localCandidate events live on a separate member
+//    emitter (webrtcEvents()) because the C++ Connection base fixes its
+//    event tuple (see streamr.dht.webrtcTypes);
+//  - the EARLY_TIMEOUT setTimeout becomes an AbortableTimers timeout with a
+//    WEAK self (the PendingConnection watchdog pattern), scheduled by
+//    newInstance after make_shared;
+//  - state is guarded by mMutex (rtc callbacks fire on libdatachannel's
+//    processor threads), following the WebsocketConnection idiom, including
+//    closing the rtc objects OUTSIDE the mutex (rtc holds its callback
+//    mutex while callbacks run and our callbacks take mMutex — calling into
+//    rtc under mMutex is the lock-order inversion that deadlocked the
+//    websocket teardowns).
+module;
+
+#include <cstddef>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <rtc/rtc.hpp>
+
+export module streamr.dht.WebrtcConnection;
+
+import streamr.dht.protos;
+
+import streamr.dht.Connection;
+import streamr.dht.Identifiers;
+import streamr.dht.webrtcTypes;
+import streamr.eventemitter.EventEmitter;
+import streamr.logger.SLogger;
+import streamr.utils.AbortableTimers;
+import streamr.utils.AbortController;
+import streamr.utils.EnableSharedFromThis;
+import streamr.utils.SharedExecutors;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+using streamr::utils::AbortableTimers;
+using streamr::utils::AbortController;
+using streamr::utils::EnableSharedFromThis;
+
+export namespace streamr::dht::connection::webrtc {
+
+using streamr::dht::Identifiers;
+using streamr::dht::connection::Connection;
+using streamr::dht::connection::ConnectionType;
+using streamr::dht::connection::connectionevents::Connected;
+using streamr::dht::connection::connectionevents::Data;
+using streamr::dht::connection::connectionevents::Disconnected;
+
+inline constexpr size_t defaultBufferThresholdHigh = 1U << 17U;
+inline constexpr size_t defaultBufferThresholdLow = 1U << 15U;
+inline constexpr size_t defaultMaxMessageSize = 1048576;
+
+// TS RtcPeerConnectionStateEnum — libdatachannel reports the same states
+// as a typed enum, so the TS unknown-state guard is unrepresentable here.
+class WebrtcConnection : public Connection, public EnableSharedFromThis {
+private:
+    WebrtcConnectionParams params;
+    std::shared_ptr<rtc::PeerConnection> connection;
+    std::shared_ptr<rtc::DataChannel> dataChannel;
+    rtc::PeerConnection::State lastState =
+        rtc::PeerConnection::State::Connecting;
+    bool remoteDescriptionSet = false;
+    // Candidates received before the remote description is set (flushed by
+    // setRemoteDescription). {candidate, mid} pairs.
+    std::vector<std::pair<std::string, std::string>> pendingCandidates;
+    bool closed = false;
+    std::optional<bool> offering;
+    std::deque<std::vector<std::byte>> messageQueue;
+    AbortController earlyTimeoutAbort;
+    streamr::eventemitter::EventEmitter<WebrtcSignallingEvents>
+        signallingEvents;
+    std::recursive_mutex mMutex;
+
+    explicit WebrtcConnection(WebrtcConnectionParams&& params)
+        : Connection(ConnectionType::WEBRTC), params(std::move(params)) {}
+
+    // Called by newInstance right after make_shared (sharedFromThis is not
+    // available in the constructor). Weak self: the timeout must not keep a
+    // torn-down connection alive, and a fired timeout on a dead connection
+    // is a no-op.
+    void scheduleEarlyTimeout() {
+        std::weak_ptr<WebrtcConnection> weakSelf =
+            this->sharedFromThis<WebrtcConnection>();
+        AbortableTimers::setAbortableTimeout(
+            [weakSelf]() {
+                if (auto self = weakSelf.lock()) {
+                    self->doClose(
+                        false,
+                        "timed out due to remote descriptor not being set");
+                }
+            },
+            earlyTimeout,
+            this->earlyTimeoutAbort.getSignal());
+    }
+
+public:
+    [[nodiscard]] static std::shared_ptr<WebrtcConnection> newInstance(
+        WebrtcConnectionParams params) {
+        struct MakeSharedEnabler : public WebrtcConnection {
+            explicit MakeSharedEnabler(WebrtcConnectionParams&& params)
+                : WebrtcConnection(std::move(params)) {}
+        };
+        auto instance = std::make_shared<MakeSharedEnabler>(std::move(params));
+        instance->scheduleEarlyTimeout();
+        return instance;
+    }
+
+    ~WebrtcConnection() override { destroy(); }
+
+    // The localDescription/localCandidate signalling events (TS
+    // WebrtcConnectionEvents extras).
+    [[nodiscard]] streamr::eventemitter::EventEmitter<WebrtcSignallingEvents>&
+    webrtcEvents() {
+        return this->signallingEvents;
+    }
+
+    void start(bool isOffering) {
+        const auto nodeId = Identifiers::getNodeIdFromPeerDescriptor(
+            this->params.remotePeerDescriptor);
+        SLogger::trace(
+            "Starting new connection for peer " + nodeId,
+            {{"isOffering", isOffering}});
+        auto self = this->sharedFromThis<WebrtcConnection>();
+        std::scoped_lock lock(this->mMutex);
+        this->offering = isOffering;
+
+        rtc::Configuration configuration;
+        for (const auto& iceServer : this->params.iceServers) {
+            configuration.iceServers.emplace_back(iceServerAsString(iceServer));
+        }
+        configuration.maxMessageSize =
+            this->params.maxMessageSize.value_or(defaultMaxMessageSize);
+        if (this->params.portRange.has_value()) {
+            configuration.portRangeBegin = this->params.portRange->min;
+            configuration.portRangeEnd = this->params.portRange->max;
+        }
+        this->connection = std::make_shared<rtc::PeerConnection>(configuration);
+
+        this->connection->onStateChange(
+            [self](rtc::PeerConnection::State state) {
+                self->onStateChange(state);
+            });
+        this->connection->onGatheringStateChange(
+            [](rtc::PeerConnection::GatheringState) {});
+        this->connection->onLocalDescription(
+            [self](const rtc::Description& description) {
+                self->signallingEvents
+                    .emit<webrtcconnectionevents::LocalDescription>(
+                        std::string(description), description.typeString());
+            });
+        this->connection->onLocalCandidate(
+            [self](const rtc::Candidate& candidate) {
+                self->signallingEvents
+                    .emit<webrtcconnectionevents::LocalCandidate>(
+                        candidate.candidate(), candidate.mid());
+            });
+        if (isOffering) {
+            this->setupDataChannel(
+                this->connection->createDataChannel("streamrDataChannel"));
+        } else {
+            this->connection->onDataChannel(
+                [self](std::shared_ptr<rtc::DataChannel> dataChannel) {
+                    std::scoped_lock lock(self->mMutex);
+                    self->setupDataChannel(std::move(dataChannel));
+                });
+        }
+    }
+
+    void setRemoteDescription(
+        const std::string& description, const std::string& type) {
+        std::scoped_lock lock(this->mMutex);
+        if (this->connection) {
+            this->earlyTimeoutAbort.abort();
+            const auto remoteNodeId = Identifiers::getNodeIdFromPeerDescriptor(
+                this->params.remotePeerDescriptor);
+            try {
+                SLogger::trace(
+                    "Setting remote descriptor for peer: " + remoteNodeId);
+                this->connection->setRemoteDescription(
+                    rtc::Description(description, type));
+                this->remoteDescriptionSet = true;
+                // Apply any candidates that arrived before the description
+                // (see addRemoteCandidate).
+                for (const auto& pending : this->pendingCandidates) {
+                    try {
+                        this->connection->addRemoteCandidate(
+                            rtc::Candidate(pending.first, pending.second));
+                    } catch (const std::exception&) {
+                        SLogger::debug(
+                            "Failed to set queued remote candidate for peer " +
+                            remoteNodeId);
+                    }
+                }
+                this->pendingCandidates.clear();
+            } catch (const std::exception&) {
+                SLogger::debug(
+                    "Failed to set remote descriptor for peer " + remoteNodeId);
+            }
+        } else {
+            this->doClose(
+                false, "Tried to set description for non-existent connection");
+        }
+    }
+
+    void addRemoteCandidate(
+        const std::string& candidate, const std::string& mid) {
+        std::scoped_lock lock(this->mMutex);
+        if (this->connection) {
+            if (this->remoteDescriptionSet) {
+                const auto remoteNodeId =
+                    Identifiers::getNodeIdFromPeerDescriptor(
+                        this->params.remotePeerDescriptor);
+                try {
+                    SLogger::trace(
+                        "Setting remote candidate for peer: " + remoteNodeId);
+                    this->connection->addRemoteCandidate(
+                        rtc::Candidate(candidate, mid));
+                } catch (const std::exception&) {
+                    SLogger::debug(
+                        "Failed to set remote candidate for peer " +
+                        remoteNodeId);
+                }
+            } else {
+                // Queue the candidate until the remote description is set
+                // (implements the TS TODO at this exact spot). Over the
+                // simulator the offerer's separate rtcOffer and iceCandidate
+                // notifications can reach the answerer out of order, so a
+                // candidate legitimately arrives before the offer is applied
+                // — TS closes here, which is the documented flaky test
+                // NET-911; queuing removes the flakiness without any
+                // wire-visible change (setRemoteDescription flushes these).
+                SLogger::trace(
+                    "Queuing remote candidate until description is set");
+                this->pendingCandidates.emplace_back(candidate, mid);
+            }
+        } else {
+            this->doClose(
+                false, "Tried to set candidate for non-existent connection");
+        }
+    }
+
+    void send(const std::vector<std::byte>& data) override {
+        std::scoped_lock lock(this->mMutex);
+        if (this->isOpen()) {
+            try {
+                if (this->dataChannel->bufferedAmount() <
+                    this->params.bufferThresholdHigh.value_or(
+                        defaultBufferThresholdHigh)) {
+                    this->dataChannel->send(data.data(), data.size());
+                } else {
+                    this->messageQueue.push_back(data);
+                }
+            } catch (const std::exception& err) {
+                SLogger::debug(
+                    "Failed to send binary message to " +
+                    Identifiers::getNodeIdFromPeerDescriptor(
+                        this->params.remotePeerDescriptor) +
+                    " " + err.what());
+            }
+        }
+    }
+
+    void close(bool gracefulLeave) override { this->doClose(gracefulLeave); }
+
+    void destroy() override {
+        this->removeAllListeners();
+        this->signallingEvents.removeAllListeners();
+        this->doClose(false);
+    }
+
+    [[nodiscard]] bool isOpen() {
+        std::scoped_lock lock(this->mMutex);
+        return !this->closed &&
+            this->lastState == rtc::PeerConnection::State::Connected &&
+            this->dataChannel != nullptr;
+    }
+
+private:
+    void doClose(bool gracefulLeave, const std::string& reason = "") {
+        std::shared_ptr<rtc::DataChannel> dataChannelToClose;
+        std::shared_ptr<rtc::PeerConnection> connectionToClose;
+        {
+            std::scoped_lock lock(this->mMutex);
+            if (this->closed) {
+                return;
+            }
+            this->earlyTimeoutAbort.abort();
+            SLogger::trace(
+                "Closing Node WebRTC Connection to " +
+                    Identifiers::getNodeIdFromPeerDescriptor(
+                        this->params.remotePeerDescriptor),
+                {{"reason", reason}});
+            // Setting closed=true under the lock with the early-return guard
+            // makes exactly one doClose call proceed past this block, so the
+            // call-outs below run once.
+            this->closed = true;
+            dataChannelToClose = std::move(this->dataChannel);
+            connectionToClose = std::move(this->connection);
+            this->dataChannel = nullptr;
+            this->connection = nullptr;
+        }
+        // Call-outs run OUTSIDE mMutex (phase-A0 locking policy: no
+        // call-outs under a connection mutex). emit<Disconnected> reaches
+        // the Endpoint / PendingConnection listeners, which take THEIR
+        // mutexes; an rtc onStateChange racing on another thread holds one
+        // of those and wants mMutex — emitting under mMutex is the ABBA
+        // deadlock that hung the connector unit test.
+        this->emit<Disconnected>(gracefulLeave, 0, reason);
+        this->removeAllListeners();
+        this->signallingEvents.removeAllListeners();
+        // The rtc teardown runs on the shared worker pool, NOT inline:
+        // doClose is reached both from the owner (main thread) and from
+        // rtc's own onStateChange/onClosed callbacks, and
+        // rtc::PeerConnection::close()/resetCallbacks() BLOCK until the
+        // current callback returns. Called inline from an rtc callback that
+        // is itself the reason we are closing, that is a self-join deadlock
+        // (the unit-test hang when a peerless connection transitioned to
+        // Failed on rtc's thread). The task owns the rtc shared_ptrs, so
+        // they outlive this WebrtcConnection if it is destroyed first; the
+        // teardown is idempotent and order-independent.
+        if (dataChannelToClose || connectionToClose) {
+            streamr::utils::SharedExecutors::worker().add(
+                [dataChannelToClose, connectionToClose]() {
+                    if (dataChannelToClose) {
+                        try {
+                            SLogger::trace("closing datachannel");
+                            dataChannelToClose->resetCallbacks();
+                            dataChannelToClose->close();
+                        } catch (const std::exception& err) {
+                            SLogger::trace(
+                                "dc.close() errored: " +
+                                std::string(err.what()));
+                        }
+                    }
+                    if (connectionToClose) {
+                        try {
+                            connectionToClose->resetCallbacks();
+                            connectionToClose->close();
+                        } catch (const std::exception& err) {
+                            SLogger::trace(
+                                "conn.close() errored: " +
+                                std::string(err.what()));
+                        }
+                    }
+                });
+        }
+    }
+
+    // Caller holds mMutex.
+    void setupDataChannel(std::shared_ptr<rtc::DataChannel> channel) {
+        auto self = this->sharedFromThis<WebrtcConnection>();
+        this->dataChannel = std::move(channel);
+        this->dataChannel->setBufferedAmountLowThreshold(
+            this->params.bufferThresholdLow.value_or(
+                defaultBufferThresholdLow));
+        this->dataChannel->onOpen([self]() {
+            SLogger::trace("dc.onOpened");
+            self->onDataChannelOpen();
+        });
+        this->dataChannel->onClosed([self]() {
+            SLogger::trace("dc.closed");
+            self->doClose(false, "DataChannel closed");
+        });
+        this->dataChannel->onError([self](std::string err) {
+            SLogger::error("error", {{"err", err}});
+        });
+        this->dataChannel->onBufferedAmountLow(
+            [self]() { self->drainMessageQueue(); });
+        this->dataChannel->onMessage([self](rtc::message_variant message) {
+            SLogger::trace("dc.onMessage");
+            if (std::holds_alternative<rtc::binary>(message)) {
+                self->emit<Data>(std::get<rtc::binary>(std::move(message)));
+            }
+        });
+    }
+
+    void drainMessageQueue() {
+        std::scoped_lock lock(this->mMutex);
+        while (!this->messageQueue.empty() && this->dataChannel &&
+               this->dataChannel->bufferedAmount() <
+                   this->params.bufferThresholdHigh.value_or(
+                       defaultBufferThresholdHigh)) {
+            const auto data = std::move(this->messageQueue.front());
+            this->messageQueue.pop_front();
+            try {
+                this->dataChannel->send(data.data(), data.size());
+            } catch (const std::exception& err) {
+                SLogger::debug(
+                    "Failed to send binary message",
+                    {{"err", std::string(err.what())}});
+            }
+        }
+    }
+
+    void onDataChannelOpen() {
+        {
+            std::scoped_lock lock(this->mMutex);
+            if (this->closed) {
+                return;
+            }
+        }
+        SLogger::trace(
+            "DataChannel opened for peer " +
+            Identifiers::getNodeIdFromPeerDescriptor(
+                this->params.remotePeerDescriptor));
+        this->emit<Connected>();
+    }
+
+    void onStateChange(rtc::PeerConnection::State state) {
+        SLogger::trace(
+            "onStateChange " + std::to_string(static_cast<int>(state)));
+        {
+            std::scoped_lock lock(this->mMutex);
+            this->lastState = state;
+        }
+        if (state == rtc::PeerConnection::State::Closed ||
+            state == rtc::PeerConnection::State::Disconnected ||
+            state == rtc::PeerConnection::State::Failed) {
+            this->doClose(false);
+        }
+    }
+};
+
+} // namespace streamr::dht::connection::webrtc

--- a/packages/streamr-dht/modules/connection/webrtc/WebrtcConnector.cppm
+++ b/packages/streamr-dht/modules/connection/webrtc/WebrtcConnector.cppm
@@ -1,0 +1,477 @@
+// Module streamr.dht.WebrtcConnector
+// Ported from packages/dht/src/connection/webrtc/WebrtcConnector.ts
+// (v103.8.0-rc.3): opens WebRTC connections by exchanging offer/answer/ICE
+// notifications over the signalling transport; the XOR-id tie-break
+// (OffererHelper) decides which side offers. Adaptations:
+//  - the fire-and-forget TS signalling calls (.catch(trace)) run as
+//    detached coroutines on a serial view of the shared worker pool,
+//    tracked by a GuardedAsyncScope that stop() drains after abort (the
+//    streamr.utils.SharedExecutors architecture); each task builds its own
+//    RpcRemote from copied descriptors, so nothing dangles if the caller
+//    moves on;
+//  - the handshakers TS keeps alive through closures are stored in a map
+//    and dropped on HandshakerStopped (the websocket connectors' pattern);
+//  - ongoingConnectAttempts is guarded by mMutex (TS has the event loop);
+//  - the non-offering branch's manual accept/reject on handshakeRequest is
+//    what the C++ IncomingHandshaker already does internally (version
+//    check + accept against the pending connection it is given).
+module;
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <folly/executors/CPUThreadPoolExecutor.h>
+
+// std::coroutine_traits must be visible in every translation unit
+// that defines OR instantiates a coroutine; it cannot arrive through
+// an imported BMI.
+#include <coroutine> // IWYU pragma: keep
+
+export module streamr.dht.WebrtcConnector;
+
+import streamr.dht.protos;
+
+import streamr.dht.Connection;
+import streamr.dht.DhtCallContext;
+import streamr.dht.Errors;
+import streamr.dht.Handshaker;
+import streamr.dht.Identifiers;
+import streamr.dht.IncomingHandshaker;
+import streamr.dht.IPendingConnection;
+import streamr.dht.ListeningRpcCommunicator;
+import streamr.dht.Offerer;
+import streamr.dht.OutgoingHandshaker;
+import streamr.dht.PendingConnection;
+import streamr.dht.PortRange;
+import streamr.dht.Transport;
+import streamr.dht.WebrtcConnection;
+import streamr.dht.WebrtcConnectorRpcLocal;
+import streamr.dht.WebrtcConnectorRpcRemote;
+import streamr.dht.webrtcTypes;
+import streamr.logger.SLogger;
+import streamr.protorpc.RpcCommunicator;
+import streamr.utils.AbortController;
+import streamr.utils.CoroutineHelper;
+import streamr.utils.GuardedAsyncScope;
+import streamr.utils.SharedExecutors;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+using streamr::protorpc::RpcCommunicatorOptions;
+using streamr::utils::AbortController;
+
+export namespace streamr::dht::connection::webrtc {
+
+using namespace std::chrono_literals;
+using ::dht::PeerDescriptor;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+using streamr::dht::connection::Handshaker;
+using streamr::dht::connection::IncomingHandshaker;
+using streamr::dht::connection::IPendingConnection;
+using streamr::dht::connection::OutgoingHandshaker;
+using streamr::dht::connection::PendingConnection;
+using streamr::dht::helpers::CannotConnectToSelf;
+using streamr::dht::helpers::Offerer;
+using streamr::dht::helpers::OffererHelper;
+using streamr::dht::transport::ListeningRpcCommunicator;
+using streamr::dht::transport::Transport;
+using streamr::dht::types::PortRange;
+
+// TS replaceInternalIpWithExternalIp (exported for tests): rewrites the
+// connection address of host-type candidates.
+inline std::string replaceInternalIpWithExternalIp(
+    const std::string& candidate, const std::string& ip) {
+    std::vector<std::string> parsed;
+    size_t start = 0;
+    while (start <= candidate.size()) {
+        const auto end = candidate.find(' ', start);
+        if (end == std::string::npos) {
+            parsed.push_back(candidate.substr(start));
+            break;
+        }
+        parsed.push_back(candidate.substr(start, end - start));
+        start = end + 1;
+    }
+    constexpr size_t addressIndex = 4;
+    constexpr size_t typeIndex = 7;
+    if (parsed.size() > typeIndex && parsed[typeIndex] == "host") {
+        parsed[addressIndex] = ip;
+    }
+    std::string joined;
+    for (const auto& part : parsed) {
+        if (!joined.empty()) {
+            joined += " ";
+        }
+        joined += part;
+    }
+    return joined;
+}
+
+struct WebrtcConnectorOptions {
+    std::function<bool(const std::shared_ptr<IPendingConnection>&)>
+        onNewConnection;
+    Transport& transport;
+    std::vector<IceServer> iceServers = {};
+    std::optional<bool> allowPrivateAddresses = std::nullopt;
+    std::optional<size_t> bufferThresholdLow = std::nullopt;
+    std::optional<size_t> bufferThresholdHigh = std::nullopt;
+    std::optional<size_t> maxMessageSize = std::nullopt;
+    std::optional<std::string> externalIp = std::nullopt;
+    std::optional<PortRange> portRange = std::nullopt;
+};
+
+class WebrtcConnector {
+public:
+    static constexpr auto webrtcConnectorServiceId = "system/webrtc-connector";
+
+private:
+    static constexpr auto rpcRequestTimeout = 15000ms;
+
+    WebrtcConnectorOptions options;
+    ListeningRpcCommunicator rpcCommunicator;
+    std::map<DhtAddress, ConnectingConnection> ongoingConnectAttempts;
+    std::map<DhtAddress, std::shared_ptr<Handshaker>> handshakers;
+    std::optional<PeerDescriptor> localPeerDescriptor;
+    bool stopped = false;
+    std::unique_ptr<WebrtcConnectorRpcLocal> rpcLocal;
+    AbortController abortController;
+    // Detached signalling notifications (the TS .catch(trace) promises) run
+    // on a serial view of the shared worker pool; stop() drains the scope
+    // after abort.
+    streamr::utils::SharedSerialExecutor signallingExecutor{
+        streamr::utils::SharedExecutors::worker()};
+    streamr::utils::GuardedAsyncScope signallingScope;
+    std::recursive_mutex mMutex;
+
+public:
+    explicit WebrtcConnector(WebrtcConnectorOptions&& options)
+        : options(std::move(options)),
+          rpcCommunicator(
+              ServiceID{webrtcConnectorServiceId},
+              this->options.transport,
+              RpcCommunicatorOptions{.rpcRequestTimeout = rpcRequestTimeout}) {
+        this->registerLocalRpcMethods();
+    }
+
+    ~WebrtcConnector() { SLogger::trace("~WebrtcConnector()"); }
+
+    std::shared_ptr<IPendingConnection> connect(
+        const PeerDescriptor& targetPeerDescriptor,
+        bool doNotRequestConnection) {
+        std::scoped_lock lock(this->mMutex);
+        if (Identifiers::areEqualPeerDescriptors(
+                targetPeerDescriptor, this->localPeerDescriptor.value())) {
+            throw CannotConnectToSelf("Cannot open WebRTC Connection to self");
+        }
+        const auto nodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(targetPeerDescriptor);
+        SLogger::trace("Opening WebRTC connection to " + nodeId);
+        const auto existingConnection =
+            this->ongoingConnectAttempts.find(nodeId);
+        if (existingConnection != this->ongoingConnectAttempts.end()) {
+            return existingConnection->second.managedConnection;
+        }
+
+        auto connection = WebrtcConnection::newInstance(
+            WebrtcConnectionParams{
+                .remotePeerDescriptor = targetPeerDescriptor,
+                .bufferThresholdHigh = this->options.bufferThresholdHigh,
+                .bufferThresholdLow = this->options.bufferThresholdLow,
+                .iceServers = this->options.iceServers,
+                .portRange = this->options.portRange});
+
+        const auto localNodeId = Identifiers::getNodeIdFromPeerDescriptor(
+            this->localPeerDescriptor.value());
+        const bool offering =
+            OffererHelper::getOfferer(localNodeId, nodeId) == Offerer::LOCAL;
+        auto pendingConnection =
+            PendingConnection::newInstance(targetPeerDescriptor);
+
+        std::shared_ptr<Handshaker> handshaker;
+        if (offering) {
+            handshaker = OutgoingHandshaker::newInstance(
+                this->localPeerDescriptor.value(),
+                connection,
+                targetPeerDescriptor,
+                pendingConnection);
+            connection->webrtcEvents()
+                .once<webrtcconnectionevents::LocalDescription>(
+                    [this, targetPeerDescriptor, connection](
+                        const std::string& description,
+                        const std::string& /*type*/) {
+                        SLogger::trace("Sending offer to remote peer");
+                        const auto connectionId = connection->getConnectionID();
+                        this->sendSignallingNotification(
+                            targetPeerDescriptor,
+                            "rtcOffer",
+                            [description,
+                             connectionId](WebrtcConnectorRpcRemote& remote) {
+                                return remote.sendRtcOffer(
+                                    description, connectionId);
+                            });
+                    });
+        } else {
+            // The incoming handshaker resolves the handshake against this
+            // pending connection (and does the version check + accept /
+            // reject the TS branch spells out inline).
+            auto pendingConnectionCopy = pendingConnection;
+            handshaker = IncomingHandshaker::newInstance(
+                this->localPeerDescriptor.value(),
+                connection,
+                [pendingConnectionCopy](const DhtAddress& /*nodeId*/)
+                    -> std::shared_ptr<IPendingConnection> {
+                    return pendingConnectionCopy;
+                });
+            connection->webrtcEvents()
+                .once<webrtcconnectionevents::LocalDescription>(
+                    [this, targetPeerDescriptor, connection](
+                        const std::string& description,
+                        const std::string& /*type*/) {
+                        // Live id: rtcOffer adopted the offerer's connection
+                        // id after connect() (TS reads connection.connectionId
+                        // at emit time, so the answer carries the offerer's
+                        // id and matches on the far side).
+                        const auto connectionId = connection->getConnectionID();
+                        this->sendSignallingNotification(
+                            targetPeerDescriptor,
+                            "rtcAnswer",
+                            [description,
+                             connectionId](WebrtcConnectorRpcRemote& remote) {
+                                return remote.sendRtcAnswer(
+                                    description, connectionId);
+                            });
+                    });
+        }
+
+        this->ongoingConnectAttempts.emplace(
+            nodeId,
+            ConnectingConnection{
+                .managedConnection = pendingConnection,
+                .connection = connection});
+        this->handshakers.emplace(nodeId, handshaker);
+        handshaker->on<handshakerevents::HandshakerStopped>([this, nodeId]() {
+            std::scoped_lock lock(this->mMutex);
+            this->handshakers.erase(nodeId);
+        });
+
+        // TS delFunc: the attempt is dropped once the connection settles
+        // either way (erasing an absent key is a no-op).
+        connection->on<connectionevents::Disconnected>(
+            [this, nodeId](
+                bool /*gracefulLeave*/,
+                uint64_t /*code*/,
+                const std::string& /*reason*/) {
+                std::scoped_lock lock(this->mMutex);
+                this->ongoingConnectAttempts.erase(nodeId);
+            });
+        pendingConnection->on<pendingconnectionevents::Disconnected>(
+            [this, nodeId](bool /*gracefulLeave*/) {
+                std::scoped_lock lock(this->mMutex);
+                this->ongoingConnectAttempts.erase(nodeId);
+            });
+        pendingConnection->on<pendingconnectionevents::Connected>(
+            [this, nodeId](
+                const PeerDescriptor& /*peerDescriptor*/,
+                const std::shared_ptr<Connection>& /*connection*/) {
+                std::scoped_lock lock(this->mMutex);
+                this->ongoingConnectAttempts.erase(nodeId);
+            });
+
+        connection->webrtcEvents().on<webrtcconnectionevents::LocalCandidate>(
+            [this, targetPeerDescriptor, connection](
+                const std::string& candidate, const std::string& mid) {
+                const auto connectionId = connection->getConnectionID();
+                std::string effectiveCandidate = candidate;
+                if (this->options.externalIp.has_value()) {
+                    effectiveCandidate = replaceInternalIpWithExternalIp(
+                        candidate, *this->options.externalIp);
+                    SLogger::debug(
+                        "onLocalCandidate injected external ip " +
+                        effectiveCandidate + " " + mid);
+                }
+                this->sendSignallingNotification(
+                    targetPeerDescriptor,
+                    "iceCandidate",
+                    [effectiveCandidate, mid, connectionId](
+                        WebrtcConnectorRpcRemote& remote) {
+                        return remote.sendIceCandidate(
+                            effectiveCandidate, mid, connectionId);
+                    });
+            });
+
+        connection->start(offering);
+
+        if (!doNotRequestConnection && !offering) {
+            this->sendSignallingNotification(
+                targetPeerDescriptor,
+                "requestConnection",
+                [](WebrtcConnectorRpcRemote& remote) {
+                    return remote.requestConnection();
+                });
+        }
+
+        return pendingConnection;
+    }
+
+    void setLocalPeerDescriptor(const PeerDescriptor& peerDescriptor) {
+        std::scoped_lock lock(this->mMutex);
+        this->localPeerDescriptor = peerDescriptor;
+    }
+
+    void stop() {
+        SLogger::trace("stop()");
+        std::map<DhtAddress, ConnectingConnection> attempts;
+        {
+            std::scoped_lock lock(this->mMutex);
+            if (this->stopped) {
+                return;
+            }
+            this->stopped = true;
+            this->abortController.abort();
+            attempts = this->ongoingConnectAttempts;
+            this->ongoingConnectAttempts.clear();
+        }
+        // Outside the mutex: destroying connections emits events whose
+        // handlers take it, and the scope drain must not hold it either.
+        for (auto& [nodeId, attempt] : attempts) {
+            attempt.connection->destroy();
+            attempt.managedConnection->close(false);
+        }
+        this->signallingScope.close();
+        this->rpcCommunicator.destroy();
+    }
+
+private:
+    void registerLocalRpcMethods() {
+        this->rpcLocal = std::make_unique<WebrtcConnectorRpcLocal>(
+            WebrtcConnectorRpcLocalOptions{
+                .connect = [this](
+                               const PeerDescriptor& targetPeerDescriptor,
+                               bool doNotRequestConnection)
+                    -> std::shared_ptr<IPendingConnection> {
+                    return this->connect(
+                        targetPeerDescriptor, doNotRequestConnection);
+                },
+                .onNewConnection =
+                    [this](
+                        const std::shared_ptr<IPendingConnection>& connection) {
+                        return this->options.onNewConnection(connection);
+                    },
+                .getOngoingConnectAttempt = [this](const DhtAddress& nodeId)
+                    -> std::optional<ConnectingConnection> {
+                    std::scoped_lock lock(this->mMutex);
+                    const auto it = this->ongoingConnectAttempts.find(nodeId);
+                    if (it == this->ongoingConnectAttempts.end()) {
+                        return std::nullopt;
+                    }
+                    return it->second;
+                },
+                .getLocalPeerDescriptor =
+                    [this]() {
+                        std::scoped_lock lock(this->mMutex);
+                        return this->localPeerDescriptor.value();
+                    },
+                .allowPrivateAddresses =
+                    this->options.allowPrivateAddresses.value_or(true)});
+
+        this->rpcCommunicator
+            .registerRpcNotification<::dht::WebrtcConnectionRequest>(
+                "requestConnection",
+                [this](
+                    const ::dht::WebrtcConnectionRequest& request,
+                    const DhtCallContext& context) {
+                    std::scoped_lock lock(this->mMutex);
+                    if (this->stopped) {
+                        return;
+                    }
+                    this->rpcLocal->requestConnection(request, context);
+                });
+        this->rpcCommunicator.registerRpcNotification<::dht::RtcOffer>(
+            "rtcOffer",
+            [this](
+                const ::dht::RtcOffer& request, const DhtCallContext& context) {
+                std::scoped_lock lock(this->mMutex);
+                if (this->stopped) {
+                    return;
+                }
+                this->rpcLocal->rtcOffer(request, context);
+            });
+        this->rpcCommunicator.registerRpcNotification<::dht::RtcAnswer>(
+            "rtcAnswer",
+            [this](
+                const ::dht::RtcAnswer& request,
+                const DhtCallContext& context) {
+                std::scoped_lock lock(this->mMutex);
+                if (this->stopped) {
+                    return;
+                }
+                this->rpcLocal->rtcAnswer(request, context);
+            });
+        this->rpcCommunicator.registerRpcNotification<::dht::IceCandidate>(
+            "iceCandidate",
+            [this](
+                const ::dht::IceCandidate& request,
+                const DhtCallContext& context) {
+                std::scoped_lock lock(this->mMutex);
+                if (this->stopped) {
+                    return;
+                }
+                this->rpcLocal->iceCandidate(request, context);
+            });
+    }
+
+    // Fires one signalling notification detached (the TS
+    // remoteConnector.sendX().catch() shape): the task owns copies of both
+    // descriptors and builds its own client/remote, is cancellable by
+    // stop()'s abort, and is drained by the scope before the communicator
+    // is destroyed.
+    void sendSignallingNotification(
+        const PeerDescriptor& targetPeerDescriptor,
+        std::string description,
+        std::function<folly::coro::Task<void>(WebrtcConnectorRpcRemote&)>
+            makeCall) {
+        PeerDescriptor local;
+        {
+            std::scoped_lock lock(this->mMutex);
+            if (this->stopped || !this->localPeerDescriptor.has_value()) {
+                return;
+            }
+            local = this->localPeerDescriptor.value();
+        }
+        this->signallingScope.add(
+            streamr::utils::co_withExecutor(
+                &this->signallingExecutor,
+                folly::coro::co_invoke(
+                    [this,
+                     local,
+                     target = targetPeerDescriptor,
+                     description = std::move(description),
+                     makeCall =
+                         std::move(makeCall)]() -> folly::coro::Task<void> {
+                        try {
+                            WebrtcConnectorRpcClient client(
+                                this->rpcCommunicator);
+                            WebrtcConnectorRpcRemote remote(
+                                PeerDescriptor(local),
+                                PeerDescriptor(target),
+                                std::move(client));
+                            co_await streamr::utils::co_withCancellation(
+                                this->abortController.getSignal()
+                                    .getCancellationToken(),
+                                makeCall(remote));
+                        } catch (const std::exception& err) {
+                            SLogger::trace(
+                                "Failed to send " + description + " " +
+                                std::string(err.what()));
+                        }
+                    })));
+    }
+};
+
+} // namespace streamr::dht::connection::webrtc

--- a/packages/streamr-dht/modules/connection/webrtc/WebrtcConnectorRpcLocal.cppm
+++ b/packages/streamr-dht/modules/connection/webrtc/WebrtcConnectorRpcLocal.cppm
@@ -1,0 +1,171 @@
+// Module streamr.dht.WebrtcConnectorRpcLocal
+// Ported from packages/dht/src/connection/webrtc/WebrtcConnectorRpcLocal.ts
+// (v103.8.0-rc.3): the receiving side of the WebRTC signalling
+// notifications. Adaptation: the TS options pass the connector's mutable
+// ongoingConnectAttempts map; here the connector provides a thread-safe
+// accessor callback instead (its own mutex guards the map — the TS
+// single-threaded event loop needed none).
+module;
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
+export module streamr.dht.WebrtcConnectorRpcLocal;
+
+import streamr.dht.protos;
+
+import streamr.dht.AddressTools;
+import streamr.dht.Connection;
+import streamr.dht.DhtCallContext;
+import streamr.dht.DhtRpcServer;
+import streamr.dht.Identifiers;
+import streamr.dht.IPendingConnection;
+import streamr.dht.WebrtcConnection;
+import streamr.dht.webrtcTypes;
+import streamr.logger.SLogger;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+
+export namespace streamr::dht::connection::webrtc {
+
+using ::dht::IceCandidate;
+using ::dht::PeerDescriptor;
+using ::dht::RtcAnswer;
+using ::dht::RtcOffer;
+using ::dht::WebrtcConnectionRequest;
+using ::dht::WebrtcConnectorRpc;
+using streamr::dht::DhtAddress;
+using streamr::dht::Identifiers;
+using streamr::dht::connection::ConnectionID;
+using streamr::dht::connection::IPendingConnection;
+using streamr::dht::helpers::AddressTools;
+using streamr::dht::rpcprotocol::DhtCallContext;
+
+// TS ConnectingConnection (WebrtcConnector.ts).
+struct ConnectingConnection {
+    std::shared_ptr<IPendingConnection> managedConnection;
+    std::shared_ptr<WebrtcConnection> connection;
+};
+
+struct WebrtcConnectorRpcLocalOptions {
+    std::function<std::shared_ptr<IPendingConnection>(
+        const PeerDescriptor& /*targetPeerDescriptor*/,
+        bool /*doNotRequestConnection*/)>
+        connect;
+    std::function<bool(const std::shared_ptr<IPendingConnection>&)>
+        onNewConnection;
+    // Thread-safe accessor into the connector's ongoingConnectAttempts.
+    std::function<std::optional<ConnectingConnection>(const DhtAddress&)>
+        getOngoingConnectAttempt;
+    std::function<PeerDescriptor()> getLocalPeerDescriptor;
+    bool allowPrivateAddresses;
+};
+
+class WebrtcConnectorRpcLocal : public WebrtcConnectorRpc<DhtCallContext> {
+private:
+    WebrtcConnectorRpcLocalOptions options;
+
+public:
+    explicit WebrtcConnectorRpcLocal(WebrtcConnectorRpcLocalOptions&& options)
+        : options(std::move(options)) {}
+    ~WebrtcConnectorRpcLocal() override = default;
+
+    void requestConnection(
+        const WebrtcConnectionRequest& /*request*/,
+        const DhtCallContext& callContext) override {
+        const auto targetPeerDescriptor =
+            callContext.incomingSourceDescriptor.value();
+        if (this->options
+                .getOngoingConnectAttempt(
+                    Identifiers::getNodeIdFromPeerDescriptor(
+                        targetPeerDescriptor))
+                .has_value()) {
+            return;
+        }
+        const auto pendingConnection =
+            this->options.connect(targetPeerDescriptor, false);
+        this->options.onNewConnection(pendingConnection);
+    }
+
+    void rtcOffer(
+        const RtcOffer& request, const DhtCallContext& callContext) override {
+        const auto remotePeerDescriptor =
+            callContext.incomingSourceDescriptor.value();
+        const auto nodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(remotePeerDescriptor);
+
+        auto existing = this->options.getOngoingConnectAttempt(nodeId);
+        std::shared_ptr<WebrtcConnection> connection;
+        if (!existing.has_value()) {
+            const auto pendingConnection =
+                this->options.connect(remotePeerDescriptor, true);
+            connection =
+                this->options.getOngoingConnectAttempt(nodeId)->connection;
+            this->options.onNewConnection(pendingConnection);
+        } else {
+            connection = existing->connection;
+        }
+        // Always use the offerer's connectionId.
+        connection->setConnectionId(ConnectionID{request.connectionid()});
+        connection->setRemoteDescription(
+            request.description(), rtcdescription::OFFER);
+    }
+
+    void rtcAnswer(
+        const RtcAnswer& request, const DhtCallContext& callContext) override {
+        const auto remotePeerDescriptor =
+            callContext.incomingSourceDescriptor.value();
+        const auto nodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(remotePeerDescriptor);
+        const auto existing = this->options.getOngoingConnectAttempt(nodeId);
+        if (!existing.has_value()) {
+            return;
+        }
+        if (existing->connection->getConnectionID() != request.connectionid()) {
+            SLogger::trace("Ignoring RTC answer due to connectionId mismatch");
+            return;
+        }
+        existing->connection->setRemoteDescription(
+            request.description(), rtcdescription::ANSWER);
+    }
+
+    void iceCandidate(
+        const IceCandidate& request,
+        const DhtCallContext& callContext) override {
+        const auto remotePeerDescriptor =
+            callContext.incomingSourceDescriptor.value();
+        const auto nodeId =
+            Identifiers::getNodeIdFromPeerDescriptor(remotePeerDescriptor);
+        const auto existing = this->options.getOngoingConnectAttempt(nodeId);
+        if (!existing.has_value()) {
+            return;
+        }
+        if (existing->connection->getConnectionID() != request.connectionid()) {
+            SLogger::trace(
+                "Ignoring remote candidate due to connectionId mismatch");
+            return;
+        }
+        if (this->isIceCandidateAllowed(request.candidate())) {
+            existing->connection->addRemoteCandidate(
+                request.candidate(), request.mid());
+        }
+    }
+
+private:
+    [[nodiscard]] bool isIceCandidateAllowed(
+        const std::string& candidate) const {
+        if (!this->options.allowPrivateAddresses) {
+            const auto address =
+                AddressTools::getAddressFromIceCandidate(candidate);
+            if (address.has_value() && AddressTools::isPrivateIPv4(*address)) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+} // namespace streamr::dht::connection::webrtc

--- a/packages/streamr-dht/modules/connection/webrtc/WebrtcConnectorRpcRemote.cppm
+++ b/packages/streamr-dht/modules/connection/webrtc/WebrtcConnectorRpcRemote.cppm
@@ -1,0 +1,102 @@
+// Module streamr.dht.WebrtcConnectorRpcRemote
+// Ported from packages/dht/src/connection/webrtc/WebrtcConnectorRpcRemote.ts
+// (v103.8.0-rc.3): the signalling notifications the connector sends to the
+// remote peer over the transport. Adaptation: the TS methods fire the
+// notification and .catch() the promise; here each method is a coroutine
+// the WebrtcConnector spawns detached into its scope — the co_await keeps
+// the request locals alive in this frame (the lazy-task trap:
+// RpcCommunicatorClientApi::notify holds its parameters by reference), and
+// the connector's spawn wrapper logs failures like the TS .catch.
+module;
+
+#include <chrono>
+#include <optional>
+#include <string>
+
+// std::coroutine_traits must be visible in every translation unit
+// that defines OR instantiates a coroutine; it cannot arrive through
+// an imported BMI.
+#include <coroutine> // IWYU pragma: keep
+
+export module streamr.dht.WebrtcConnectorRpcRemote;
+
+import streamr.dht.protos;
+
+import streamr.utils.CoroutineHelper;
+import streamr.dht.DhtRpcClient;
+import streamr.protorpc.RpcCommunicator;
+import streamr.logger.SLogger;
+import streamr.dht.Connection;
+import streamr.dht.DhtCallContext;
+import streamr.dht.RpcRemote;
+
+// Hoisted from the former header (file scope, NOT exported).
+using streamr::logger::SLogger;
+
+export namespace streamr::dht::connection::webrtc {
+
+using ::dht::IceCandidate;
+using ::dht::PeerDescriptor;
+using ::dht::RtcAnswer;
+using ::dht::RtcOffer;
+using ::dht::WebrtcConnectionRequest;
+using streamr::dht::connection::ConnectionID;
+using streamr::dht::contact::DhtCallContext;
+using streamr::dht::contact::RpcRemote;
+
+using WebrtcConnectorRpcClient =
+    ::dht::WebrtcConnectorRpcClient<DhtCallContext>;
+
+class WebrtcConnectorRpcRemote : public RpcRemote<WebrtcConnectorRpcClient> {
+public:
+    WebrtcConnectorRpcRemote(
+        PeerDescriptor&& localPeerDescriptor, // NOLINT
+        PeerDescriptor&& remotePeerDescriptor,
+        WebrtcConnectorRpcClient&& client,
+        std::optional<std::chrono::milliseconds> timeout = std::nullopt)
+        : RpcRemote<WebrtcConnectorRpcClient>(
+              std::move(localPeerDescriptor),
+              std::move(remotePeerDescriptor),
+              client,
+              timeout) {}
+
+    folly::coro::Task<void> requestConnection() {
+        WebrtcConnectionRequest request{};
+        auto options = this->formDhtRpcOptions();
+        co_await this->getClient().requestConnection(
+            std::move(request), std::move(options), this->getTimeout());
+    }
+
+    folly::coro::Task<void> sendRtcOffer(
+        std::string description, ConnectionID connectionId) {
+        RtcOffer request;
+        request.set_connectionid(connectionId);
+        request.set_description(std::move(description));
+        auto options = this->formDhtRpcOptions();
+        co_await this->getClient().rtcOffer(
+            std::move(request), std::move(options), this->getTimeout());
+    }
+
+    folly::coro::Task<void> sendRtcAnswer(
+        std::string description, ConnectionID connectionId) {
+        RtcAnswer request;
+        request.set_connectionid(connectionId);
+        request.set_description(std::move(description));
+        auto options = this->formDhtRpcOptions();
+        co_await this->getClient().rtcAnswer(
+            std::move(request), std::move(options), this->getTimeout());
+    }
+
+    folly::coro::Task<void> sendIceCandidate(
+        std::string candidate, std::string mid, ConnectionID connectionId) {
+        IceCandidate request;
+        request.set_connectionid(connectionId);
+        request.set_mid(std::move(mid));
+        request.set_candidate(std::move(candidate));
+        auto options = this->formDhtRpcOptions();
+        co_await this->getClient().iceCandidate(
+            std::move(request), std::move(options), this->getTimeout());
+    }
+};
+
+} // namespace streamr::dht::connection::webrtc

--- a/packages/streamr-dht/modules/connection/webrtc/webrtcTypes.cppm
+++ b/packages/streamr-dht/modules/connection/webrtc/webrtcTypes.cppm
@@ -1,0 +1,96 @@
+// Module streamr.dht.webrtcTypes
+// Ported from packages/dht/src/connection/webrtc/types.ts, consts.ts,
+// iceServerAsString.ts and the event/ctor-parameter shapes of
+// IWebrtcConnection.ts / types/WebrtcConnectionParams.ts (v103.8.0-rc.3).
+// iceServerAsString produces the URL form libdatachannel's rtc::IceServer
+// constructor parses (the TS node-datachannel binding feeds the same
+// strings to the same parser) — wire/config-visible, keep exact.
+module;
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+export module streamr.dht.webrtcTypes;
+
+import streamr.dht.protos;
+
+import streamr.dht.PortRange;
+import streamr.eventemitter.EventEmitter;
+
+export namespace streamr::dht::connection::webrtc {
+
+using ::dht::PeerDescriptor;
+
+struct IceServer {
+    std::string url;
+    uint16_t port = 0;
+    std::optional<std::string> username = std::nullopt;
+    std::optional<std::string> password = std::nullopt;
+    std::optional<bool> tcp = std::nullopt;
+};
+
+// TS consts.ts EARLY_TIMEOUT: how long a started connection may wait for
+// the remote description before it is torn down.
+inline constexpr std::chrono::milliseconds earlyTimeout{5000};
+
+// TS RtcDescription enum.
+namespace rtcdescription {
+inline constexpr auto OFFER = "offer";
+inline constexpr auto ANSWER = "answer";
+} // namespace rtcdescription
+
+inline std::string iceServerAsString(const IceServer& iceServer) {
+    const auto separator = iceServer.url.find(':');
+    if (separator == std::string::npos ||
+        separator + 1 >= iceServer.url.size()) {
+        throw std::runtime_error("invalid stun/turn format: " + iceServer.url);
+    }
+    const std::string protocol = iceServer.url.substr(0, separator);
+    const std::string hostname = iceServer.url.substr(separator + 1);
+    if (!iceServer.username.has_value() && !iceServer.password.has_value()) {
+        return protocol + ":" + hostname + ":" + std::to_string(iceServer.port);
+    }
+    if (iceServer.username.has_value() && iceServer.password.has_value()) {
+        return protocol + ":" + *iceServer.username + ":" +
+            *iceServer.password + "@" + hostname + ":" +
+            std::to_string(iceServer.port) +
+            (iceServer.tcp.has_value() ? "?transport=tcp" : "");
+    }
+    throw std::runtime_error(
+        "username (" + iceServer.username.value_or("undefined") +
+        ") and password (" + iceServer.password.value_or("undefined") +
+        ") must be supplied together");
+}
+
+// TS WebrtcConnectionEvents extends ConnectionEvents with these two; the
+// C++ Connection base fixes its event tuple, so WebrtcConnection exposes
+// them through a separate member emitter (webrtcEvents()).
+namespace webrtcconnectionevents {
+struct LocalDescription
+    : streamr::eventemitter::
+          Event<std::string /*description*/, std::string /*type*/> {};
+struct LocalCandidate
+    : streamr::eventemitter::
+          Event<std::string /*candidate*/, std::string /*mid*/> {};
+} // namespace webrtcconnectionevents
+
+using WebrtcSignallingEvents = std::tuple<
+    webrtcconnectionevents::LocalDescription,
+    webrtcconnectionevents::LocalCandidate>;
+
+// TS types/WebrtcConnectionParams.ts.
+struct WebrtcConnectionParams {
+    PeerDescriptor remotePeerDescriptor;
+    std::optional<size_t> bufferThresholdHigh = std::nullopt;
+    std::optional<size_t> bufferThresholdLow = std::nullopt;
+    std::optional<size_t> maxMessageSize = std::nullopt;
+    std::vector<IceServer> iceServers = {};
+    std::optional<streamr::dht::types::PortRange> portRange = std::nullopt;
+};
+
+} // namespace streamr::dht::connection::webrtc

--- a/packages/streamr-dht/modules/transport/FakeTransport.cppm
+++ b/packages/streamr-dht/modules/transport/FakeTransport.cppm
@@ -28,7 +28,10 @@ using streamr::dht::transport::Transport;
 class FakeTransport : public Transport, public ConnectionsView {
 private:
     std::function<void(const Message&)> onSend;
-    const PeerDescriptor& localPeerDescriptor;
+    // By VALUE: a reference member dangled when callers passed a temporary
+    // descriptor into FakeEnvironment::createTransport (BUS error in send()
+    // the first time the source descriptor was stamped).
+    const PeerDescriptor localPeerDescriptor;
     // currently adds a peerDescription to the connections array when a
     // "connect" option is seen in in send() call and never disconnects (TODO
     // could add some disconnection logic? and maybe the connection should be

--- a/packages/streamr-dht/test/integration/RpcConnectionsOverWebrtcTest.cpp
+++ b/packages/streamr-dht/test/integration/RpcConnectionsOverWebrtcTest.cpp
@@ -1,0 +1,178 @@
+// Ported from packages/dht/test/integration/rpc-connections-over-webrtc.test.ts
+// (v103.8.0-rc.3): a full RPC round trip (ping) between two
+//
+// Residual flakiness note: CanMakeRpcCallOverWebrtc drives a real ICE +
+// DTLS handshake over loopback, which occasionally fails to stabilise (the
+// far side transitions straight to Disconnected). This is the same
+// nondeterminism the TS suite documents as flaky (ticket NET-911); the
+// dominant deterministic cause — an ICE candidate arriving before the offer
+// — is fixed in WebrtcConnection by queuing early candidates, leaving a
+// ~7% single-run rate that CI's `ctest --repeat until-pass:2` absorbs.
+// ConnectionManagers whose only mutual connectivity is WebRTC (no websocket
+// info in either descriptor), signalled over a Simulator with FIXED 50 ms
+// latency. Adaptations: the raw generated DhtNodeRpcClient is driven with a
+// hand-built DhtCallContext instead of toProtoRpcClient options, and the
+// failure cases assert the exception type/rough shape rather than the exact
+// TS error strings (the C++ error texts differ).
+#include <chrono>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <gtest/gtest.h>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+#include <coroutine> // IWYU pragma: keep
+
+import streamr.dht.ConnectionManager;
+import streamr.dht.ConnectorFacade;
+import streamr.dht.DhtCallContext;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.Identifiers;
+import streamr.dht.ListeningRpcCommunicator;
+import streamr.dht.Simulator;
+import streamr.dht.SimulatorTransport;
+import streamr.dht.TestUtils;
+import streamr.dht.Transport;
+import streamr.dht.protos;
+import streamr.protorpc.RpcCommunicator;
+import streamr.utils.CoroutineHelper;
+import streamr.utils.Uuid;
+
+using ::dht::ConnectivityResponse;
+using ::dht::PeerDescriptor;
+using ::dht::PingRequest;
+using ::dht::PingResponse;
+using streamr::dht::ServiceID;
+using streamr::dht::connection::ConnectionManager;
+using streamr::dht::connection::ConnectionManagerOptions;
+using streamr::dht::connection::DefaultConnectorFacade;
+using streamr::dht::connection::DefaultConnectorFacadeOptions;
+using streamr::dht::connection::simulator::LatencyType;
+using streamr::dht::connection::simulator::Simulator;
+using streamr::dht::connection::simulator::SimulatorTransport;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::dht::transport::ListeningRpcCommunicator;
+using streamr::utils::blockingWait;
+using streamr::utils::Uuid;
+
+using DhtNodeRpcClient = ::dht::DhtNodeRpcClient<DhtCallContext>;
+
+namespace {
+
+constexpr auto serviceId = "test";
+constexpr double fixedLatencyMs = 50;
+constexpr auto failureCaseTimeout = std::chrono::milliseconds(10000);
+
+std::shared_ptr<ConnectionManager> createConnectionManager(
+    const PeerDescriptor& localPeerDescriptor,
+    streamr::dht::transport::Transport& transport) {
+    return std::make_shared<ConnectionManager>(ConnectionManagerOptions{
+        .createConnectorFacade = [localPeerDescriptor, &transport]()
+            -> std::shared_ptr<DefaultConnectorFacade> {
+            return std::make_shared<DefaultConnectorFacade>(
+                DefaultConnectorFacadeOptions{
+                    .transport = transport,
+                    .createLocalPeerDescriptor =
+                        [localPeerDescriptor](
+                            const ConnectivityResponse& /*response*/)
+                        -> PeerDescriptor { return localPeerDescriptor; }});
+        }});
+}
+
+} // namespace
+
+class RpcConnectionsOverWebrtcTest : public ::testing::Test {
+protected:
+    // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
+    Simulator simulator{LatencyType::FIXED, fixedLatencyMs};
+    PeerDescriptor peerDescriptor1;
+    PeerDescriptor peerDescriptor2;
+    std::shared_ptr<SimulatorTransport> connectorTransport1;
+    std::shared_ptr<SimulatorTransport> connectorTransport2;
+    std::shared_ptr<ConnectionManager> manager1;
+    std::shared_ptr<ConnectionManager> manager2;
+    std::unique_ptr<ListeningRpcCommunicator> rpcCommunicator1;
+    std::unique_ptr<ListeningRpcCommunicator> rpcCommunicator2;
+    // NOLINTEND(misc-non-private-member-variables-in-classes)
+
+    void SetUp() override {
+        this->peerDescriptor1 = createMockPeerDescriptor();
+        this->peerDescriptor2 = createMockPeerDescriptor();
+        this->connectorTransport1 = std::make_shared<SimulatorTransport>(
+            this->peerDescriptor1, this->simulator);
+        this->connectorTransport1->start();
+        this->manager1 = createConnectionManager(
+            this->peerDescriptor1, *this->connectorTransport1);
+        this->rpcCommunicator1 = std::make_unique<ListeningRpcCommunicator>(
+            ServiceID{serviceId}, *this->manager1);
+
+        this->connectorTransport2 = std::make_shared<SimulatorTransport>(
+            this->peerDescriptor2, this->simulator);
+        this->connectorTransport2->start();
+        this->manager2 = createConnectionManager(
+            this->peerDescriptor2, *this->connectorTransport2);
+        this->rpcCommunicator2 = std::make_unique<ListeningRpcCommunicator>(
+            ServiceID{serviceId}, *this->manager2);
+
+        this->manager1->start();
+        this->manager2->start();
+    }
+
+    void TearDown() override {
+        this->rpcCommunicator1->destroy();
+        this->rpcCommunicator2->destroy();
+        this->manager1->stop();
+        this->manager2->stop();
+        this->connectorTransport1->stop();
+        this->connectorTransport2->stop();
+        this->simulator.stop();
+    }
+
+    [[nodiscard]] DhtCallContext createCallContext() const {
+        DhtCallContext context;
+        context.sourceDescriptor = this->peerDescriptor1;
+        context.targetDescriptor = this->peerDescriptor2;
+        return context;
+    }
+};
+
+TEST_F(RpcConnectionsOverWebrtcTest, CanMakeRpcCallOverWebrtc) {
+    this->rpcCommunicator2->registerRpcMethod<PingRequest, PingResponse>(
+        "ping",
+        [](const PingRequest& request,
+           const DhtCallContext& /*context*/) -> PingResponse {
+            PingResponse response;
+            response.set_requestid(request.requestid());
+            return response;
+        });
+
+    const std::string requestId = Uuid::v4();
+    PingRequest request;
+    request.set_requestid(requestId);
+    DhtNodeRpcClient client(*this->rpcCommunicator1);
+    const auto response = blockingWait(
+        client.ping(std::move(request), this->createCallContext()));
+    EXPECT_EQ(response.requestid(), requestId);
+}
+
+TEST_F(RpcConnectionsOverWebrtcTest, ThrowsIfRpcMethodIsNotDefined) {
+    PingRequest request;
+    request.set_requestid(Uuid::v4());
+    DhtNodeRpcClient client(*this->rpcCommunicator1);
+    EXPECT_THROW(
+        blockingWait(
+            client.ping(std::move(request), this->createCallContext())),
+        std::exception);
+}
+
+TEST_F(RpcConnectionsOverWebrtcTest, ThrowsClientSideIfWebrtcConnectionFails) {
+    this->manager2->stop();
+    PingRequest request;
+    request.set_requestid(Uuid::v4());
+    DhtNodeRpcClient client(*this->rpcCommunicator1);
+    EXPECT_THROW(
+        blockingWait(client.ping(
+            std::move(request), this->createCallContext(), failureCaseTimeout)),
+        std::exception);
+}

--- a/packages/streamr-dht/test/integration/WebrtcConnectionManagementTest.cpp
+++ b/packages/streamr-dht/test/integration/WebrtcConnectionManagementTest.cpp
@@ -1,0 +1,217 @@
+// Ported from packages/dht/test/integration/WebrtcConnectionManagement.test.ts
+// (v103.8.0-rc.3): two ConnectionManagers whose peers have NO websocket
+// server signal over a Simulator (FIXED 20 ms latency) and open real WebRTC
+// data channels to each other. Adaptations: jest done-callbacks and event
+// promises become waitForCondition on captured flags; the
+// connects-and-disconnects case triggers the disconnect by stopping one
+// manager through the public API instead of the TS @ts-expect-error call to
+// the private closeConnection() (the ConnectionManagerIntegrationTest
+// adaptation); the failed-connection case waits for the target's cleanup
+// via hasConnection() like its websocket sibling.
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <gtest/gtest.h>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+#include <coroutine> // IWYU pragma: keep
+
+import streamr.dht.ConnectionManager;
+import streamr.dht.ConnectorFacade;
+import streamr.dht.Errors;
+import streamr.dht.Identifiers;
+import streamr.dht.Simulator;
+import streamr.dht.SimulatorTransport;
+import streamr.dht.TestUtils;
+import streamr.dht.Transport;
+import streamr.dht.protos;
+import streamr.utils.CoroutineHelper;
+import streamr.utils.waitForCondition;
+
+using ::dht::ConnectivityResponse;
+using ::dht::Message;
+using ::dht::PeerDescriptor;
+using streamr::dht::Identifiers;
+using streamr::dht::connection::ConnectionManager;
+using streamr::dht::connection::ConnectionManagerOptions;
+using streamr::dht::connection::DefaultConnectorFacade;
+using streamr::dht::connection::DefaultConnectorFacadeOptions;
+using streamr::dht::connection::simulator::LatencyType;
+using streamr::dht::connection::simulator::Simulator;
+using streamr::dht::connection::simulator::SimulatorTransport;
+using streamr::dht::helpers::CannotConnectToSelf;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::utils::waitForCondition;
+
+namespace transportevents = streamr::dht::transport::transportevents;
+
+namespace {
+
+constexpr auto serviceId = "dummy";
+constexpr double fixedLatencyMs = 20;
+// The TS cases run under 15-60 s jest timeouts; a real ICE + DTLS
+// handshake over the loopback interface completes well within this.
+constexpr auto webrtcConnectTimeout = std::chrono::seconds(30);
+constexpr auto pollInterval = std::chrono::milliseconds(200);
+
+Message createDummyMessage(
+    const std::string& messageServiceId,
+    const PeerDescriptor& targetDescriptor) {
+    Message message;
+    message.set_serviceid(messageServiceId);
+    message.mutable_rpcmessage(); // body.oneofKind = rpcMessage
+    message.set_messageid("mockerer");
+    message.mutable_targetdescriptor()->CopyFrom(targetDescriptor);
+    return message;
+}
+
+std::shared_ptr<ConnectionManager> createConnectionManager(
+    const PeerDescriptor& localPeerDescriptor,
+    streamr::dht::transport::Transport& transport) {
+    return std::make_shared<ConnectionManager>(ConnectionManagerOptions{
+        .createConnectorFacade = [localPeerDescriptor, &transport]()
+            -> std::shared_ptr<DefaultConnectorFacade> {
+            return std::make_shared<DefaultConnectorFacade>(
+                DefaultConnectorFacadeOptions{
+                    .transport = transport,
+                    .createLocalPeerDescriptor =
+                        [localPeerDescriptor](
+                            const ConnectivityResponse& /*response*/)
+                        -> PeerDescriptor { return localPeerDescriptor; }});
+        }});
+}
+
+void expectCondition(
+    const char* label,
+    std::function<bool()>&& condition,
+    std::chrono::milliseconds timeout = webrtcConnectTimeout) {
+    SCOPED_TRACE(label);
+    auto task = waitForCondition(std::move(condition), timeout, pollInterval);
+    EXPECT_NO_THROW(streamr::utils::blockingWait(std::move(task)));
+}
+
+} // namespace
+
+class WebrtcConnectionManagementTest : public ::testing::Test {
+protected:
+    // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
+    Simulator simulator{LatencyType::FIXED, fixedLatencyMs};
+    PeerDescriptor peerDescriptor1;
+    PeerDescriptor peerDescriptor2;
+    std::shared_ptr<SimulatorTransport> connectorTransport1;
+    std::shared_ptr<SimulatorTransport> connectorTransport2;
+    std::shared_ptr<ConnectionManager> manager1;
+    std::shared_ptr<ConnectionManager> manager2;
+    // NOLINTEND(misc-non-private-member-variables-in-classes)
+
+    void SetUp() override {
+        this->peerDescriptor1 = createMockPeerDescriptor();
+        this->peerDescriptor2 = createMockPeerDescriptor();
+        this->connectorTransport1 = std::make_shared<SimulatorTransport>(
+            this->peerDescriptor1, this->simulator);
+        this->connectorTransport1->start();
+        this->manager1 = createConnectionManager(
+            this->peerDescriptor1, *this->connectorTransport1);
+        this->connectorTransport2 = std::make_shared<SimulatorTransport>(
+            this->peerDescriptor2, this->simulator);
+        this->connectorTransport2->start();
+        this->manager2 = createConnectionManager(
+            this->peerDescriptor2, *this->connectorTransport2);
+        this->manager1->start();
+        this->manager2->start();
+    }
+
+    void TearDown() override {
+        this->manager1->stop();
+        this->manager2->stop();
+        this->connectorTransport1->stop();
+        this->connectorTransport2->stop();
+        this->simulator.stop();
+    }
+};
+
+TEST_F(WebrtcConnectionManagementTest, Peer1CanOpenWebrtcDatachannels) {
+    std::atomic<bool> received = false;
+    this->manager2->on<transportevents::Message>(
+        [&received](const Message& message) {
+            EXPECT_EQ(message.messageid(), "mockerer");
+            received = true;
+        });
+    this->manager1->send(
+        createDummyMessage("unknown", this->peerDescriptor2), {});
+    expectCondition("message received over webrtc", [&received]() {
+        return received.load();
+    });
+}
+
+TEST_F(WebrtcConnectionManagementTest, Peer2CanOpenWebrtcDatachannel) {
+    std::atomic<bool> received = false;
+    this->manager1->on<transportevents::Message>(
+        [&received](const Message& message) {
+            EXPECT_EQ(message.messageid(), "mockerer");
+            received = true;
+        });
+    this->manager2->send(
+        createDummyMessage(serviceId, this->peerDescriptor1), {});
+    expectCondition("message received over webrtc", [&received]() {
+        return received.load();
+    });
+}
+
+TEST_F(WebrtcConnectionManagementTest, ConnectingToSelfThrows) {
+    const auto selfMessage =
+        createDummyMessage(serviceId, this->peerDescriptor1);
+    EXPECT_THROW(this->manager1->send(selfMessage, {}), CannotConnectToSelf);
+}
+
+TEST_F(
+    WebrtcConnectionManagementTest, ConnectsAndDisconnectsWebrtcConnections) {
+    std::atomic<bool> dataReceived = false;
+    std::atomic<bool> connected1 = false;
+    std::atomic<bool> connected2 = false;
+    std::atomic<bool> disconnected1 = false;
+    std::atomic<bool> disconnected2 = false;
+
+    this->manager2->on<transportevents::Message>(
+        [&dataReceived](const Message& message) {
+            EXPECT_TRUE(message.has_rpcmessage());
+            dataReceived = true;
+        });
+    this->manager1->on<transportevents::Connected>(
+        [&connected1](const PeerDescriptor& /*peer*/) { connected1 = true; });
+    this->manager2->on<transportevents::Connected>(
+        [&connected2](const PeerDescriptor& /*peer*/) { connected2 = true; });
+    this->manager1->on<transportevents::Disconnected>(
+        [&disconnected1](const PeerDescriptor& /*peer*/, bool /*graceful*/) {
+            disconnected1 = true;
+        });
+    this->manager2->on<transportevents::Disconnected>(
+        [&disconnected2](const PeerDescriptor& /*peer*/, bool /*graceful*/) {
+            disconnected2 = true;
+        });
+
+    this->manager1->send(
+        createDummyMessage(serviceId, this->peerDescriptor2), {});
+    expectCondition("both connected and data flowed", [&]() {
+        return dataReceived.load() && connected1.load() && connected2.load();
+    });
+
+    // TS closes the connection through the private closeConnection();
+    // stopping one manager closes it through the public API.
+    this->manager2->stop();
+    expectCondition("both saw the disconnect", [&]() {
+        return disconnected1.load() && disconnected2.load();
+    });
+}
+
+TEST_F(WebrtcConnectionManagementTest, FailedConnectionsAreCleanedUp) {
+    const auto targetDescriptor = createMockPeerDescriptor();
+    const auto nodeId =
+        Identifiers::getNodeIdFromPeerDescriptor(targetDescriptor);
+    this->manager1->send(createDummyMessage(serviceId, targetDescriptor), {});
+    auto* manager = this->manager1.get();
+    expectCondition("failed connection cleaned up", [manager, nodeId]() {
+        return !manager->hasConnection(nodeId);
+    });
+}

--- a/packages/streamr-dht/test/integration/WebrtcConnectorRpcTest.cpp
+++ b/packages/streamr-dht/test/integration/WebrtcConnectorRpcTest.cpp
@@ -1,0 +1,130 @@
+// Ported from packages/dht/test/integration/WebrtcConnectorRpc.test.ts
+// (v103.8.0-rc.3): the four signalling notifications travel between two
+// loopback-wired RpcCommunicators and hit the registered handlers.
+// Adaptation: the TS test drives the raw generated client through
+// toProtoRpcClient; here the calls go through WebrtcConnectorRpcRemote
+// (which wraps that same generated client and is what the connector
+// actually uses), awaited with blockingWait instead of until(counter).
+#include <atomic>
+#include <string>
+#include <gtest/gtest.h>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+#include <coroutine> // IWYU pragma: keep
+
+import streamr.dht.Connection;
+import streamr.dht.DhtCallContext;
+import streamr.dht.DhtRpcClient;
+import streamr.dht.protos;
+import streamr.dht.TestUtils;
+import streamr.dht.WebrtcConnectorRpcRemote;
+import streamr.protorpc.RpcCommunicator;
+import streamr.utils.CoroutineHelper;
+
+using ::dht::IceCandidate;
+using ::dht::PeerDescriptor;
+using ::dht::RtcAnswer;
+using ::dht::RtcOffer;
+using ::dht::WebrtcConnectionRequest;
+using ::protorpc::RpcMessage;
+using streamr::dht::connection::ConnectionID;
+using streamr::dht::connection::webrtc::WebrtcConnectorRpcClient;
+using streamr::dht::connection::webrtc::WebrtcConnectorRpcRemote;
+using streamr::dht::rpcprotocol::DhtCallContext;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::protorpc::RpcCommunicator;
+using streamr::utils::blockingWait;
+
+using RpcCommunicatorType = RpcCommunicator<DhtCallContext>;
+
+class WebrtcConnectorRpcTest : public ::testing::Test {
+protected:
+    RpcCommunicatorType rpcCommunicator1;
+    RpcCommunicatorType rpcCommunicator2;
+    PeerDescriptor localPeerDescriptor = createMockPeerDescriptor();
+    PeerDescriptor targetDescriptor = createMockPeerDescriptor();
+    std::atomic<int> requestConnectionCounter{0};
+    std::atomic<int> rtcOfferCounter{0};
+    std::atomic<int> rtcAnswerCounter{0};
+    std::atomic<int> iceCandidateCounter{0};
+
+    void SetUp() override {
+        this->rpcCommunicator2.registerRpcNotification<WebrtcConnectionRequest>(
+            "requestConnection",
+            [this](
+                const WebrtcConnectionRequest& /*request*/,
+                const DhtCallContext& /*context*/) {
+                this->requestConnectionCounter++;
+            });
+        this->rpcCommunicator2.registerRpcNotification<RtcOffer>(
+            "rtcOffer",
+            [this](
+                const RtcOffer& /*request*/,
+                const DhtCallContext& /*context*/) {
+                this->rtcOfferCounter++;
+            });
+        this->rpcCommunicator2.registerRpcNotification<RtcAnswer>(
+            "rtcAnswer",
+            [this](
+                const RtcAnswer& /*request*/,
+                const DhtCallContext& /*context*/) {
+                this->rtcAnswerCounter++;
+            });
+        this->rpcCommunicator2.registerRpcNotification<IceCandidate>(
+            "iceCandidate",
+            [this](
+                const IceCandidate& /*request*/,
+                const DhtCallContext& /*context*/) {
+                this->iceCandidateCounter++;
+            });
+
+        this->rpcCommunicator1.setOutgoingMessageCallback(
+            [this](
+                const RpcMessage& message,
+                const std::string& /*requestId*/,
+                const DhtCallContext& /*context*/) {
+                this->rpcCommunicator2.handleIncomingMessage(
+                    message, DhtCallContext());
+            });
+        this->rpcCommunicator2.setOutgoingMessageCallback(
+            [this](
+                const RpcMessage& message,
+                const std::string& /*requestId*/,
+                const DhtCallContext& /*context*/) {
+                this->rpcCommunicator1.handleIncomingMessage(
+                    message, DhtCallContext());
+            });
+    }
+
+    [[nodiscard]] WebrtcConnectorRpcRemote createRemote() {
+        return WebrtcConnectorRpcRemote(
+            PeerDescriptor(this->localPeerDescriptor),
+            PeerDescriptor(this->targetDescriptor),
+            WebrtcConnectorRpcClient(this->rpcCommunicator1));
+    }
+};
+
+TEST_F(WebrtcConnectorRpcTest, SendConnectionRequest) {
+    auto remote = this->createRemote();
+    blockingWait(remote.requestConnection());
+    EXPECT_EQ(this->requestConnectionCounter.load(), 1);
+}
+
+TEST_F(WebrtcConnectorRpcTest, SendRtcOffer) {
+    auto remote = this->createRemote();
+    blockingWait(remote.sendRtcOffer("aaaaaa", ConnectionID{"rtcOffer"}));
+    EXPECT_EQ(this->rtcOfferCounter.load(), 1);
+}
+
+TEST_F(WebrtcConnectorRpcTest, SendRtcAnswer) {
+    auto remote = this->createRemote();
+    blockingWait(remote.sendRtcAnswer("aaaaaa", ConnectionID{"rtcOffer"}));
+    EXPECT_EQ(this->rtcAnswerCounter.load(), 1);
+}
+
+TEST_F(WebrtcConnectorRpcTest, SendIceCandidate) {
+    auto remote = this->createRemote();
+    blockingWait(remote.sendIceCandidate(
+        "aaaaaa", "asdasdasdasdasd", ConnectionID{"rtcOffer"}));
+    EXPECT_EQ(this->iceCandidateCounter.load(), 1);
+}

--- a/packages/streamr-dht/test/unit/WebrtcConnectionTest.cpp
+++ b/packages/streamr-dht/test/unit/WebrtcConnectionTest.cpp
@@ -1,0 +1,65 @@
+// Ported from packages/dht/test/unit/WebrtcConnection.test.ts
+// (v103.8.0-rc.3): a started connection whose remote descriptor is never
+// set closes itself after EARLY_TIMEOUT with the ported reason string.
+// Adaptation: jest's waitForEvent becomes a Disconnected listener captured
+// into flags polled with waitForCondition.
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <gtest/gtest.h>
+
+#include <coroutine> // IWYU pragma: keep
+
+import streamr.dht.Connection;
+import streamr.dht.TestUtils;
+import streamr.dht.WebrtcConnection;
+import streamr.dht.webrtcTypes;
+import streamr.utils.CoroutineHelper;
+import streamr.utils.waitForCondition;
+
+using streamr::dht::connection::connectionevents::Disconnected;
+using streamr::dht::connection::webrtc::WebrtcConnection;
+using streamr::dht::connection::webrtc::WebrtcConnectionParams;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::utils::blockingWait;
+using streamr::utils::waitForCondition;
+
+namespace {
+// TS waits 5001 ms for the 5000 ms EARLY_TIMEOUT; polling needs a little
+// more headroom.
+constexpr auto disconnectTimeout = std::chrono::milliseconds(7000);
+constexpr auto pollInterval = std::chrono::milliseconds(100);
+} // namespace
+
+TEST(WebrtcConnectionTest, DisconnectsEarlyIfRemoteDescriptorIsNotSet) {
+    auto connection = WebrtcConnection::newInstance(
+        WebrtcConnectionParams{
+            .remotePeerDescriptor = createMockPeerDescriptor()});
+
+    std::atomic<bool> disconnected = false;
+    std::mutex reasonMutex;
+    std::string reason;
+    connection->on<Disconnected>([&](bool /*gracefulLeave*/,
+                                     uint64_t /*code*/,
+                                     const std::string& disconnectionReason) {
+        {
+            std::scoped_lock lock(reasonMutex);
+            reason = disconnectionReason;
+        }
+        disconnected = true;
+    });
+
+    connection->start(true);
+
+    blockingWait(waitForCondition(
+        [&disconnected]() { return disconnected.load(); },
+        disconnectTimeout,
+        pollInterval));
+    std::scoped_lock lock(reasonMutex);
+    EXPECT_EQ(reason, "timed out due to remote descriptor not being set");
+
+    connection->close(true);
+}

--- a/packages/streamr-dht/test/unit/WebrtcConnectorTest.cpp
+++ b/packages/streamr-dht/test/unit/WebrtcConnectorTest.cpp
@@ -1,0 +1,105 @@
+// Ported from packages/dht/test/unit/WebrtcConnector.test.ts
+// (v103.8.0-rc.3): the connector's ongoingConnectAttempts dedupe — a second
+// connect() to the same peer returns the SAME pending connection until the
+// first one settles (connected or disconnected), after which a new attempt
+// is created. Adaptations: the TS `new MockTransport() as any` becomes a
+// FakeTransport in its own FakeEnvironment (the connector's RPC
+// communicator needs a working transport reference), and the TS
+// MockConnection is a minimal local Connection subclass.
+#include <memory>
+#include <vector>
+#include <gtest/gtest.h>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+import streamr.dht.Connection;
+import streamr.dht.FakeTransport;
+import streamr.dht.IPendingConnection;
+import streamr.dht.TestUtils;
+import streamr.dht.WebrtcConnector;
+import streamr.dht.protos;
+
+using ::dht::PeerDescriptor;
+using streamr::dht::connection::Connection;
+using streamr::dht::connection::ConnectionType;
+using streamr::dht::connection::IPendingConnection;
+using streamr::dht::connection::webrtc::WebrtcConnector;
+using streamr::dht::connection::webrtc::WebrtcConnectorOptions;
+using streamr::dht::testutils::createMockPeerDescriptor;
+using streamr::dht::transport::FakeEnvironment;
+using streamr::dht::transport::FakeTransport;
+
+namespace {
+
+class MockConnection : public Connection {
+public:
+    MockConnection() : Connection(ConnectionType::WEBRTC) {}
+    void send(const std::vector<std::byte>& /*data*/) override {}
+    void close(bool /*gracefulLeave*/) override {}
+    void destroy() override {}
+};
+
+} // namespace
+
+class WebrtcConnectorTest : public ::testing::Test {
+protected:
+    FakeEnvironment fakeEnvironment;
+    std::shared_ptr<FakeTransport> transport;
+    std::unique_ptr<WebrtcConnector> connector;
+
+    void SetUp() override {
+        this->transport =
+            this->fakeEnvironment.createTransport(createMockPeerDescriptor());
+        this->connector =
+            std::make_unique<WebrtcConnector>(WebrtcConnectorOptions{
+                .onNewConnection =
+                    [](const std::shared_ptr<IPendingConnection>&) {
+                        return true;
+                    },
+                .transport = *this->transport});
+        this->connector->setLocalPeerDescriptor(createMockPeerDescriptor());
+    }
+
+    void TearDown() override { this->connector->stop(); }
+};
+
+TEST_F(WebrtcConnectorTest, ReturnsExistingConnectingConnection) {
+    const auto remotePeerDescriptor = createMockPeerDescriptor();
+    const auto firstConnection =
+        this->connector->connect(remotePeerDescriptor, false);
+    const auto secondConnection =
+        this->connector->connect(remotePeerDescriptor, false);
+    EXPECT_EQ(firstConnection, secondConnection);
+    firstConnection->close(false);
+}
+
+TEST_F(WebrtcConnectorTest, DisconnectedEventRemovesConnectingConnection) {
+    const auto remotePeerDescriptor = createMockPeerDescriptor();
+    const auto firstConnection =
+        this->connector->connect(remotePeerDescriptor, false);
+    // Adaptation: TS raises the Disconnected event with a bare
+    // `firstConnection.emit('disconnected', false)`. The C++ EventEmitter
+    // mutex is non-recursive (JS re-entrant emit has no analogue), and a
+    // direct emit bypasses PendingConnection's `stopped` guard, so the
+    // connection<->pendingConnection close cross-wiring re-enters the same
+    // emitter and deadlocks. close(false) is the real API that raises the
+    // same Disconnected event AND sets the guard, so the cascade terminates
+    // — testing the identical behaviour (a disconnect drops the ongoing
+    // attempt) without the JS-only re-entrancy assumption.
+    firstConnection->close(false);
+    const auto secondConnection =
+        this->connector->connect(remotePeerDescriptor, false);
+    EXPECT_NE(firstConnection, secondConnection);
+    secondConnection->close(false);
+}
+
+TEST_F(WebrtcConnectorTest, ConnectedEventRemovesConnectingConnection) {
+    const auto remotePeerDescriptor = createMockPeerDescriptor();
+    const auto firstConnection =
+        this->connector->connect(remotePeerDescriptor, false);
+    firstConnection->onHandshakeCompleted(std::make_shared<MockConnection>());
+    const auto secondConnection =
+        this->connector->connect(remotePeerDescriptor, false);
+    EXPECT_NE(firstConnection, secondConnection);
+    firstConnection->close(false);
+    secondConnection->close(false);
+}


### PR DESCRIPTION
Implements Phase B2 of `trackerless-network-completion-plan.md` (Milestone B): the WebRTC connector, ported line-by-line from the pinned TypeScript (`af966cf03`, v103.8.0-rc.3) onto libdatachannel's `rtc::PeerConnection`/`rtc::DataChannel`. TS's `node-datachannel` wraps the same library, so the offer/answer/ICE signalling and callback semantics carry over closely.

## New modules

- **`webrtcTypes`** — `IceServer` + `iceServerAsString` (produces the URL form `rtc::IceServer` parses), the `localDescription`/`localCandidate` signalling events (a separate member emitter, since the `Connection` base fixes its event tuple), `EARLY_TIMEOUT`, `WebrtcConnectionParams`.
- **`WebrtcConnection`** — one data-channel connection. `EARLY_TIMEOUT` via an `AbortableTimers` weak-self watchdog; rtc callbacks guarded by `mMutex`, with all call-outs and the rtc `close()` performed outside it.
- **`WebrtcConnectorRpcRemote` / `WebrtcConnectorRpcLocal`** — the `requestConnection`/`rtcOffer`/`rtcAnswer`/`iceCandidate` signalling notifications. The remote `co_await`s the generated client (the lazy-task trap); the local drives `connect`/`setRemoteDescription`.
- **`WebrtcConnector`** — the XOR-id offerer tie-break (`OffererHelper`), `ongoingConnectAttempts` dedupe, handshaker bookkeeping, and detached signalling on a serial view of the shared worker pool drained by a `GuardedAsyncScope` in `stop()` (the PR #75 executor architecture). `replaceInternalIpWithExternalIp` for `externalIp` candidate rewriting.
- **`DefaultConnectorFacade`** — `createConnection` now falls through to the `WebrtcConnector`; `iceServers` / `allowPrivateAddresses` / buffer-threshold / `externalIp` / `webrtcPortRange` options are plumbed through.

## Four lifecycle bugs the TS original doesn't face

node-datachannel is async; the C++ library's calls block. Each was found by runtime evidence (trace/sampling/ASan), not guesswork:

1. **rtc `close()` self-deadlock.** `rtc::PeerConnection::close()`/`resetCallbacks()` block until the current callback returns. Called inline from `onStateChange` (rtc's own ThreadPool thread) that is *itself* why we're closing, that is a self-join hang (deterministic once a peerless connection transitioned to Failed). The rtc teardown is posted to the shared worker pool, owning the rtc `shared_ptr`s.
2. **Live signalling connectionId.** The answerer adopts the *offerer's* connection id in `rtcOffer` **after** `connect()`; a value captured at connect time made the answer carry the wrong id → "connectionId mismatch" → the handshake never completed. The signalling callbacks now read `getConnectionID()` live at emit time.
3. **Early ICE candidates.** Over the simulator the offerer's separate `rtcOffer` and `iceCandidate` notifications reach the answerer out of order, so a candidate legitimately arrives before the offer. TS closes here — its documented flaky test **NET-911**, with a TODO right at that line saying "should queue". Queuing (flushed in `setRemoteDescription`) took the rpc-over-webrtc case from 4/10 to 14/15.
4. **ABBA deadlock in `doClose`.** It emitted `Disconnected` while holding `mMutex`, racing rtc's `onStateChange` which wants `mMutex`; the emit/`removeAllListeners` now run outside the lock (the phase-A0 "no call-outs under a connection mutex" policy).

Also: `FakeTransport` held its `localPeerDescriptor` by reference and dangled when a caller passed a temporary (BUS error in `send()`); it's now by value.

## Tests

All five ported: `unit/WebrtcConnection`, `unit/WebrtcConnector`, `integration/WebrtcConnectorRpc`, `integration/WebrtcConnectionManagement` (real ICE + DTLS data channels over loopback, signalled through the Simulator), `integration/rpc-connections-over-webrtc`. The connector unit test triggers its disconnect through `close(false)` rather than a bare re-entrant `emit` — C++'s `EventEmitter` mutex is non-recursive, so a handler that re-emits on the same emitter self-deadlocks (a JS-only assumption; `close()`'s `stopped` guard breaks the cascade, which is why the real disconnect paths and all integration tests are fine).

- Unit **181/181**, integration **43/43** (as a single binary), lint green.
- The five B2 test files join the documented clangd std-type-unification exclusion list (the compiler builds and runs them on every platform).
- The rpc-over-webrtc happy path retains ~7% ICE-over-loopback nondeterminism (the NET-911 class) that `ctest --repeat until-pass:2` absorbs.

## Notes

- Depends on the shared-executor pools (PR #75, merged) and B1 (PR #74, merged) — based on current `main`.
- GeoIP-related options remain deferred to milestone E, consistent with B1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)