### PR TITLE
Phase B3 (part 2): C++<->TS interop — a C++ node joins a TS-driven DHT

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,6 +59,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: install
         uses: ./.github/workflows/reusable/cached-install
+      # The C++<->TS interop test (streamr-dht-test-ts-interop) runs the
+      # pinned @streamr/dht npm package in a child node process and needs a
+      # node runtime >= 20 on PATH.
+      - name: setup node for TS interop tests
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - name: check proto sync with pinned TS reference
         run:
           ./check-proto-sync.sh

--- a/packages/streamr-dht/CMakeLists.txt
+++ b/packages/streamr-dht/CMakeLists.txt
@@ -310,10 +310,35 @@ if(NOT IOS AND STREAMR_MODULES_SUPPORTED)
         PUBLIC GTest::gtest
         PUBLIC streamr-dht-test-main
     )
+    # C++<->TS interop: the C++ node joins a DHT whose entry point is the
+    # pinned TypeScript implementation from npm, run in a child node
+    # process (test/ts-interop/entryPoint.js). Skips when no node runtime
+    # >= 20 is available.
+    add_executable(streamr-dht-test-ts-interop
+        test/ts-interop/TsInteropTest.cpp
+    )
+    target_compile_definitions(streamr-dht-test-ts-interop
+        PRIVATE TS_INTEROP_HARNESS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/test/ts-interop"
+    )
+    target_include_directories(streamr-dht-test-ts-interop
+        PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test/utils>
+    )
+    streamr_enable_imports(streamr-dht-test-ts-interop)
+    target_link_libraries(streamr-dht-test-ts-interop
+        PUBLIC streamr-dht
+        PUBLIC streamr-dht-test-utils
+        PUBLIC streamr::streamr-logger
+        PUBLIC streamr::streamr-eventemitter
+        PUBLIC streamr::streamr-utils
+        PUBLIC streamr::streamr-proto-rpc
+        PUBLIC GTest::gtest
+        PUBLIC streamr-dht-test-main
+    )
     if (NOT (${VCPKG_TARGET_TRIPLET} MATCHES "android"))
         include(GoogleTest)
         gtest_discover_tests(streamr-dht-test-unit)
         gtest_discover_tests(streamr-dht-test-integration)
         gtest_discover_tests(streamr-dht-test-end-to-end)
+        gtest_discover_tests(streamr-dht-test-ts-interop)
     endif()
 endif()

--- a/packages/streamr-dht/lint.sh
+++ b/packages/streamr-dht/lint.sh
@@ -2,7 +2,10 @@
 
 set -e
 
-FILES=$(find . -type d \( -name src -o -name test -o -name include \) ! -path '*/build/*' ! -path '*/proto/*' -print0 | xargs -0 -I{} find {} -type f \( -name "*.hpp" -o -name "*.cpp" \) -print0 | xargs -0 echo)
+# node_modules is excluded because the TS interop harness (test/ts-interop)
+# npm-installs packages that vendor third-party C++ sources
+# (node-datachannel's napi wrappers etc.) — not our code.
+FILES=$(find . -type d \( -name src -o -name test -o -name include \) ! -path '*/build/*' ! -path '*/proto/*' -print0 | xargs -0 -I{} find {} -type f \( -name "*.hpp" -o -name "*.cpp" \) ! -path '*/node_modules/*' -print0 | xargs -0 echo)
 # Compile database: the standalone build dir when present, else the root
 # tree's (the Linux CI legs skip the standalone builds — MODERNIZATION.md
 # "After the consolidation: CI speed" — and lint against the root tree,
@@ -98,8 +101,13 @@ echo "Running clangd-tidy on $FILES"
 # exclusion in phase B3: DhtNode's BMI grew with the ConnectionManager-path
 # imports and the TU now trips the branded-ServiceID false positive
 # documented for MultipleEntryPointJoiningTest above.)
+# TsInteropTest.cpp (phase B3, C++<->TS interop) imports the DhtNode
+# aggregate like the end-to-end tests and trips the same std-type
+# unification false positive (std::string-vs-std::string mismatches on its
+# own std::string locals); the compiler builds and runs it, clang-format
+# still checks it.
 HEAVY_TIDY_FILES='./test/integration/Layer1ScaleTest.cpp ./test/integration/DhtNodeExternalApiTest.cpp ./test/integration/KademliaCorrectnessTest.cpp'
-TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/integration/ConnectionLockingTest.cpp' | grep -v 'test/unit/PendingConnectionTest.cpp' | grep -v 'test/unit/SimulatorTest.cpp' | grep -v 'test/integration/SimultaneousConnectionsTest.cpp' | grep -v 'test/integration/ConnectionManagerIntegrationTest.cpp' | grep -v 'test/unit/DhtNodeRpcLocalTest.cpp' | grep -v 'test/integration/DhtNodeRpcRemoteTest.cpp' | grep -v 'test/unit/RoutingSessionTest.cpp' | grep -v 'test/unit/RecursiveOperationSessionTest.cpp' | grep -v 'test/unit/StoreRpcLocalTest.cpp' | grep -v 'test/unit/StoreManagerTest.cpp' | grep -v 'test/integration/MultipleEntryPointJoiningTest.cpp' | grep -v 'test/utils/DhtNodeTestUtils.hpp' | grep -v 'test/integration/DhtNodeTest.cpp' | grep -v 'test/integration/MockLayer1Layer0Test.cpp' | grep -v 'test/integration/Layer1ScaleTest.cpp' | grep -v 'test/integration/DhtNodeExternalApiTest.cpp' | grep -v 'test/integration/KademliaCorrectnessTest.cpp' | grep -v 'test/unit/CreatePeerDescriptorTest.cpp' | grep -v 'test/unit/ConnectivityRequestHandlerTest.cpp' | grep -v 'test/integration/WebsocketConnectionManagementTest.cpp' | grep -v 'test/unit/WebrtcConnectionTest.cpp' | grep -v 'test/unit/WebrtcConnectorTest.cpp' | grep -v 'test/integration/RpcConnectionsOverWebrtcTest.cpp' | grep -v 'test/integration/WebrtcConnectorRpcTest.cpp' | grep -v 'test/integration/WebrtcConnectionManagementTest.cpp' | grep -v 'test/end-to-end/Layer0Test.cpp' | grep -v 'test/end-to-end/Layer0WebrtcTest.cpp' | grep -v 'test/end-to-end/Layer0MixedConnectionTypesTest.cpp' | grep -v 'test/end-to-end/Layer0Layer1Test.cpp' | grep -v 'test/end-to-end/Layer0WebrtcLayer1Test.cpp' | tr '\n' ' ')
+TIDY_FILES=$(echo "$FILES" | tr ' ' '\n' | grep -v 'test/integration/ConnectionLockingTest.cpp' | grep -v 'test/unit/PendingConnectionTest.cpp' | grep -v 'test/unit/SimulatorTest.cpp' | grep -v 'test/integration/SimultaneousConnectionsTest.cpp' | grep -v 'test/integration/ConnectionManagerIntegrationTest.cpp' | grep -v 'test/unit/DhtNodeRpcLocalTest.cpp' | grep -v 'test/integration/DhtNodeRpcRemoteTest.cpp' | grep -v 'test/unit/RoutingSessionTest.cpp' | grep -v 'test/unit/RecursiveOperationSessionTest.cpp' | grep -v 'test/unit/StoreRpcLocalTest.cpp' | grep -v 'test/unit/StoreManagerTest.cpp' | grep -v 'test/integration/MultipleEntryPointJoiningTest.cpp' | grep -v 'test/utils/DhtNodeTestUtils.hpp' | grep -v 'test/integration/DhtNodeTest.cpp' | grep -v 'test/integration/MockLayer1Layer0Test.cpp' | grep -v 'test/integration/Layer1ScaleTest.cpp' | grep -v 'test/integration/DhtNodeExternalApiTest.cpp' | grep -v 'test/integration/KademliaCorrectnessTest.cpp' | grep -v 'test/unit/CreatePeerDescriptorTest.cpp' | grep -v 'test/unit/ConnectivityRequestHandlerTest.cpp' | grep -v 'test/integration/WebsocketConnectionManagementTest.cpp' | grep -v 'test/unit/WebrtcConnectionTest.cpp' | grep -v 'test/unit/WebrtcConnectorTest.cpp' | grep -v 'test/integration/RpcConnectionsOverWebrtcTest.cpp' | grep -v 'test/integration/WebrtcConnectorRpcTest.cpp' | grep -v 'test/integration/WebrtcConnectionManagementTest.cpp' | grep -v 'test/end-to-end/Layer0Test.cpp' | grep -v 'test/end-to-end/Layer0WebrtcTest.cpp' | grep -v 'test/end-to-end/Layer0MixedConnectionTypesTest.cpp' | grep -v 'test/end-to-end/Layer0Layer1Test.cpp' | grep -v 'test/end-to-end/Layer0WebrtcLayer1Test.cpp' | grep -v 'test/ts-interop/TsInteropTest.cpp' | tr '\n' ' ')
 # Chunked: one clangd process accumulates source-location space across the
 # files it serves and never releases it; with the phase-A8 module graph a
 # single process no longer survives the whole list (mid-batch the affected

--- a/packages/streamr-dht/test/ts-interop/.gitignore
+++ b/packages/streamr-dht/test/ts-interop/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+npm-install.log
+driver-stderr.log

--- a/packages/streamr-dht/test/ts-interop/TsInteropTest.cpp
+++ b/packages/streamr-dht/test/ts-interop/TsInteropTest.cpp
@@ -1,0 +1,334 @@
+// C++<->TS interop test (milestone B exit criterion): a C++ DhtNode joins a
+// real layer-0 DHT whose entry point is the pinned TypeScript implementation
+// (@streamr/dht 103.8.0-rc.3 from npm) over real websockets on 127.0.0.1.
+// The TS side runs in a child node process driven by entryPoint.js in this
+// directory, which prints the entry point's PeerDescriptor (protobuf binary
+// as hex) once ready and then its DHT neighbor set every 500 ms; mutual
+// visibility is asserted from both sides.
+//
+// The pinned package's dependencies require a node runtime >= 20. Discovery
+// order: $STREAMR_TS_INTEROP_NODE, `node` on PATH, newest ~/.nvm version.
+// Only a missing runtime SKIPs the test; every other failure (npm ci, driver
+// crash, join failure) is a hard failure.
+#include <fcntl.h>
+#include <poll.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <array>
+#include <chrono>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <gtest/gtest.h>
+#include "packages/dht/protos/DhtRpc.pb.h"
+
+#include <coroutine> // IWYU pragma: keep
+
+import streamr.dht.DhtNode;
+import streamr.dht.Identifiers;
+import streamr.dht.protos;
+import streamr.utils.BinaryUtils;
+import streamr.utils.CoroutineHelper;
+
+using ::dht::PeerDescriptor;
+using streamr::dht::DhtNode;
+using streamr::dht::DhtNodeOptions;
+using streamr::dht::Identifiers;
+using streamr::utils::BinaryUtils;
+using streamr::utils::blockingWait;
+
+namespace {
+
+constexpr uint16_t tsEntryPointPort = 17771;
+constexpr int minNodeMajorVersion = 20;
+constexpr std::chrono::seconds driverStartTimeout{60};
+constexpr std::chrono::seconds mutualVisibilityTimeout{30};
+
+std::optional<std::string> runAndCaptureFirstLine(const std::string& command) {
+    FILE* pipe = popen(command.c_str(), "r"); // NOLINT
+    if (pipe == nullptr) {
+        return std::nullopt;
+    }
+    std::array<char, 256> buffer{};
+    std::string output;
+    if (fgets(buffer.data(), buffer.size(), pipe) != nullptr) {
+        output = buffer.data();
+    }
+    const int status = pclose(pipe);
+    if (status != 0 || output.empty()) {
+        return std::nullopt;
+    }
+    while (!output.empty() &&
+           (output.back() == '\n' || output.back() == '\r')) {
+        output.pop_back();
+    }
+    return output;
+}
+
+// Parses the major version out of `<node> --version` output ("v22.17.1").
+std::optional<int> nodeMajorVersion(const std::string& nodeBinary) {
+    const auto version =
+        runAndCaptureFirstLine("'" + nodeBinary + "' --version 2>/dev/null");
+    if (!version || version->size() < 2 || (*version)[0] != 'v') {
+        return std::nullopt;
+    }
+    return std::atoi(version->c_str() + 1); // NOLINT
+}
+
+std::optional<std::string> findNodeBinary() {
+    if (const char* fromEnv = std::getenv("STREAMR_TS_INTEROP_NODE")) {
+        return std::string{fromEnv};
+    }
+    if (const auto onPath = runAndCaptureFirstLine("command -v node")) {
+        const auto major = nodeMajorVersion(*onPath);
+        if (major && *major >= minNodeMajorVersion) {
+            return onPath;
+        }
+    }
+    // Local-development convenience: PATH may point at an old node while nvm
+    // has suitable ones installed.
+    std::optional<std::string> best;
+    int bestMajor = 0;
+    if (const char* home = std::getenv("HOME")) {
+        const auto nvmDir =
+            std::filesystem::path(home) / ".nvm" / "versions" / "node";
+        std::error_code ec;
+        for (const auto& entry :
+             std::filesystem::directory_iterator(nvmDir, ec)) {
+            const auto candidate = entry.path() / "bin" / "node";
+            if (!std::filesystem::exists(candidate)) {
+                continue;
+            }
+            const auto major = nodeMajorVersion(candidate.string());
+            if (major && *major >= minNodeMajorVersion && *major > bestMajor) {
+                bestMajor = *major;
+                best = candidate.string();
+            }
+        }
+    }
+    return best;
+}
+
+} // namespace
+
+class TsInteropTest : public ::testing::Test {
+protected:
+    PeerDescriptor tsPeerDescriptor;
+    std::shared_ptr<DhtNode> cppNode;
+    pid_t driverPid = -1;
+    int driverStdout = -1;
+    std::string lineBuffer;
+
+    void SetUp() override {
+        const auto nodeBinary = findNodeBinary();
+        if (!nodeBinary) {
+            GTEST_SKIP() << "No node runtime >= " << minNodeMajorVersion
+                         << " found (set STREAMR_TS_INTEROP_NODE to one)";
+        }
+        installHarnessDependencies(*nodeBinary);
+        if (::testing::Test::HasFatalFailure()) {
+            return;
+        }
+        spawnDriver(*nodeBinary);
+        ASSERT_NE(this->driverPid, -1);
+        const auto descriptorHex =
+            readLineWithPrefix("DESCRIPTOR ", driverStartTimeout);
+        ASSERT_TRUE(descriptorHex.has_value())
+            << "TS driver did not print its descriptor; see "
+            << harnessDir() / "driver-stderr.log";
+        ASSERT_TRUE(this->tsPeerDescriptor.ParseFromString(
+            BinaryUtils::hexToBinaryString(*descriptorHex)));
+    }
+
+    void TearDown() override {
+        if (this->cppNode) {
+            this->cppNode->stop();
+        }
+        stopDriver();
+    }
+
+    static std::filesystem::path harnessDir() {
+        return std::filesystem::path{TS_INTEROP_HARNESS_DIR};
+    }
+
+    // npm ci into the harness directory when node_modules is absent. npm
+    // lives next to the chosen node binary, which is not necessarily the
+    // PATH one.
+    static void installHarnessDependencies(const std::string& nodeBinary) {
+        if (std::filesystem::exists(harnessDir() / "node_modules")) {
+            return;
+        }
+        const auto nodeBinDir =
+            std::filesystem::path(nodeBinary).parent_path().string();
+        std::string command = "cd '" + harnessDir().string() + "' && ";
+        if (!nodeBinDir.empty()) {
+            command += "PATH='" + nodeBinDir + "':\"$PATH\" ";
+        }
+        command += "npm ci --no-audit --no-fund > npm-install.log 2>&1";
+        ASSERT_EQ(std::system(command.c_str()), 0) // NOLINT
+            << "npm ci failed; see " << harnessDir() / "npm-install.log";
+    }
+
+    void spawnDriver(const std::string& nodeBinary) {
+        std::array<int, 2> stdoutPipe{};
+        ASSERT_EQ(pipe(stdoutPipe.data()), 0);
+        const pid_t pid = fork();
+        ASSERT_NE(pid, -1);
+        if (pid == 0) {
+            dup2(stdoutPipe[1], STDOUT_FILENO);
+            close(stdoutPipe[0]);
+            close(stdoutPipe[1]);
+            const auto stderrPath =
+                (harnessDir() / "driver-stderr.log").string();
+            const int stderrFd = open(
+                stderrPath.c_str(),
+                O_WRONLY | O_CREAT | O_TRUNC,
+                0644); // NOLINT
+            if (stderrFd != -1) {
+                dup2(stderrFd, STDERR_FILENO);
+                close(stderrFd);
+            }
+            if (chdir(harnessDir().c_str()) != 0) {
+                _exit(126);
+            }
+            const auto port = std::to_string(tsEntryPointPort);
+            execl( // NOLINT
+                nodeBinary.c_str(),
+                nodeBinary.c_str(),
+                "entryPoint.js",
+                port.c_str(),
+                static_cast<char*>(nullptr));
+            _exit(127);
+        }
+        close(stdoutPipe[1]);
+        this->driverPid = pid;
+        this->driverStdout = stdoutPipe[0];
+        fcntl(this->driverStdout, F_SETFL, O_NONBLOCK); // NOLINT
+    }
+
+    void stopDriver() {
+        if (this->driverPid != -1) {
+            kill(this->driverPid, SIGTERM);
+            const auto deadline = std::chrono::steady_clock::now() +
+                std::chrono::seconds(10); // NOLINT
+            int status = 0;
+            while (waitpid(this->driverPid, &status, WNOHANG) == 0) {
+                if (std::chrono::steady_clock::now() > deadline) {
+                    kill(this->driverPid, SIGKILL);
+                    waitpid(this->driverPid, &status, 0);
+                    break;
+                }
+                usleep(50000); // NOLINT
+            }
+            this->driverPid = -1;
+        }
+        if (this->driverStdout != -1) {
+            close(this->driverStdout);
+            this->driverStdout = -1;
+        }
+    }
+
+    // Reads driver stdout until a line starting with the given prefix
+    // arrives; returns the rest of that line. Non-matching lines (e.g.
+    // NEIGHBORS heartbeats while waiting for something else) are dropped.
+    std::optional<std::string> readLineWithPrefix(
+        const std::string& prefix, std::chrono::milliseconds timeout) {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (true) {
+            const auto newline = this->lineBuffer.find('\n');
+            if (newline != std::string::npos) {
+                std::string line = this->lineBuffer.substr(0, newline);
+                this->lineBuffer.erase(0, newline + 1);
+                if (!line.empty() && line.back() == '\r') {
+                    line.pop_back();
+                }
+                if (line.starts_with(prefix)) {
+                    return line.substr(prefix.size());
+                }
+                continue;
+            }
+            const auto now = std::chrono::steady_clock::now();
+            if (now >= deadline) {
+                return std::nullopt;
+            }
+            struct pollfd pfd{
+                .fd = this->driverStdout, .events = POLLIN, .revents = 0};
+            const auto remaining =
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    deadline - now)
+                    .count();
+            const int ready = poll(
+                &pfd,
+                1,
+                static_cast<int>(
+                    std::min<long long>(remaining, 200))); // NOLINT
+            if (ready <= 0) {
+                continue;
+            }
+            std::array<char, 4096> chunk{};
+            const ssize_t bytes =
+                read(this->driverStdout, chunk.data(), chunk.size());
+            if (bytes > 0) {
+                this->lineBuffer.append(chunk.data(), bytes);
+            } else if (bytes == 0) {
+                return std::nullopt; // driver exited
+            }
+        }
+    }
+
+    // True once the TS driver reports the given node id in a NEIGHBORS line.
+    bool tsSeesNeighbor(
+        const std::string& nodeId, std::chrono::milliseconds timeout) {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            const auto csv =
+                readLineWithPrefix("NEIGHBORS ", std::chrono::seconds(2));
+            if (!csv) {
+                continue;
+            }
+            size_t start = 0;
+            while (start <= csv->size()) {
+                auto end = csv->find(',', start);
+                if (end == std::string::npos) {
+                    end = csv->size();
+                }
+                if (csv->substr(start, end - start) == nodeId) {
+                    return true;
+                }
+                start = end + 1;
+            }
+        }
+        return false;
+    }
+};
+
+TEST_F(TsInteropTest, CppNodeJoinsTsEntryPointDht) {
+    this->cppNode = std::make_shared<DhtNode>(
+        DhtNodeOptions{.entryPoints = {this->tsPeerDescriptor}});
+    blockingWait(this->cppNode->start());
+    blockingWait(this->cppNode->joinDht({this->tsPeerDescriptor}));
+
+    // C++ -> TS visibility: the TS entry point is in the routing table and
+    // there is a live connection to it.
+    const auto tsNodeId =
+        Identifiers::getNodeIdFromPeerDescriptor(this->tsPeerDescriptor);
+    EXPECT_GE(this->cppNode->getNeighborCount(), 1);
+    const auto contacts = this->cppNode->getClosestContacts(1);
+    ASSERT_EQ(contacts.size(), 1);
+    EXPECT_TRUE(
+        Identifiers::areEqualPeerDescriptors(
+            contacts[0], this->tsPeerDescriptor));
+    EXPECT_TRUE(this->cppNode->getConnectionsView()->hasConnection(tsNodeId));
+
+    // TS -> C++ visibility: the driver reports the C++ node id among its
+    // DHT neighbors.
+    const auto cppNodeId = Identifiers::getNodeIdFromPeerDescriptor(
+        this->cppNode->getLocalPeerDescriptor());
+    EXPECT_TRUE(tsSeesNeighbor(cppNodeId, mutualVisibilityTimeout))
+        << "TS entry point never listed the C++ node " << cppNodeId
+        << " as a neighbor";
+}

--- a/packages/streamr-dht/test/ts-interop/entryPoint.js
+++ b/packages/streamr-dht/test/ts-interop/entryPoint.js
@@ -1,0 +1,46 @@
+// TS side of the C++<->TS DHT interop test (TsInteropTest.cpp).
+//
+// Starts a TypeScript layer-0 DhtNode from the pinned @streamr/dht npm
+// package as a websocket entry point on 127.0.0.1:<port>, joins its own
+// DHT, and then speaks a line protocol on stdout:
+//
+//   DESCRIPTOR <hex>     once ready; hex is the protobuf-binary encoding of
+//                        the node's PeerDescriptor (exact wire fidelity, so
+//                        the C++ side parses it with PeerDescriptor protobuf)
+//   NEIGHBORS <id,...>   every 500 ms; comma-separated hex node ids of the
+//                        node's current DHT neighbors (may be empty)
+//
+// The entry-point construction mirrors packages/dht/test/end-to-end/
+// Layer0.test.ts at the pin. region is passed explicitly because without it
+// start() falls back to a GeoIP/CDN lookup over the real network.
+const { DhtNode, PeerDescriptor, toNodeId } = require('@streamr/dht')
+
+const port = parseInt(process.argv[2], 10)
+if (!(port > 0)) {
+    console.error('usage: node entryPoint.js <websocket-port>')
+    process.exit(1)
+}
+
+const main = async () => {
+    const node = new DhtNode({
+        websocketHost: '127.0.0.1',
+        websocketPortRange: { min: port, max: port },
+        websocketServerEnableTls: false,
+        region: 0
+    })
+    await node.start()
+    await node.joinDht([node.getLocalPeerDescriptor()])
+    const descriptorHex = Buffer.from(
+        PeerDescriptor.toBinary(node.getLocalPeerDescriptor())
+    ).toString('hex')
+    console.log(`DESCRIPTOR ${descriptorHex}`)
+    setInterval(() => {
+        const neighborIds = node.getNeighbors().map((n) => toNodeId(n))
+        console.log(`NEIGHBORS ${neighborIds.join(',')}`)
+    }, 500)
+}
+
+main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/streamr-dht/test/ts-interop/package-lock.json
+++ b/packages/streamr-dht/test/ts-interop/package-lock.json
@@ -1,0 +1,2138 @@
+{
+    "name": "streamr-dht-ts-interop-harness",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "streamr-dht-ts-interop-harness",
+            "dependencies": {
+                "@streamr/dht": "103.8.0-rc.3"
+            }
+        },
+        "node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@js-sdsl/ordered-map": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+            "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/js-sdsl"
+            }
+        },
+        "node_modules/@noble/curves": {
+            "version": "1.9.7",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+            "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "1.8.0"
+            },
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/curves/node_modules/@noble/hashes": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+            "license": "MIT",
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+            "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/post-quantum": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@noble/post-quantum/-/post-quantum-0.4.1.tgz",
+            "integrity": "sha512-TRXjvnY9jAFNWbxOx+pKt21BNsCEWKFjMbIKwdx9CQXBudDanpY20EfOcooV7DIsRS/+Mf8D8utpUPjfGrQ8fA==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "1.8.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/post-quantum/node_modules/@noble/hashes": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+            "license": "MIT",
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@pinojs/redact": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+            "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+            "license": "MIT"
+        },
+        "node_modules/@protobuf-ts/runtime": {
+            "version": "2.11.1",
+            "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.11.1.tgz",
+            "integrity": "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==",
+            "license": "(Apache-2.0 AND BSD-3-Clause)"
+        },
+        "node_modules/@protobuf-ts/runtime-rpc": {
+            "version": "2.11.1",
+            "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.11.1.tgz",
+            "integrity": "sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@protobuf-ts/runtime": "^2.11.1"
+            }
+        },
+        "node_modules/@streamr/autocertifier-client": {
+            "version": "103.8.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@streamr/autocertifier-client/-/autocertifier-client-103.8.0-rc.3.tgz",
+            "integrity": "sha512-AzVViVJ3tfgF/45hj6p/1kbS+pRniZaAvooJQNZoYT2Cpmg0AS2Ak/IN+aDu8vouW2z89voLv8I59k4wpqFLuQ==",
+            "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
+            "dependencies": {
+                "@protobuf-ts/runtime-rpc": "^2.8.2",
+                "@streamr/utils": "103.8.0-rc.3",
+                "eventemitter3": "^5.0.0",
+                "node-forge": "^1.3.2"
+            }
+        },
+        "node_modules/@streamr/cdn-location": {
+            "version": "103.8.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@streamr/cdn-location/-/cdn-location-103.8.0-rc.3.tgz",
+            "integrity": "sha512-j9KDMrDPH+SfDuGd7cScb9nIlq/xlHAV+Cr0ruJEo8BOkQm/ZgIsCN2uFVsLmuxOhF17WrRnp/tSl/YfrlmnOw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@streamr/utils": "103.8.0-rc.3",
+                "haversine": "^1.1.1"
+            }
+        },
+        "node_modules/@streamr/dht": {
+            "version": "103.8.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@streamr/dht/-/dht-103.8.0-rc.3.tgz",
+            "integrity": "sha512-jb91JMV5secjAHSyxs7INNJWf8eQ8WHBUuMNqufKQi6hzZPJCiU9ZFTHbTZFm9IMbYv+qgY+Lrqu0s+5Fa6PHA==",
+            "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
+            "dependencies": {
+                "@js-sdsl/ordered-map": "^4.4.2",
+                "@protobuf-ts/runtime": "^2.8.2",
+                "@protobuf-ts/runtime-rpc": "^2.8.2",
+                "@streamr/autocertifier-client": "103.8.0-rc.3",
+                "@streamr/cdn-location": "103.8.0-rc.3",
+                "@streamr/geoip-location": "103.8.0-rc.3",
+                "@streamr/proto-rpc": "103.8.0-rc.3",
+                "@streamr/utils": "103.8.0-rc.3",
+                "comlink": "^4.4.2",
+                "eventemitter3": "^5.0.0",
+                "heap": "^0.2.6",
+                "ipaddr.js": "^2.0.1",
+                "k-bucket": "^5.1.0",
+                "lodash": "^4.17.21",
+                "lru-cache": "^11.2.2",
+                "node-datachannel": "^0.27.0",
+                "timers-browserify": "^2.0.12",
+                "uuid": "^11.1.0",
+                "websocket": "^1.0.34",
+                "ws": "^8.18.3"
+            },
+            "optionalDependencies": {
+                "bufferutil": "^4.0.9",
+                "utf-8-validate": "^6.0.5"
+            }
+        },
+        "node_modules/@streamr/geoip-location": {
+            "version": "103.8.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@streamr/geoip-location/-/geoip-location-103.8.0-rc.3.tgz",
+            "integrity": "sha512-VA9SVMXfV+2ivnSS4rgyztd6G/NGEzvGNvvPrKbvOr97LhtlP7ApOfLK5aZDqhXgIKy33+v7vF8ms55jgZXlHw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@streamr/utils": "103.8.0-rc.3",
+                "eventemitter3": "^5.0.0",
+                "long-timeout": "^0.1.1",
+                "mmdb-lib": "^3.0.1",
+                "tar": "^7.5.2",
+                "uuid": "^11.1.0"
+            }
+        },
+        "node_modules/@streamr/proto-rpc": {
+            "version": "103.8.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@streamr/proto-rpc/-/proto-rpc-103.8.0-rc.3.tgz",
+            "integrity": "sha512-b+9E2fs/Fsd4rJ6i8U/xs+Ie+XSSFS9zS2DEOt/JnubECrHrrspVi99UKkkwZB4i8vC3w4iCUZvyhkqs7C7nfw==",
+            "license": "(Apache-2.0 AND BSD-3-Clause)",
+            "dependencies": {
+                "@protobuf-ts/runtime": "^2.8.2",
+                "@protobuf-ts/runtime-rpc": "^2.8.2",
+                "@streamr/utils": "103.8.0-rc.3",
+                "eventemitter3": "^5.0.0",
+                "lodash": "^4.17.21",
+                "uuid": "^11.1.0"
+            },
+            "optionalDependencies": {
+                "bufferutil": "^4.0.9",
+                "utf-8-validate": "^6.0.5"
+            }
+        },
+        "node_modules/@streamr/utils": {
+            "version": "103.8.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@streamr/utils/-/utils-103.8.0-rc.3.tgz",
+            "integrity": "sha512-4hDwDjzbxXjrXJ8YP70H0PYN6Y3/+zpYS+H0vJa021ZnZVAVE3P9uf1dpEskI9D3BWU8G0psPFAvGeRmZQfaaQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@noble/curves": "^1.9.7",
+                "@noble/hashes": "^2.0.1",
+                "@noble/post-quantum": "^0.4.1",
+                "asn1.js": "^5.4.1",
+                "browserify-aes": "^1.2.0",
+                "buffer": "^6.0.3",
+                "buffer-shim": "^1.0.1",
+                "eventemitter3": "^5.0.0",
+                "hash-base": "^3.1.2",
+                "lodash": "^4.17.21",
+                "path-browserify": "^1.0.1",
+                "pino": "^10.1.0",
+                "pino-pretty": "^13.1.2",
+                "public-encrypt": "^4.0.3",
+                "readable-stream": "^4.7.0",
+                "secp256k1": "^5.0.1",
+                "sha3": "^2.1.4"
+            }
+        },
+        "node_modules/abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "license": "MIT",
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
+            }
+        },
+        "node_modules/asn1.js": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "node_modules/atomic-sleep": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+            "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "possible-typed-array-names": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/bl/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/bl/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/bn.js": {
+            "version": "4.12.5",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+            "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+            "license": "MIT"
+        },
+        "node_modules/brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+            "license": "MIT"
+        },
+        "node_modules/browserify-aes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/browserify-rsa": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+            "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^5.2.1",
+                "randombytes": "^2.1.0",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/browserify-rsa/node_modules/bn.js": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+            "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
+            "license": "MIT"
+        },
+        "node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/buffer-shim": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-shim/-/buffer-shim-1.0.1.tgz",
+            "integrity": "sha512-VG1oTE6Ecr9h/Gx3XOXue0F1vQaQlkBd3tGAzpL7Fsu+8f1Jbtk5ORPkrVLA/ADBTQ08bcPt3HanaZ7tUfJqMg==",
+            "license": "ISC",
+            "peerDependencies": {
+                "buffer": "^6.0.3"
+            }
+        },
+        "node_modules/buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+            "license": "MIT"
+        },
+        "node_modules/bufferutil": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+            "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "node-gyp-build": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=6.14.2"
+            }
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/chownr": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/cipher-base": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+            "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/colorette": {
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+            "license": "MIT"
+        },
+        "node_modules/comlink": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+            "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "license": "MIT"
+        },
+        "node_modules/create-hash": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+            "license": "MIT",
+            "dependencies": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
+            }
+        },
+        "node_modules/create-hmac": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+            "license": "MIT",
+            "dependencies": {
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+            }
+        },
+        "node_modules/d": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+            "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+            "license": "ISC",
+            "dependencies": {
+                "es5-ext": "^0.10.64",
+                "type": "^2.7.2"
+            },
+            "engines": {
+                "node": ">=0.12"
+            }
+        },
+        "node_modules/dateformat": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+            "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/decompress-response": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-response": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/elliptic": {
+            "version": "6.6.1",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+            "license": "MIT",
+            "dependencies": {
+                "once": "^1.4.0"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es5-ext": {
+            "version": "0.10.64",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+            "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+            "hasInstallScript": true,
+            "license": "ISC",
+            "dependencies": {
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.3",
+                "esniff": "^2.0.1",
+                "next-tick": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+            "license": "MIT",
+            "dependencies": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "node_modules/es6-symbol": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+            "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+            "license": "ISC",
+            "dependencies": {
+                "d": "^1.0.2",
+                "ext": "^1.7.0"
+            },
+            "engines": {
+                "node": ">=0.12"
+            }
+        },
+        "node_modules/esniff": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+            "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+            "license": "ISC",
+            "dependencies": {
+                "d": "^1.0.1",
+                "es5-ext": "^0.10.62",
+                "event-emitter": "^0.3.5",
+                "type": "^2.7.2"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+            "license": "MIT",
+            "dependencies": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
+            }
+        },
+        "node_modules/event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "license": "MIT"
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.x"
+            }
+        },
+        "node_modules/evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "license": "MIT",
+            "dependencies": {
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
+            }
+        },
+        "node_modules/expand-template": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+            "license": "(MIT OR WTFPL)",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/ext": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+            "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+            "license": "ISC",
+            "dependencies": {
+                "type": "^2.7.2"
+            }
+        },
+        "node_modules/fast-copy": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.4.tgz",
+            "integrity": "sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA==",
+            "license": "MIT"
+        },
+        "node_modules/fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "license": "MIT"
+        },
+        "node_modules/for-each": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "license": "MIT"
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/github-from-package": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+            "license": "MIT"
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hash-base": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+            "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "readable-stream": "^2.3.8",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/hash-base/node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "license": "MIT"
+        },
+        "node_modules/hash-base/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/hash-base/node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "license": "MIT"
+        },
+        "node_modules/hash-base/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/hash-base/node_modules/string_decoder/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "license": "MIT"
+        },
+        "node_modules/hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/haversine": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/haversine/-/haversine-1.1.1.tgz",
+            "integrity": "sha512-KW4MS8+krLIeiw8bF5z532CptG0ZyGGFj0UbKMxx25lKnnJ1hMUbuzQl+PXQjNiDLnl1bOyz23U6hSK10r4guw==",
+            "license": "MIT"
+        },
+        "node_modules/heap": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
+            "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
+            "license": "MIT"
+        },
+        "node_modules/help-me": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+            "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+            "license": "MIT"
+        },
+        "node_modules/hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+            "license": "MIT",
+            "dependencies": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
+        },
+        "node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "license": "ISC"
+        },
+        "node_modules/ipaddr.js": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+            "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-typed-array": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "license": "MIT",
+            "dependencies": {
+                "which-typed-array": "^1.1.16"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+            "license": "MIT"
+        },
+        "node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "license": "MIT"
+        },
+        "node_modules/joycon": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+            "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/k-bucket": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.1.0.tgz",
+            "integrity": "sha512-Fac7iINEovXIWU20GPnOMLUbjctiS+cnmyjC4zAUgvs3XPf1vo9akfCHkigftSic/jiKqKl+KA3a/vFcJbHyCg==",
+            "license": "MIT",
+            "dependencies": {
+                "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "license": "MIT"
+        },
+        "node_modules/long-timeout": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+            "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
+            "license": "MIT"
+        },
+        "node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/md5.js": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+            "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+            "license": "MIT",
+            "dependencies": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "node_modules/mimic-response": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "license": "ISC"
+        },
+        "node_modules/minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+            "license": "MIT"
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/minizlib": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "license": "MIT"
+        },
+        "node_modules/mmdb-lib": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mmdb-lib/-/mmdb-lib-3.0.2.tgz",
+            "integrity": "sha512-7e87vk0DdWT647wjcfEtWeMtjm+zVGqNohN/aeIymbUfjHQ2T4Sx5kM+1irVDBSloNC3CkGKxswdMoo8yhqTDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10",
+                "npm": ">=6"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "license": "MIT"
+        },
+        "node_modules/napi-build-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+            "license": "MIT"
+        },
+        "node_modules/next-tick": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+            "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+            "license": "ISC"
+        },
+        "node_modules/node-abi": {
+            "version": "3.94.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+            "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/node-addon-api": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+            "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
+            "license": "MIT"
+        },
+        "node_modules/node-datachannel": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.27.0.tgz",
+            "integrity": "sha512-RuClwcfRYJn0YqosgkAdocEM78jo7F3z9hSZzUiogB7QegD28mFOOjMoX/CAbU4ckHaLAoppfROwZXMro/EmNA==",
+            "hasInstallScript": true,
+            "license": "MPL 2.0",
+            "dependencies": {
+                "prebuild-install": "^7.1.3"
+            },
+            "engines": {
+                "node": ">=18.20.0"
+            }
+        },
+        "node_modules/node-forge": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+            "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+            "license": "(BSD-3-Clause OR GPL-2.0)",
+            "engines": {
+                "node": ">= 6.13.0"
+            }
+        },
+        "node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "node_modules/on-exit-leak-free": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+            "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/parse-asn1": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+            "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
+            "license": "ISC",
+            "dependencies": {
+                "asn1.js": "^4.10.1",
+                "browserify-aes": "^1.2.0",
+                "evp_bytestokey": "^1.0.3",
+                "pbkdf2": "^3.1.5",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/parse-asn1/node_modules/asn1.js": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "node_modules/path-browserify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+            "license": "MIT"
+        },
+        "node_modules/pbkdf2": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz",
+            "integrity": "sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==",
+            "license": "MIT",
+            "dependencies": {
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "ripemd160": "^2.0.3",
+                "safe-buffer": "^5.2.1",
+                "sha.js": "^2.4.12",
+                "to-buffer": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/pino": {
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+            "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+            "license": "MIT",
+            "dependencies": {
+                "@pinojs/redact": "^0.4.0",
+                "atomic-sleep": "^1.0.0",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^3.0.0",
+                "pino-std-serializers": "^7.0.0",
+                "process-warning": "^5.0.0",
+                "quick-format-unescaped": "^4.0.3",
+                "real-require": "^0.2.0",
+                "safe-stable-stringify": "^2.3.1",
+                "sonic-boom": "^4.0.1",
+                "thread-stream": "^4.0.0"
+            },
+            "bin": {
+                "pino": "bin.js"
+            }
+        },
+        "node_modules/pino-abstract-transport": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+            "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+            "license": "MIT",
+            "dependencies": {
+                "split2": "^4.0.0"
+            }
+        },
+        "node_modules/pino-pretty": {
+            "version": "13.1.3",
+            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+            "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+            "license": "MIT",
+            "dependencies": {
+                "colorette": "^2.0.7",
+                "dateformat": "^4.6.3",
+                "fast-copy": "^4.0.0",
+                "fast-safe-stringify": "^2.1.1",
+                "help-me": "^5.0.0",
+                "joycon": "^3.1.1",
+                "minimist": "^1.2.6",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^3.0.0",
+                "pump": "^3.0.0",
+                "secure-json-parse": "^4.0.0",
+                "sonic-boom": "^4.0.1",
+                "strip-json-comments": "^5.0.2"
+            },
+            "bin": {
+                "pino-pretty": "bin.js"
+            }
+        },
+        "node_modules/pino-std-serializers": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+            "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+            "license": "MIT"
+        },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/prebuild-install": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+            "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+            "license": "MIT",
+            "dependencies": {
+                "detect-libc": "^2.0.0",
+                "expand-template": "^2.0.3",
+                "github-from-package": "0.0.0",
+                "minimist": "^1.2.3",
+                "mkdirp-classic": "^0.5.3",
+                "napi-build-utils": "^2.0.0",
+                "node-abi": "^3.3.0",
+                "pump": "^3.0.0",
+                "rc": "^1.2.7",
+                "simple-get": "^4.0.0",
+                "tar-fs": "^2.0.0",
+                "tunnel-agent": "^0.6.0"
+            },
+            "bin": {
+                "prebuild-install": "bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "license": "MIT"
+        },
+        "node_modules/process-warning": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+            "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/public-encrypt": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+            "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "node_modules/pump": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+            "license": "MIT",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "node_modules/quick-format-unescaped": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+            "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+            "license": "MIT"
+        },
+        "node_modules/randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "node_modules/rc/node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/readable-stream": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+            "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+            "license": "MIT",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/real-require": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+            "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12.13.0"
+            }
+        },
+        "node_modules/ripemd160": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+            "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+            "license": "MIT",
+            "dependencies": {
+                "hash-base": "^3.1.2",
+                "inherits": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/safe-stable-stringify": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+            "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "license": "MIT"
+        },
+        "node_modules/secp256k1": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-5.0.1.tgz",
+            "integrity": "sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "elliptic": "^6.5.7",
+                "node-addon-api": "^5.0.0",
+                "node-gyp-build": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/secure-json-parse": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+            "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "license": "MIT"
+        },
+        "node_modules/sha.js": {
+            "version": "2.4.12",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+            "license": "(MIT AND BSD-3-Clause)",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.0"
+            },
+            "bin": {
+                "sha.js": "bin.js"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/sha3": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
+            "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer": "6.0.3"
+            }
+        },
+        "node_modules/simple-concat": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/simple-get": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decompress-response": "^6.0.0",
+                "once": "^1.3.1",
+                "simple-concat": "^1.0.0"
+            }
+        },
+        "node_modules/sonic-boom": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+            "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+            "license": "MIT",
+            "dependencies": {
+                "atomic-sleep": "^1.0.0"
+            }
+        },
+        "node_modules/split2": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">= 10.x"
+            }
+        },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+            "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/tar": {
+            "version": "7.5.19",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+            "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tar-fs": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+            "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+            "license": "MIT",
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "node_modules/tar-fs/node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "license": "ISC"
+        },
+        "node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "license": "MIT",
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tar-stream/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/thread-stream": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+            "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+            "license": "MIT",
+            "dependencies": {
+                "real-require": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/thread-stream/node_modules/real-require": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+            "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+            "license": "MIT"
+        },
+        "node_modules/timers-browserify": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+            "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "setimmediate": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
+        },
+        "node_modules/to-buffer": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+            "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+            "license": "MIT",
+            "dependencies": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/type": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+            "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+            "license": "ISC"
+        },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/typedarray-to-buffer": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "license": "MIT",
+            "dependencies": {
+                "is-typedarray": "^1.0.0"
+            }
+        },
+        "node_modules/utf-8-validate": {
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+            "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "node-gyp-build": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=6.14.2"
+            }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "license": "MIT"
+        },
+        "node_modules/uuid": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
+            }
+        },
+        "node_modules/websocket": {
+            "version": "1.0.35",
+            "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.35.tgz",
+            "integrity": "sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bufferutil": "^4.0.1",
+                "debug": "^2.2.0",
+                "es5-ext": "^0.10.63",
+                "typedarray-to-buffer": "^3.1.5",
+                "utf-8-validate": "^5.0.2",
+                "yaeti": "^0.0.6"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/websocket/node_modules/utf-8-validate": {
+            "version": "5.0.10",
+            "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+            "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "node-gyp-build": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=6.14.2"
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.22",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+            "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
+        },
+        "node_modules/ws": {
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/yaeti": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+            "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.32"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        }
+    }
+}

--- a/packages/streamr-dht/test/ts-interop/package.json
+++ b/packages/streamr-dht/test/ts-interop/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "streamr-dht-ts-interop-harness",
+    "private": true,
+    "description": "TS side of the C++<->TS DHT interop test: the pinned @streamr/dht from npm, driven by entryPoint.js",
+    "dependencies": {
+        "@streamr/dht": "103.8.0-rc.3"
+    }
+}


### PR DESCRIPTION
## Summary

Completes the **milestone B exit criterion against the real TypeScript implementation**: a C++ `DhtNode` joins a layer-0 DHT whose entry point is **`@streamr/dht@103.8.0-rc.3`** (exactly the TS pin) installed from npm and run in a child `node` process, over real websockets on `127.0.0.1`. Mutual visibility is asserted from both sides.

## How the harness works

- **`test/ts-interop/entryPoint.js`** — node driver that starts a TS `DhtNode` entry point (constructed exactly like the TS `Layer0.test.ts` entry point at the pin), joins its own DHT, then speaks a line protocol on stdout: `DESCRIPTOR <hex>` (the protobuf-binary `PeerDescriptor` — exact wire fidelity, no field mapping) followed by `NEIGHBORS <id,...>` every 500 ms. `region` is passed explicitly because TS `start()` otherwise does a GeoIP/CDN lookup over the real network.
- **`test/ts-interop/package.json` + lockfile** — per the granular-packages direction: the harness depends only on the published npm package at the pin; the TS monorepo checkout is never built. `npm ci` runs on demand from the test itself when `node_modules` is absent.
- **`test/ts-interop/TsInteropTest.cpp`** (new `streamr-dht-test-ts-interop` target) — spawns the driver, reads the descriptor, starts a **serverless** C++ node with the TS node as entry point, and joins. The serverless start also exercises the B1 connectivity request/response protocol against the TS websocket server for real. Asserts:
  - C++ -> TS: the TS entry point is the C++ node's closest contact and has a live connection,
  - TS -> C++: the TS node reports the C++ node id among its DHT neighbors.

  Node runtime discovery: `$STREAMR_TS_INTEROP_NODE`, then PATH `node` if >= 20 (required by the pinned package's dependencies), then the newest `~/.nvm` install. **Only a missing runtime skips the test; every other failure (npm ci, driver crash, join failure) is a hard failure.**
- **CI**: `actions/setup-node` (node 22) added to the validate workflow so all three legs run the interop test.
- **lint**: npm-vendored third-party C++ under `node_modules` excluded from the sweep; `TsInteropTest.cpp` joins the documented std-type-unification exclusion list (the compiler builds and runs it; clang-format still checks it).

## Test results (local, arm64 mac)

| Suite | Result |
|---|---|
| ts-interop | 6/6 consecutive runs, ~1.7 s each |
| unit | 181/181 |
| integration | 43/43 (including `SingleLayer1Dht` this run) |
| end-to-end | 7/7 |
| lint.sh | rc=0 |

With this, milestone B is complete: C++ nodes interoperate over websocket + WebRTC with each other (part 1, #77) and over websocket with the pinned TS implementation (this PR). Known follow-up (pre-existing, documented in #77): the occasional `Layer1ScaleTest.SingleLayer1Dht` neighbor-count flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)