### PR TITLE
EventEmitter: offAndWait()/removeAllListenersAndWait() for the destroy-vs-in-flight-handler race

### DIFF
--- a/packages/streamr-dht/modules/connection/simulator/Simulator.cppm
+++ b/packages/streamr-dht/modules/connection/simulator/Simulator.cppm
@@ -30,6 +30,7 @@ module;
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <functional>
 #include <map>
 #include <memory>
@@ -301,16 +302,30 @@ private:
             this->inFlightOperations++;
             lock.unlock();
             executor->add([this, operation]() {
-                switch (operation.type) {
-                    case OperationType::CONNECT:
-                        this->executeConnectOperation(operation);
-                        break;
-                    case OperationType::CLOSE:
-                        this->executeCloseOperation(operation);
-                        break;
-                    case OperationType::SEND:
-                        this->executeSendOperation(operation);
-                        break;
+                // The decrement below must run even if the call-out
+                // throws: folly's SerialExecutor swallows task exceptions
+                // (SerialExecutor::worker invokeCatchingExns), so a
+                // propagated exception would silently skip the decrement
+                // and park stop()'s drain-wait forever.
+                try {
+                    switch (operation.type) {
+                        case OperationType::CONNECT:
+                            this->executeConnectOperation(operation);
+                            break;
+                        case OperationType::CLOSE:
+                            this->executeCloseOperation(operation);
+                            break;
+                        case OperationType::SEND:
+                            this->executeSendOperation(operation);
+                            break;
+                    }
+                } catch (const std::exception& e) {
+                    SLogger::error(
+                        "Simulator operation threw an exception: " +
+                        std::string(e.what()));
+                } catch (...) {
+                    SLogger::error(
+                        "Simulator operation threw a non-std exception");
                 }
                 // Notify under the lock: once stop()'s drain-wait sees the
                 // count hit zero the Simulator may be destroyed, so this

--- a/packages/streamr-dht/modules/transport/ListeningRpcCommunicator.cppm
+++ b/packages/streamr-dht/modules/transport/ListeningRpcCommunicator.cppm
@@ -78,13 +78,21 @@ public:
     }
 
     void destroy() {
-        transport.off<transportevents::Message>(this->onMessageHandlerToken);
+        // The waiting variant: the owner destroys this communicator right
+        // after destroy() returns, and a Message/Disconnected handler
+        // mid-invocation on another thread would then dereference freed
+        // memory. offAndWait() returns only once no such invocation is
+        // running (unless destroy() itself is called from inside a
+        // handler invocation, where waiting could deadlock and the
+        // historical non-blocking semantics are kept).
+        transport.offAndWait<transportevents::Message>(
+            this->onMessageHandlerToken);
         // Also detach the Disconnected listener: leaving it registered
         // dangles `this` on the transport after destruction, and a live
         // listener could still add client errors while a retired
         // communicator waits to be destroyed (see
         // RecursiveOperationManager::retiredSessionCommunicators).
-        transport.off<transportevents::Disconnected>(
+        transport.offAndWait<transportevents::Disconnected>(
             this->onDisconnectedHandlerToken);
     }
     using RpcCommunicator::registerRpcMethod;

--- a/packages/streamr-eventemitter/modules/EventEmitter.cppm
+++ b/packages/streamr-eventemitter/modules/EventEmitter.cppm
@@ -4,16 +4,49 @@
 // this file is now the source of truth.
 module;
 
+#include <algorithm>
+#include <condition_variable>
 #include <cstddef>
 #include <functional>
 #include <list>
 #include <map>
 #include <mutex>
 #include <optional>
+#include <thread>
 #include <tuple>
 #include <type_traits>
+#include <vector>
 
 export module streamr.eventemitter.EventEmitter;
+
+namespace streamr::eventemitter::detail {
+
+// Number of event-handler invocations currently on THIS thread's call
+// stack, across ALL emitter instances and event types. offAndWait() and
+// removeAllListenersAndWait() block on in-flight invocations only when
+// this is zero: a wait issued from inside a handler can deadlock,
+// because handlers routinely remove each other's listeners from within
+// handler context. The proven cycle (Layer1ScaleTest, 2026-07-13):
+// thread A ran a connection's Data handler (handshake success ->
+// stopHandshaker -> off<Disconnected>) while thread B ran the same
+// connection's Disconnected handler (close tie-break -> off<Data>) —
+// each waited for the other's invocation to end, forever. Depth must be
+// global (not per-emitter): the cycle spans emitter instances.
+// With the depth guard, every blocked waiter runs no handler itself, so
+// wait edges only point from non-handler threads to handler-running
+// threads and no cycle can form among them.
+inline thread_local size_t handlerInvocationDepth = 0;
+
+struct InvocationDepthGuard {
+    InvocationDepthGuard() { ++handlerInvocationDepth; }
+    ~InvocationDepthGuard() { --handlerInvocationDepth; }
+    InvocationDepthGuard(const InvocationDepthGuard&) = delete;
+    InvocationDepthGuard& operator=(const InvocationDepthGuard&) = delete;
+    InvocationDepthGuard(InvocationDepthGuard&&) = delete;
+    InvocationDepthGuard& operator=(InvocationDepthGuard&&) = delete;
+};
+
+} // namespace streamr::eventemitter::detail
 
 export namespace streamr::eventemitter {
 
@@ -135,6 +168,65 @@ private:
     std::map<size_t, typename EmitterEventType::Handler>
         mExecutingEmitLoopHandlers;
 
+    // Invocations currently RUNNING, per handler id (one entry per
+    // invoking thread; replays and the emit loop may overlap). Guarded
+    // by mExecutingEmitLoopHandlersMutex. offAndWait() blocks on
+    // mInvocationFinished until the removed handler has no in-flight
+    // invocation on another thread, so a listener's owner may free the
+    // captured state right after offAndWait() returns — without this, a
+    // handler mid-invocation on the emit thread dereferences freed
+    // memory (seen as ListeningRpcCommunicator crashes when a transport
+    // Message raced the communicator's destroy()).
+    std::map<size_t, std::vector<std::thread::id>> mInFlightInvocations;
+    std::condition_variable mInvocationFinished;
+
+    // Call under mExecutingEmitLoopHandlersMutex.
+    [[nodiscard]] bool hasInFlightInvocationOnOtherThread(
+        size_t handlerId) const {
+        const auto it = mInFlightInvocations.find(handlerId);
+        if (it == mInFlightInvocations.end()) {
+            return false;
+        }
+        return std::ranges::any_of(
+            it->second, [](const std::thread::id& threadId) {
+                return threadId != std::this_thread::get_id();
+            });
+    }
+
+    // Call under mExecutingEmitLoopHandlersMutex.
+    [[nodiscard]] bool hasAnyInFlightInvocationOnOtherThread() const {
+        return std::ranges::any_of(mInFlightInvocations, [](const auto& entry) {
+            return std::ranges::any_of(
+                entry.second, [](const std::thread::id& threadId) {
+                    return threadId != std::this_thread::get_id();
+                });
+        });
+    }
+
+    void beginInvocation(size_t handlerId) {
+        std::lock_guard guard{mExecutingEmitLoopHandlersMutex};
+        mInFlightInvocations[handlerId].push_back(std::this_thread::get_id());
+    }
+
+    void endInvocation(size_t handlerId) {
+        {
+            std::lock_guard guard{mExecutingEmitLoopHandlersMutex};
+            const auto it = mInFlightInvocations.find(handlerId);
+            if (it != mInFlightInvocations.end()) {
+                auto& threads = it->second;
+                const auto threadIt =
+                    std::ranges::find(threads, std::this_thread::get_id());
+                if (threadIt != threads.end()) {
+                    threads.erase(threadIt);
+                }
+                if (threads.empty()) {
+                    mInFlightInvocations.erase(it);
+                }
+            }
+        }
+        mInvocationFinished.notify_all();
+    }
+
     std::optional<StoredEvent<typename EmitterEventType::ArgumentTypes>>
         mLatestEvent;
     std::mutex mLatestEventMutex;
@@ -171,6 +263,12 @@ private:
         auto handler = handlerIterator->second;
 
         mExecutingEmitLoopHandlers.erase(handlerIterator);
+
+        // Marked in-flight atomically with the pop, so off() sees the
+        // handler either in the pending snapshot or in-flight — never
+        // in the gap between the two.
+        mInFlightInvocations[handler.getId()].push_back(
+            std::this_thread::get_id());
 
         return handler;
     }
@@ -244,7 +342,16 @@ public:
                 }
             }
             if (replayArguments.has_value()) {
-                invokeLatestEvent(handler, std::move(replayArguments.value()));
+                this->beginInvocation(handler.getId());
+                try {
+                    detail::InvocationDepthGuard depthGuard;
+                    invokeLatestEvent(
+                        handler, std::move(replayArguments.value()));
+                } catch (...) {
+                    this->endInvocation(handler.getId());
+                    throw;
+                }
+                this->endInvocation(handler.getId());
                 if (once) {
                     return HandlerToken{};
                 }
@@ -284,14 +391,67 @@ public:
 
     template <MatchingEventType<EmitterEventType> EventType>
     void off(HandlerToken handlerReference) {
-        std::lock_guard guard{mEventHandlersMutex};
+        {
+            std::lock_guard guard{mEventHandlersMutex};
+            mEventHandlers.remove_if(
+                [&handlerReference](
+                    const typename EmitterEventType::Handler& handler) {
+                    return handler.getId() == handlerReference.getId();
+                });
+        }
+        // Also remove the pending copy an executing emit loop may still
+        // hold. NOTE: an invocation of this handler that already STARTED
+        // on another thread may still be running when off() returns; an
+        // owner that frees the handler's captures right after off() must
+        // use offAndWait() instead.
+        this->removeHandlerFromExecutingEmitLoops(handlerReference);
+    }
 
-        mEventHandlers.remove_if(
-            [&handlerReference](
-                const typename EmitterEventType::Handler& handler) {
-                return handler.getId() == handlerReference.getId();
+    /**
+     * @brief Remove an event listener and wait until it is no longer
+     * running, so the caller may free the listener's captured state
+     * immediately afterwards.
+     *
+     * @details Waits out an invocation already running on ANOTHER
+     * thread. The wait is skipped when called from inside any event
+     * handler invocation (on any emitter): handlers legitimately remove
+     * each other's listeners from handler context, and blocking there
+     * deadlocks — two threads, each inside a handler the other wants
+     * removed, would wait on each other forever (seen between a
+     * connection's Data and Disconnected handlers in the Layer1 scale
+     * tests). The caller must also not hold any lock that this event's
+     * handlers can take, or the wait deadlocks on that lock (seen
+     * between Endpoint's state mutex and a PendingConnection Connected
+     * handler).
+     *
+     * @tparam EventType The type of the event to remove the listener from.
+     * @param handlerReference The token of the listener to remove.
+     */
+
+    template <MatchingEventType<EmitterEventType> EventType>
+    void offAndWait(HandlerToken handlerReference) {
+        {
+            std::lock_guard guard{mEventHandlersMutex};
+            mEventHandlers.remove_if(
+                [&handlerReference](
+                    const typename EmitterEventType::Handler& handler) {
+                    return handler.getId() == handlerReference.getId();
+                });
+        }
+        // Remove the pending snapshot copy and wait out an invocation
+        // already running on another thread. NB: the wait must not hold
+        // mEventHandlersMutex: the running handler may need it
+        // (once-removal, on()/off() reentry).
+        std::unique_lock lock{mExecutingEmitLoopHandlersMutex};
+        mExecutingEmitLoopHandlers.erase(handlerReference.getId());
+        // Wait only from non-handler context (see the method comment and
+        // detail::handlerInvocationDepth).
+        if (detail::handlerInvocationDepth == 0) {
+            mInvocationFinished.wait(lock, [this, &handlerReference]() {
+                return !this->hasInFlightInvocationOnOtherThread(
+                    handlerReference.getId());
             });
-        removeHandlerFromExecutingEmitLoops(handlerReference);
+        }
     }
 
     /**
@@ -317,6 +477,33 @@ public:
     void removeAllListeners() {
         std::lock_guard guard{mEventHandlersMutex};
         mEventHandlers.clear();
+    }
+
+    /**
+     * @brief Remove all listeners for an event type and wait until none
+     * of them is still running — same guarantee and same caller
+     * constraints as offAndWait(), for every handler at once.
+     *
+     * @tparam EventType The type of the event to remove all listeners for.
+     */
+
+    template <MatchingEventType<EmitterEventType> EventType>
+    void removeAllListenersAndWait() {
+        {
+            std::lock_guard guard{mEventHandlersMutex};
+            mEventHandlers.clear();
+        }
+        // Also cancel invocations an in-progress emit loop has not started
+        // yet — after this method returns, no handler may start.
+        std::unique_lock lock{mExecutingEmitLoopHandlersMutex};
+        mExecutingEmitLoopHandlers.clear();
+        // Wait only from non-handler context — same deadlock-avoidance
+        // rule as offAndWait().
+        if (detail::handlerInvocationDepth == 0) {
+            mInvocationFinished.wait(lock, [this]() {
+                return !this->hasAnyInFlightInvocationOnOtherThread();
+            });
+        }
     }
 
     /**
@@ -362,7 +549,14 @@ public:
             // event, for instance). The per-handler copy is the intended
             // fan-out semantics; Handler::operator() then moves the copy
             // on into the stored std::function.
-            std::invoke(handler, args...);
+            try {
+                detail::InvocationDepthGuard depthGuard;
+                std::invoke(handler, args...);
+            } catch (...) {
+                this->endInvocation(handler.getId());
+                throw;
+            }
+            this->endInvocation(handler.getId());
             if (handler.isOnce()) {
                 std::lock_guard guard{mEventHandlersMutex};
                 mEventHandlers.remove(handler);
@@ -413,8 +607,10 @@ public:
     using EventEmitterImpl<EventTypes>::on...;
     using EventEmitterImpl<EventTypes>::once...;
     using EventEmitterImpl<EventTypes>::off...;
+    using EventEmitterImpl<EventTypes>::offAndWait...;
     using EventEmitterImpl<EventTypes>::listenerCount...;
     using EventEmitterImpl<EventTypes>::removeAllListeners...;
+    using EventEmitterImpl<EventTypes>::removeAllListenersAndWait...;
     using EventEmitterImpl<EventTypes>::emit...;
 
     template <typename EventType>
@@ -434,6 +630,21 @@ public:
         // Use C++ 17 fold expression to remove all listeners for all event
         // types https://www.foonathan.net/2020/05/fold-tricks/
         (EventEmitterImpl<EventTypes>::template removeAllListeners<
+             EventTypes>(),
+         ...);
+    }
+
+    /**
+     * @brief Remove all listeners for all event types and wait until none
+     * of them is still running (see
+     * EventEmitterImpl::removeAllListenersAndWait for the caller
+     * constraints).
+     *
+     */
+
+    template <typename T = std::nullopt_t>
+    void removeAllListenersAndWait() {
+        (EventEmitterImpl<EventTypes>::template removeAllListenersAndWait<
              EventTypes>(),
          ...);
     }
@@ -458,8 +669,10 @@ public:
     using EventEmitterImpl<EventTypes, true>::on...;
     using EventEmitterImpl<EventTypes, true>::once...;
     using EventEmitterImpl<EventTypes, true>::off...;
+    using EventEmitterImpl<EventTypes, true>::offAndWait...;
     using EventEmitterImpl<EventTypes, true>::listenerCount...;
     using EventEmitterImpl<EventTypes, true>::removeAllListeners...;
+    using EventEmitterImpl<EventTypes, true>::removeAllListenersAndWait...;
     using EventEmitterImpl<EventTypes, true>::emit...;
 
     template <typename EventType>
@@ -482,6 +695,21 @@ public:
         // Use C++ 17 fold expression to remove all listeners for all event
         // types https://www.foonathan.net/2020/05/fold-tricks/
         (EventEmitterImpl<EventTypes, true>::template removeAllListeners<
+             EventTypes>(),
+         ...);
+    }
+
+    /**
+     * @brief Remove all listeners for all event types and wait until none
+     * of them is still running (see
+     * EventEmitterImpl::removeAllListenersAndWait for the caller
+     * constraints).
+     *
+     */
+
+    template <typename T = std::nullopt_t>
+    void removeAllListenersAndWait() {
+        (EventEmitterImpl<EventTypes, true>::template removeAllListenersAndWait<
              EventTypes>(),
          ...);
     }

--- a/packages/streamr-eventemitter/test/unit/EventEmitterTest.cpp
+++ b/packages/streamr-eventemitter/test/unit/EventEmitterTest.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <future>
@@ -508,4 +509,133 @@ TEST_F(EventEmitterTest, TestEventMethod) {
 
     eventEmitter.emit<Greeting>("Hello, world!");
     ASSERT_EQ(promise1.get_future().get(), "Hello, world!");
+}
+
+// --- Regression tests for the destroy-vs-in-flight-handler race -------------
+// An owner that removes a listener and then frees the state its handler
+// captured must be able to rely on the handler no longer running:
+// offAndWait()/removeAllListenersAndWait() wait out an invocation in
+// flight on another thread — but only when called from OUTSIDE any
+// handler invocation: handlers legitimately remove each other's listeners
+// from within handler context, and waiting there deadlocks (two threads,
+// each inside a handler the other wants removed, waited on each other
+// forever in the Layer1 scale tests). Plain off()/removeAllListeners()
+// never wait.
+
+constexpr int inFlightHandlerDurationMs = 300;
+constexpr int deadlockWatchdogSeconds = 20;
+
+TEST_F(EventEmitterTest, OffWaitsForInFlightHandlerBeforeOwnerFreesState) {
+    struct TestEvent : Event<> {};
+    using Events = std::tuple<TestEvent>;
+
+    EventEmitter<Events> eventEmitter;
+
+    std::promise<void> handlerEntered;
+    // Stands in for owner state the handler dereferences right up to its
+    // last statement; pre-wait off() semantics let the owner free it while
+    // the handler was still running (use-after-free in real owners).
+    std::atomic<bool> handlerFinished{false};
+
+    auto token = eventEmitter.on<TestEvent>(
+        [&handlerEntered, &handlerFinished]() -> void {
+            handlerEntered.set_value();
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(inFlightHandlerDurationMs));
+            handlerFinished.store(true);
+        });
+
+    std::thread emitterThread(
+        [&eventEmitter]() { eventEmitter.emit<TestEvent>(); });
+
+    handlerEntered.get_future().wait();
+    eventEmitter.offAndWait<TestEvent>(token);
+    // offAndWait() returned from a non-handler thread: the in-flight
+    // invocation must be complete, so freeing the captured state is now
+    // safe.
+    EXPECT_EQ(handlerFinished.load(), true);
+
+    emitterThread.join();
+}
+
+TEST_F(EventEmitterTest, RemoveAllListenersWaitsForInFlightHandler) {
+    struct TestEvent : Event<> {};
+    using Events = std::tuple<TestEvent>;
+
+    EventEmitter<Events> eventEmitter;
+
+    std::promise<void> handlerEntered;
+    std::atomic<bool> handlerFinished{false};
+
+    eventEmitter.on<TestEvent>([&handlerEntered, &handlerFinished]() -> void {
+        handlerEntered.set_value();
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(inFlightHandlerDurationMs));
+        handlerFinished.store(true);
+    });
+
+    std::thread emitterThread(
+        [&eventEmitter]() { eventEmitter.emit<TestEvent>(); });
+
+    handlerEntered.get_future().wait();
+    eventEmitter.removeAllListenersAndWait();
+    EXPECT_EQ(handlerFinished.load(), true);
+
+    emitterThread.join();
+}
+
+TEST_F(EventEmitterTest, HandlersRemovingEachOtherAcrossThreadsDoNotDeadlock) {
+    // The exact shape that deadlocked the Layer1 scale tests: thread A is
+    // inside the Data handler and off()s the Disconnected listener while
+    // thread B is inside the Disconnected handler and off()s the Data
+    // listener. off() from handler context must not block on the foreign
+    // in-flight invocation.
+    struct EventA : Event<> {};
+    struct EventB : Event<> {};
+    using Events = std::tuple<EventA, EventB>;
+
+    EventEmitter<Events> eventEmitter;
+
+    std::atomic<bool> handlerAStarted{false};
+    std::atomic<bool> handlerBStarted{false};
+    HandlerToken tokenA;
+    HandlerToken tokenB;
+
+    tokenA = eventEmitter.on<EventA>(
+        [&eventEmitter, &handlerAStarted, &handlerBStarted, &tokenB]() -> void {
+            handlerAStarted.store(true);
+            while (!handlerBStarted.load()) {
+                std::this_thread::yield();
+            }
+            eventEmitter.offAndWait<EventB>(tokenB);
+        });
+    tokenB = eventEmitter.on<EventB>(
+        [&eventEmitter, &handlerAStarted, &handlerBStarted, &tokenA]() -> void {
+            handlerBStarted.store(true);
+            while (!handlerAStarted.load()) {
+                std::this_thread::yield();
+            }
+            eventEmitter.offAndWait<EventA>(tokenA);
+        });
+
+    auto futureA = std::async(
+        std::launch::async, [&eventEmitter]() { eventEmitter.emit<EventA>(); });
+    auto futureB = std::async(
+        std::launch::async, [&eventEmitter]() { eventEmitter.emit<EventB>(); });
+
+    // Both handlers are guaranteed concurrently in flight (each spins for
+    // the other's start flag), so pre-fix both off() calls waited forever.
+    ASSERT_EQ(
+        futureA.wait_for(std::chrono::seconds(deadlockWatchdogSeconds)),
+        std::future_status::ready)
+        << "deadlock: off() called from inside a handler blocked on a"
+           " foreign in-flight invocation";
+    ASSERT_EQ(
+        futureB.wait_for(std::chrono::seconds(deadlockWatchdogSeconds)),
+        std::future_status::ready)
+        << "deadlock: off() called from inside a handler blocked on a"
+           " foreign in-flight invocation";
+
+    ASSERT_EQ(eventEmitter.listenerCount<EventA>(), 0);
+    ASSERT_EQ(eventEmitter.listenerCount<EventB>(), 0);
 }


### PR DESCRIPTION
## Problem

An owner that removes a listener and immediately frees the state the listener captured (the `ListeningRpcCommunicator::destroy()` pattern behind the phase-C6 SIGSEGVs) can race a handler invocation still running on another thread — a use-after-free. The phase-C6 attempt made `off()` itself wait for in-flight invocations and was reverted before merge: it hung `Layer1ScaleTest.MultipleLayer1Dht` and `ContentDeliveryLayerNodeLayer1Test.HappyPathSixtyFourNodes`.

## Root cause of the hang (runtime-proven with thread samples of the hung tests)

Blocking `off()` deadlocks in two distinct shapes, so it cannot be the default:

1. **Handler↔handler cycle** — one worker ran a connection's Data handler (handshake success → `stopHandshaker()` → `off<Disconnected>`) while another ran the same connection's Disconnected handler (close tie-break → `off<Data>`); each waited forever for the other's invocation to end. One of the two workers was a Simulator association-executor delivery task, so its `inFlightOperations` decrement never ran — that is exactly why the hang surfaced as `Simulator::stop()`'s drain never completing.
2. **Caller-held-lock ABBA** — `ConnectionManager::acceptNewConnection` holds the Endpoint state mutex while `detachFromPendingConnection` removes the Connected listener; the in-flight Connected handler blocks on that same mutex.

## Design

- `off()`/`removeAllListeners()` keep their historical **non-blocking** semantics.
- New `offAndWait()`/`removeAllListenersAndWait()` remove the listener(s), cancel not-yet-started invocations of an executing emit loop, and wait until no invocation runs on another thread.
- The wait is skipped when the caller is itself inside **any** handler invocation, tracked by a `thread_local` invocation depth bumped around every handler call. A blocked waiter therefore never runs a handler itself, so no cycle of handlers waiting on each other can form (shape 1). Waiting callers must not hold locks the event's handlers take (shape 2) — documented on the methods.
- `ListeningRpcCommunicator::destroy()` now uses the waiting variants.
- Simulator hardening found during the investigation: `folly::SerialExecutor` swallows task exceptions, so a throwing delivery call-out would silently skip the `inFlightOperations` decrement and park `stop()`'s drain forever. The decrement now runs on all paths (exception logged). No such exception was observed at runtime; this closes the hazard.

## Tests

- `OffWaitsForInFlightHandlerBeforeOwnerFreesState` / `RemoveAllListenersWaitsForInFlightHandler` — the destroy-vs-in-flight-handler regression tests; they fail under non-waiting semantics.
- `HandlersRemovingEachOtherAcrossThreadsDoNotDeadlock` — replica of deadlock shape 1; completes via the depth guard.
- Scale verification: reintroducing blocking `off()` deadlocked 8 s into `MultipleLayer1Dht` (two workers parked forever, drain starved); with this design `MultipleLayer1Dht` and the 64-node test passed 8/8 runs (instrumented + clean builds) with zero blocked-wait diagnostics. Full emitter suite 22/22; `streamr-eventemitter` and `streamr-dht` lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)